### PR TITLE
Remove unused rules to edit tasks

### DIFF
--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -67,10 +67,6 @@ def permissions(permissions: PermissionManager):
     add(scope=S.ORGANIZATION, operation=P.VIEW, assign_to_container=True,
         assign_to_node=True, description="view tasks of your organization")
 
-    add(scope=S.GLOBAL, operation=P.EDIT, description="edit any task")
-    add(scope=S.ORGANIZATION, operation=P.EDIT,
-        description="edit tasks of your organization")
-
     add(scope=S.GLOBAL, operation=P.CREATE, description="create a new task")
     add(scope=S.ORGANIZATION, operation=P.CREATE,
         description=(


### PR DESCRIPTION
For #208. Note that there could be a conflict with #203 where default roles are created. These should not include the 'edit task' rules if both PRs are merged