### PR TITLE
Using UUID4 instead of UUID1 to generate API keys for nodes

### DIFF
--- a/vantage6-server/vantage6/server/resource/node.py
+++ b/vantage6-server/vantage6/server/resource/node.py
@@ -247,7 +247,7 @@ class Nodes(NodeBase):
                         HTTPStatus.BAD_REQUEST
 
         # Ok we're good to go!
-        api_key = str(uuid.uuid1())
+        api_key = str(uuid.uuid4())
         node = db.Node(
             name=f"{organization.name} - {collaboration.name} Node",
             collaboration=collaboration,


### PR DESCRIPTION
They are dissmilar now:
![image](https://user-images.githubusercontent.com/10533678/175023569-7c91a16d-e264-407d-9575-46965eb7193a.png)

Fix #211 
