### PR TITLE
Check permission when deleting roles/rules from user

### DIFF
--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -1099,14 +1099,38 @@ class TestResources(unittest.TestCase):
         })
         self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
 
-        # test that you CAN change the rules
+        # test that you cannot assign rules if you don't have all the rules
+        # that the other user has
         headers = self.create_user_and_login(rules=[rule, not_owning_rule])
+        result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
+            'rules': [not_owning_rule.id, rule.id]
+        })
+        self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
+
+        # test that you CAN change the rules. To do so, a user is generated
+        # that has same rules as current user, but also rule to edit other
+        # users and another one current user does not possess
+        assigning_user_rules = user.rules
+        assigning_user_rules.append(
+            Rule.get_by_("user", Scope.GLOBAL, Operation.EDIT)
+        )
+        assigning_user_rules.append(not_owning_rule)
+        headers = self.create_user_and_login(rules=assigning_user_rules)
         result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
             'rules': [not_owning_rule.id, rule.id]
         })
         self.assertEqual(result.status_code, HTTPStatus.OK)
         user_rule_ids = [rule['id'] for rule in result.json['rules']]
         self.assertIn(not_owning_rule.id, user_rule_ids)
+
+        # test that you cannot assign roles if you don't have all the
+        # permissions for that role yourself (even though you have permission
+        # to assign roles)
+        headers = self.create_user_and_login(rules=[rule])
+        result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
+            'roles': [role.id]
+        })
+        self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
 
         # test that you CAN assign roles
         headers = self.create_user_and_login(rules=[rule, not_owning_rule])

--- a/vantage6-server/vantage6/server/permission.py
+++ b/vantage6-server/vantage6/server/permission.py
@@ -1,4 +1,3 @@
-import collections
 import logging
 import importlib
 
@@ -146,7 +145,6 @@ class PermissionManager:
             log.critical(f"Missing permission collection! {name}")
             raise e
 
-
     @staticmethod
     def rule_exists_in_db(name, scope, operation):
         """Check if the rule exists in the DB.
@@ -178,6 +176,6 @@ class PermissionManager:
             try:
                 Permission(requires).test()
             except PermissionDenied:
-                return {"msg": f"You dont have the rule ({rule.name},"
+                return {"msg": f"You don't have the rule ({rule.name}, "
                         f"{rule.scope}, {rule.operation})"}
         return False

--- a/vantage6-server/vantage6/server/resource/user.py
+++ b/vantage6-server/vantage6/server/resource/user.py
@@ -496,6 +496,16 @@ class User(UserBase):
             if denied:
                 return denied, HTTPStatus.UNAUTHORIZED
 
+            # validate that user is not deleting rules they do not have
+            # themselves
+            deleted_rules = [r for r in user.rules if r not in rules]
+            denied = self.permissions.verify_user_rules(deleted_rules)
+            if denied:
+                return {"msg": (
+                    f"{denied['msg']}. You can't delete permissions for "
+                    "another user that you don't have yourself!"
+                )}, HTTPStatus.UNAUTHORIZED
+
             user.rules = rules
 
         if data["organization_id"] and \


### PR DESCRIPTION
Fix #51 

Introduced a check for both roles and rules that if user A wants to delete them for user B, user A should have the role/rule themselves.