### PR TITLE
Require that API keys are defined in vserver import files. 

### DIFF
--- a/vantage6-server/vantage6/server/_data/example_fixtures.yaml
+++ b/vantage6-server/vantage6/server/_data/example_fixtures.yaml
@@ -55,22 +55,29 @@ collaborations:
 
   - name: ZEPPELIN
     participants:
-      - IKNL
-      - Small Organization
-      - Big Organization
+      - name: IKNL
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Small Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Big Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
     tasks: ["hello-world"]
     encrypted: false
 
   - name: PIPELINE
     participants:
-      - IKNL
-      - Big Organization
+      - name: IKNL
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Big Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
     tasks: ["hello-world"]
     encrypted: false
 
   - name: SLIPPERS
     participants:
-      - Small Organization
-      - Big Organization
+      - name: Small Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Big Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
     tasks: ["hello-world", "hello-world"]
     encrypted: false

--- a/vantage6-server/vantage6/server/_data/unittest_fixtures.yaml
+++ b/vantage6-server/vantage6/server/_data/unittest_fixtures.yaml
@@ -61,19 +61,26 @@ collaborations:
 
   - name: ZEPPELIN
     participants:
-      - IKNL
-      - Small Organization
-      - Big Organization
+      - name: IKNL
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Small Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Big Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
     tasks: ["hello-world"]
 
   - name: PIPELINE
     participants:
-      - IKNL
-      - Big Organization
+      - name: IKNL
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Big Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
     tasks: ["hello-world"]
 
   - name: SLIPPERS
     participants:
-      - Small Organization
-      - Big Organization
+      - name: Small Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
+      - name: Big Organization
+        api_key: 123e4567-e89b-12d3-a456-426614174000
     tasks: ["hello-world", "hello-world"]

--- a/vantage6/vantage6/cli/server.py
+++ b/vantage6/vantage6/cli/server.py
@@ -411,10 +411,12 @@ def cli_server_new(name, environment, system_folders):
 @click.argument('file_', type=click.Path(exists=True))
 @click.option('--drop-all', is_flag=True, default=False)
 @click.option('-i', '--image', default=None, help="Node Docker image to use")
+@click.option('--mount-src', default='',
+              help="mount vantage6-master package source")
 @click.option('--keep/--auto-remove', default=False,
               help="Keep image after finishing")
 @click_insert_context
-def cli_server_import(ctx, file_, drop_all, image, keep):
+def cli_server_import(ctx, file_, drop_all, image, mount_src, keep):
     """ Import organizations/collaborations/users and tasks.
 
         Especially useful for testing purposes.
@@ -457,6 +459,10 @@ def cli_server_import(ctx, file_, drop_all, image, keep):
     uri = ctx.config['uri']
     url = make_url(uri)
     environment_vars = None
+
+    if mount_src:
+        mount_src = os.path.abspath(mount_src)
+        mounts.append(docker.types.Mount("/vantage6", mount_src, type="bind"))
 
     # If host is None, we're dealing with a file-based DB, like SQLite
     if (url.host is None):


### PR DESCRIPTION
This prevents they are unknown after the import. Also added `--mount-src` option to `vserver import` while I was at it.

Fix #55 

Note: when releasing this, we should also update the documentation [here](https://docs.vantage6.ai/usage/running-the-server/importing-entities) with the new content of example_fixture.yaml (see code changes)