### PR TITLE
Change default for pagination metadata inclusion in listing organizations in the Python client

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -982,7 +982,7 @@ class UserClient(ClientBase):
         @post_filtering()
         def list(self, name: str = None, country: int = None,
                  collaboration: int = None, page: int = None,
-                 per_page: int = None, include_metadata: bool = False) -> list:
+                 per_page: int = None, include_metadata: bool = True) -> list:
             """List organizations
 
             Parameters


### PR DESCRIPTION
The default is now in line with all other list functions

Fix #238 