### PR TITLE
Always yield default roles in GET `/role`

### DIFF
--- a/vantage6-server/vantage6/server/resource/role.py
+++ b/vantage6-server/vantage6/server/resource/role.py
@@ -225,11 +225,12 @@ class Roles(RoleBase):
             own_role_ids = [role.id for role in g.user.roles]
             if self.r.v_org.can():
                 # allow user to view all roles of their organization and any
-                # other roles they may have themselves
-                q = q.join(db.Organization)\
-                    .filter(or_(
+                # other roles they may have themselves, or default roles from
+                # the root organization
+                q = q.filter(or_(
                         db.Role.organization_id == auth_org_id,
-                        db.Role.id.in_(own_role_ids)
+                        db.Role.id.in_(own_role_ids),
+                        db.Role.organization_id == None
                     ))
             else:
                 # allow users without permission to view only their own roles


### PR DESCRIPTION
Users with organization-level permission to view roles were able to see their organization's roles, but not the new default roles that are available to all organizations. That is corrected here.