### PR TITLE
Freeze pandas version: use latest pandas that is python v3.7 compatible

### DIFF
--- a/vantage6-client/requirements.txt
+++ b/vantage6-client/requirements.txt
@@ -3,5 +3,5 @@ requests==2.25.1
 PyJWT==2.4.0
 pyfiglet==0.8.post1
 SPARQLWrapper==1.8.5
-pandas
+pandas==1.3.5
 

--- a/vantage6-client/setup.py
+++ b/vantage6-client/setup.py
@@ -37,7 +37,7 @@ setup(
         'cryptography==3.3.2',
         'requests==2.25.1',
         'PyJWT==2.4.0',
-        'pandas',
+        'pandas==1.3.5',
         f'vantage6-common=={version_ns["__version__"]}',
         'pyfiglet==0.8.post1',
         'SPARQLWrapper==1.8.5'


### PR DESCRIPTION
Fix #266 

Motivation for using v1.3.5: 1.3 is still [compatible with python 3.7](https://pandas.pydata.org/pandas-docs/version/1.3/getting_started/install.html) whereas 1.4 is [not](https://pandas.pydata.org/pandas-docs/version/1.4/getting_started/install.html)