### PR TITLE
Fix for creating columns in user table in postgres.

### DIFF
--- a/vantage6-server/vantage6/server/model/base.py
+++ b/vantage6-server/vantage6/server/model/base.py
@@ -183,7 +183,8 @@ class Database(metaclass=Singleton):
         log.warn(f"Adding column {col_name} to table {tab_name} as it did not "
                  "exist yet")
         self.engine.execute(
-            'ALTER TABLE %s ADD COLUMN %s %s' % (tab_name, col_name, col_type)
+            'ALTER TABLE "%s" ADD COLUMN %s %s' % (tab_name, col_name,
+                                                   col_type)
         )
 
     @staticmethod


### PR DESCRIPTION
Creating new column in user table failed because user is reserved keyword in postgres, so now the tablename is surrounded by double quotes to mitigate that

Fix #411 