### PR TITLE
Implementation of multi db wrapper

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -335,8 +335,8 @@ class ClientBase(object):
             print_qr_code(data)
             return False
         else:
-            # If no QR two-factor authentication is
-            # required, but that is not an error
+            # Check if there is an access token. If not, there is a problem
+            # with authenticating
             if 'access_token' not in data:
                 if 'msg' in data:
                     raise Exception(data['msg'])

--- a/vantage6-client/vantage6/tools/docker_wrapper.py
+++ b/vantage6-client/vantage6/tools/docker_wrapper.py
@@ -10,6 +10,7 @@ import pickle
 import io
 from abc import ABC, abstractmethod
 import pandas
+import json
 
 from vantage6.tools.dispatch_rpc import dispatch_rpc
 from vantage6.tools.util import info
@@ -37,6 +38,11 @@ def sparql_wrapper(module: str):
 
 def parquet_wrapper(module: str):
     wrapper = ParquetWrapper()
+    wrapper.wrap_algorithm(module)
+
+
+def multidb_wrapper(module: str):
+    wrapper = MultiDBWrapper()
     wrapper.wrap_algorithm(module)
 
 
@@ -152,11 +158,11 @@ class ParquetWrapper(WrapperBase):
 class MultiDBWrapper(WrapperBase):
     @staticmethod
     def load_data(database_uri, input_data):
-        db_env_vars = os.environ.get("ALL_DATABASE_ENVVARS")
+        db_labels = json.loads(os.environ.get("DB_LABELS"))
         databases = {}
-        for db_label in db_env_vars:
-            databases[db_label] = os.environ.get(db_label)
-        info(f"{databases}")
+        for db_label in db_labels:
+            db_env_var = f'{db_label.upper()}_DATABASE_URI'
+            databases[db_label] = os.environ.get(db_env_var)
         return databases
 
 

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 import docker.errors
+import json
 
 from enum import Enum
 from typing import Dict, List, Union
@@ -404,15 +405,15 @@ class DockerTaskManager(DockerBaseManager):
         # Only prepend the data_folder is it is a file-based database
         # This allows algorithms to access multiple data-sources at the
         # same time
-        db_env_vars = []
+        db_labels = []
         for label in self.databases:
             db = self.databases[label]
             var_name = f'{label.upper()}_DATABASE_URI'
             environment_variables[var_name] = \
                 f"{self.data_folder}/{os.path.basename(db['uri'])}" \
                 if db['is_file'] else db['uri']
-            db_env_vars.append(var_name)
-        environment_variables['ALL_DATABASE_ENVVARS'] = db_env_vars
+            db_labels.append(label)
+        environment_variables['DB_LABELS'] = json.dumps(db_labels)
 
         # Support legacy algorithms
         # TODO remove in v4+

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -404,14 +404,18 @@ class DockerTaskManager(DockerBaseManager):
         # Only prepend the data_folder is it is a file-based database
         # This allows algorithms to access multiple data-sources at the
         # same time
+        db_env_vars = []
         for label in self.databases:
             db = self.databases[label]
             var_name = f'{label.upper()}_DATABASE_URI'
             environment_variables[var_name] = \
                 f"{self.data_folder}/{os.path.basename(db['uri'])}" \
                 if db['is_file'] else db['uri']
+            db_env_vars.append(var_name)
+        environment_variables['ALL_DATABASE_ENVVARS'] = db_env_vars
 
         # Support legacy algorithms
+        # TODO remove in v4+
         try:
             environment_variables["DATABASE_URI"] = (
                 f"{self.data_folder}/"

--- a/vantage6/vantage6/cli/node.py
+++ b/vantage6/vantage6/cli/node.py
@@ -383,6 +383,7 @@ def cli_node_start(name, config, environment, system_folders, image, keep,
             mounts.append((f'/mnt/{label}.csv', str(uri)))
 
         # FIXME legacy to support < 2.1.3 can be removed from 3+
+        # FIXME this is still required in v3+ but should be removed in v4
         if label == 'default':
             env['DATABASE_URI'] = '/mnt/default.csv'
 
@@ -632,6 +633,8 @@ def cli_node_create_private_key(name, config, environment, system_folders,
         if 'client' not in locals():
             client = create_client_and_authenticate(ctx)
 
+        # TODO what happens if the user doesn't have permission to upload key?
+        # Does that lead to an exception or not?
         try:
             client.request(
                 f"/organization/{client.whoami.organization_id}",


### PR DESCRIPTION
Fix #398.

This wrapper passes the following as 'data' to an algorithm:

```{'my_label': '/mnt/data/my_label.csv', 'default': '/mnt/data/default.csv}```

The algorithm is then responsible itself to read these datafiles (e.g. `pd.read_csv(data['my_label'])`. I made that choice to allow passing databases of different types to the algorithm.