### PR TITLE
Improved vpn error handling

### DIFF
--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -620,8 +620,7 @@ class Node(object):
         )
 
         if not self.config.get('vpn_subnet'):
-            self.log.warn("VPN subnet is not defined!")
-            self.log.info("Not trying to establish VPN connection.")
+            self.log.warn("VPN subnet is not defined! VPN disabled.")
         elif not os.path.isfile(ovpn_file):
             # if vpn config doesn't exist, get it and write to disk
             self._connect_vpn(vpn_manager, VPNConnectMode.REFRESH_COMPLETE,

--- a/vantage6-node/vantage6/node/docker/vpn_manager.py
+++ b/vantage6-node/vantage6/node/docker/vpn_manager.py
@@ -2,6 +2,7 @@ import docker
 import logging
 import json
 import time
+import ipaddress
 
 from json.decoder import JSONDecodeError
 from typing import List, Union, Dict
@@ -124,6 +125,17 @@ class VPNManager(DockerBaseManager):
         else:
             raise ConnectionError("VPN connection not established!")
 
+        # check that the VPN connection IP address is part of the subnet
+        # defined in the node configuration. If not, the VPN connection would
+        # not work.
+        if not self._vpn_in_right_subnet():
+            self.log.error(
+                "The VPN subnet defined in the node configuration file does "
+                "not match the VPN server subnet. Turning off VPN..."
+            )
+            self.exit_vpn(cleanup_host_rules=False)
+            return
+
         # create network exception so that packet transfer between VPN network
         # and the vpn client container is allowed
         self.isolated_bridge = self._find_isolated_bridge()
@@ -153,9 +165,15 @@ class VPNManager(DockerBaseManager):
                 time.sleep(1)
         return self.has_vpn
 
-    def exit_vpn(self) -> None:
+    def exit_vpn(self, cleanup_host_rules: bool = True) -> None:
         """
         Gracefully shutdown the VPN and clean up
+
+        Parameters
+        ----------
+        cleanup_host_rules: bool, optional
+            Whether or not to clear host configuration rules. Should be True
+            if they have been created at the time this function runs.
         """
         if not self.has_vpn:
             return
@@ -166,21 +184,22 @@ class VPNManager(DockerBaseManager):
         # Clean up host network changes. We have added two rules to the front
         # of the DOCKER-USER chain. We now execute more or less the same
         # commands, but with -D (delete) instead of -I (insert)
-        command = (
-            'sh -c "'
-            f'iptables -D DOCKER-USER -d {self.subnet} '
-            f'-i {self.isolated_bridge} -j ACCEPT; '
-            f'iptables -D DOCKER-USER -s {self.subnet} '
-            f'-o {self.isolated_bridge} -j ACCEPT; '
-            '"'
-        )
-        self.docker.containers.run(
-            image=self.network_config_image,
-            network='host',
-            cap_add='NET_ADMIN',
-            command=command,
-            remove=True,
-        )
+        if cleanup_host_rules:
+            command = (
+                'sh -c "'
+                f'iptables -D DOCKER-USER -d {self.subnet} '
+                f'-i {self.isolated_bridge} -j ACCEPT; '
+                f'iptables -D DOCKER-USER -s {self.subnet} '
+                f'-o {self.isolated_bridge} -j ACCEPT; '
+                '"'
+            )
+            self.docker.containers.run(
+                image=self.network_config_image,
+                network='host',
+                cap_add='NET_ADMIN',
+                command=command,
+                remove=True,
+            )
 
     def get_vpn_ip(self) -> str:
         """
@@ -319,6 +338,21 @@ class VPNManager(DockerBaseManager):
         self.vpn_client_container.exec_run(command)
 
         return ports
+
+    def _vpn_in_right_subnet(self) -> bool:
+        """
+        Check if the VPN connection is part of the subnet defined in the node
+        configuration.
+
+        Returns
+        -------
+        bool
+            Whether the VPN IP address is part of the subnet or not
+        """
+        vpn_ip = self.get_vpn_ip()
+        return (
+            ipaddress.ip_address(vpn_ip) in ipaddress.ip_network(self.subnet)
+        )
 
     def _find_exposed_ports(self, image: str) -> List[Dict]:
         """

--- a/vantage6-server/vantage6/server/exceptions.py
+++ b/vantage6-server/vantage6/server/exceptions.py
@@ -1,0 +1,6 @@
+class VPNPortalAuthException(Exception):
+    pass
+
+
+class VPNConfigException(Exception):
+    pass

--- a/vantage6-server/vantage6/server/resource/vpn.py
+++ b/vantage6-server/vantage6/server/resource/vpn.py
@@ -392,7 +392,7 @@ class EduVPNConnector:
                 "'client_id' and 'redirect_url' settings in your server "
                 "configuration file."
             )
-        elif not response.headers.get('Location'):
+        elif 'Location' not in response.headers:
             raise VPNPortalAuthException(
                 "Authenticating to EduVPN failed. Please check the following "
                 "settings of your configuration file: portal_username and "
@@ -497,7 +497,7 @@ class EduVPNConnector:
         response = self.session.get(f'{self.API_URL}/profile_list')
         return json.loads(response.content.decode('utf-8'))
 
-    def get_config(self, profile_id) -> str:
+    def get_config(self, profile_id: str) -> str:
         """ Call the profile_config route of EduVPN API
 
         Parameters


### PR DESCRIPTION
Fix #278 

In working on this, I also noticed a design error if someone defines a subnet in the node configuration file that doesn't match the subnet in which VPN IPs are provided. Then, there was no error of any kind, however the VPN connection would not have worked because the IP tables rules were generated for the wrong subnet. This has now been resolved with an extra check: when the VPN is connected, check if the VPN IP falls within the node subnet range; otherwise give an error and turn VPN off explicitly