### PR TITLE
Resolve circular import db session

### DIFF
--- a/vantage6-server/tests_server/test_models.py
+++ b/vantage6-server/tests_server/test_models.py
@@ -4,13 +4,12 @@ import yaml
 import datetime
 
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm.exc import NoResultFound
 
 from vantage6.server.controller.fixture import load
 from vantage6.server.model.base import Database, DatabaseSessionManager
 from vantage6.server.globals import PACAKAGE_FOLDER, APPNAME
 
-from vantage6.server import db
+from vantage6.server import session
 from vantage6.server.model import (
     User,
     Organization,
@@ -104,7 +103,7 @@ class TestUserModel(TestBaseModel):
         user2 = User(username="duplicate-user", email="something-else@org.org")
         self.assertRaises(IntegrityError, user2.save)
 
-        db.session.remove()
+        session.session.remove()
 
 
 class TestCollaborationModel(TestBaseModel):

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -16,7 +16,7 @@ from werkzeug.utils import cached_property
 from vantage6.common import logger_name
 from vantage6.common.globals import APPNAME
 from vantage6.server.globals import PACAKAGE_FOLDER
-from vantage6.server import ServerApp, db
+from vantage6.server import ServerApp, session
 from vantage6.server.model import (Rule, Role, Organization, User, Node,
                                    Collaboration, Task, Result)
 from vantage6.server.model.rule import Scope, Operation
@@ -91,12 +91,12 @@ class TestResources(unittest.TestCase):
 
     @classmethod
     def setUp(cls):
-        # set db.session
+        # set session.session
         DatabaseSessionManager.get_session()
 
     @classmethod
     def tearDown(cls):
-        # unset db.session
+        # unset session.session
         DatabaseSessionManager.clear_session()
 
     def login(self, type_='root'):
@@ -567,7 +567,7 @@ class TestResources(unittest.TestCase):
             "new_password": "A_new_password1"
         })
         self.assertEqual(result.status_code, 200)
-        db.session.refresh(user)
+        session.session.refresh(user)
         self.assertTrue(user.check_password("A_new_password1"))
 
     def test_view_rules(self):
@@ -694,7 +694,7 @@ class TestResources(unittest.TestCase):
             "description": "some description of this role..."
         })
 
-        db.session.refresh(role)
+        session.session.refresh(role)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         self.assertEqual(role.name, "a-different-role-name")
         self.assertEqual(role.description, "some description of this role...")
@@ -1092,7 +1092,7 @@ class TestResources(unittest.TestCase):
         result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
             'firstname': 'yeah'
         })
-        db.session.refresh(user)
+        session.session.refresh(user)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         self.assertEqual("yeah", user.firstname)
 
@@ -1103,7 +1103,7 @@ class TestResources(unittest.TestCase):
         result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
             'firstname': 'whatever'
         })
-        db.session.refresh(user)
+        session.session.refresh(user)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         self.assertEqual("whatever", user.firstname)
 
@@ -1120,7 +1120,7 @@ class TestResources(unittest.TestCase):
             'firstname': 'again',
             'lastname': 'and again',
         })
-        db.session.refresh(user)
+        session.session.refresh(user)
         self.assertEqual(result.status_code, HTTPStatus.OK)
         self.assertEqual("again", user.firstname)
         self.assertEqual("and again", user.lastname)

--- a/vantage6-server/vantage6/server/db.py
+++ b/vantage6-server/vantage6/server/db.py
@@ -31,11 +31,6 @@ from vantage6.common.globals import STRING_ENCODING
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 
-# DB connection session. This is used by the iPython shell (from db import
-# session). It is important to mention that the flask requests obtain their
-# session from `g.session` which is initialized on `pre_request`.
-session = None
-
 
 def jsonable(value):
     """Convert a (list of) SQLAlchemy instance(s) to native Python objects."""
@@ -59,7 +54,7 @@ def jsonable(value):
             elif isinstance(column_value, datetime.datetime):
                 column_value = column_value.isoformat()
             elif isinstance(column_value, bytes):
-                log.debug(f"decoding bytes!")
+                log.debug("decoding bytes!")
                 column_value = column_value.decode(STRING_ENCODING)
 
             retval[column] = column_value

--- a/vantage6-server/vantage6/server/model/base.py
+++ b/vantage6-server/vantage6/server/model/base.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import scoped_session, sessionmaker, RelationshipProperty
 from sqlalchemy.orm.exc import NoResultFound
 
 from vantage6.common import logger_name, Singleton
-from vantage6.server import db
+from vantage6.server import session
 
 
 module_name = logger_name(__name__)
@@ -242,12 +242,11 @@ class DatabaseSessionManager:
             return g.session
         else:
             # log.critical('Obtaining non flask session')
-            if not db.session:
+            if not session.session:
                 DatabaseSessionManager.new_session()
                 # log.critical('WE NEED TO MAKE A NEW ONE')
 
-            # print(f'db.session {db.session}')
-            return db.session
+            return session.session
 
     @staticmethod
     def new_session():
@@ -259,7 +258,7 @@ class DatabaseSessionManager:
             # g.session.refresh()
             # print('new flask session')
         else:
-            db.session = Database().session_b
+            session.session = Database().session_b
 
     @staticmethod
     def clear_session():
@@ -268,9 +267,9 @@ class DatabaseSessionManager:
             g.session.remove()
             # g.session = None
         else:
-            if db.session:
-                db.session.remove()
-                db.session = None
+            if session.session:
+                session.session.remove()
+                session.session = None
             else:
                 print('No DB session found to clear!')
 

--- a/vantage6-server/vantage6/server/session.py
+++ b/vantage6-server/vantage6/server/session.py
@@ -1,0 +1,4 @@
+# DB connection session. This is used by the iPython shell (from server import
+# session). Flask requests obtain their session from `g.session` which is
+# initialized on `pre_request`.
+session = None


### PR DESCRIPTION
Fix #53 

Resolved this by putting the `session` variable in `db.py` into its own separate file, `session.py`.
Then it was much easier than expected...

Tested that nodes can still connect, API still works, and vserver shell still works