### PR TITLE
Change/shorter logging 404 requests

### DIFF
--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -249,8 +249,12 @@ class ServerApp:
             It is important to close the db session to avoid having dangling
             sessions.
             """
-            log.warn('HTTP Exception occured during request')
-            log.debug(traceback.format_exc())
+            if error.code == 404:
+                log.debug(
+                    f"404 error for route '{_get_request_path(request)}'")
+            else:
+                log.warn('HTTP Exception occured during request')
+                log.debug(traceback.format_exc())
             DatabaseSessionManager.clear_session()
             return error.get_response()
 


### PR DESCRIPTION
Fix #393 

Also, I checked which routes are actually causing the 404 errors on the server. It turns out this is the root route (e.g. `https://petronas.vantage6.ai/` without extension) that web crawlers are requesting. We could consider generating a non-erroneous response there