### PR TITLE
Feature/improved logging client

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -15,7 +15,6 @@ import json as json_lib
 import itertools
 import sys
 import traceback
-import logging
 
 from pathlib import Path
 from typing import Dict, Tuple, Union
@@ -588,7 +587,8 @@ class UserClient(ClientBase):
         self.log.info("https://vantage6.ai/vantage6/references")
         self.log.info("-" * 60)
 
-    def get_logger(self, enabled: bool, level: str) -> logging.Logger:
+    @staticmethod
+    def get_logger(enabled: bool, level: str) -> logging.Logger:
         """
         Create print-logger
 

--- a/vantage6-client/vantage6/client/utils.py
+++ b/vantage6-client/vantage6/client/utils.py
@@ -1,5 +1,6 @@
 import qrcode
 
+from enum import Enum
 from typing import Dict
 
 
@@ -43,3 +44,11 @@ def show_qr_code_image(qr_uri: str) -> None:
     qr.add_data(qr_uri)
     qr.make(fit=True)
     qr.print_ascii()
+
+
+class LogLevel(Enum):
+    DEBUG = 'DEBUG'
+    INFO = 'INFO'
+    WARN = 'WARN'
+    ERROR = 'ERROR'
+    CRITICAL = 'CRITICAL'


### PR DESCRIPTION
Fix #340 

Log level in client is now settable to debug, info, warn, error or critical.
The `verbose=True|False` option has been retained but should be removed in v4+
