### PR TITLE
Bugfix/permission error config folder non existent

### DIFF
--- a/docs/user-documentation/use.rst
+++ b/docs/user-documentation/use.rst
@@ -287,7 +287,7 @@ set up and if they have access to the private key.
 
 .. code:: python
 
-   from vantage6.common import (warning, error, info, debug, bytes_to_base64s, check_config_write_permissions)
+   from vantage6.common import (warning, error, info, debug, bytes_to_base64s)
    from vantage6.common.encryption import RSACryptor
    from pathlib import Path
 

--- a/vantage6-common/vantage6/common/__init__.py
+++ b/vantage6-common/vantage6/common/__init__.py
@@ -107,7 +107,7 @@ class ClickLogger:
         debug(msg)
 
 
-def check_config_write_permissions(system_folders=False):
+def check_config_writeable(system_folders=False):
     dirs = appdirs.AppDirs()
     if system_folders:
         dirs_to_check = [
@@ -119,8 +119,12 @@ def check_config_write_permissions(system_folders=False):
         ]
     w_ok = True
     for dir_ in dirs_to_check:
-        if not os.access(dir_, os.W_OK):
-            warning(f"No write permissions at '{dir_}'")
+        if not os.path.isdir(dir_):
+            warning(f"Target directory '{dir_}' for configuration file does "
+                    "not exist.")
+            w_ok = False
+        elif not os.access(dir_, os.W_OK):
+            warning(f"No write permissions at '{dir_}'.")
             w_ok = False
 
     return w_ok

--- a/vantage6-node/vantage6/node/cli/node.py
+++ b/vantage6-node/vantage6/node/cli/node.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from vantage6 import node
 from vantage6.node.context import NodeContext, DockerNodeContext
-from vantage6.common import warning, info, error, check_config_write_permissions
+from vantage6.common import warning, info, error, check_config_writeable
 
 from vantage6.cli.configuration_wizard import (
     configuration_wizard,
@@ -82,7 +82,7 @@ def cli_node_new_configuration(name, environment, system_folders):
         ).ask()
 
     # Check that we can write in this folder
-    if not check_config_write_permissions(system_folders):
+    if not check_config_writeable(system_folders):
         error("Your user does not have write access to all folders. Exiting")
         exit(1)
 

--- a/vantage6-server/vantage6/server/cli/server.py
+++ b/vantage6-server/vantage6/server/cli/server.py
@@ -11,7 +11,7 @@ from vantage6.common import (
     info,
     warning,
     error,
-    check_config_write_permissions
+    check_config_writeable
 )
 from vantage6.server.model.base import Database
 from vantage6.server import ServerApp, run_dev_server
@@ -191,7 +191,7 @@ def cli_server_new(name, environment, system_folders):
             name = name_new
 
     # Check that we can write in this folder
-    if not check_config_write_permissions(system_folders):
+    if not check_config_writeable(system_folders):
         error("Your user does not have write access to all folders. Exiting")
         exit(1)
 

--- a/vantage6/tests_cli/test_node_cli.py
+++ b/vantage6/tests_cli/test_node_cli.py
@@ -86,7 +86,7 @@ class NodeCLITest(unittest.TestCase):
         )
 
     @patch("vantage6.cli.node.configuration_wizard")
-    @patch("vantage6.cli.node.check_config_write_permissions")
+    @patch("vantage6.cli.node.check_config_writeable")
     @patch("vantage6.cli.node.NodeContext")
     def test_new_config(self, context, permissions, wizard):
         """No error produced when creating new configuration."""
@@ -139,7 +139,7 @@ class NodeCLITest(unittest.TestCase):
         # check non-zero exit code
         self.assertEqual(result.exit_code, 1)
 
-    @patch("vantage6.cli.node.check_config_write_permissions")
+    @patch("vantage6.cli.node.check_config_writeable")
     @patch("vantage6.cli.node.NodeContext")
     def test_new_write_permissions(self, context, permissions):
         """User needs write permissions."""

--- a/vantage6/tests_cli/test_server_cli.py
+++ b/vantage6/tests_cli/test_server_cli.py
@@ -114,7 +114,7 @@ class ServerCLITest(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
 
     @patch("vantage6.cli.server.configuration_wizard")
-    @patch("vantage6.cli.server.check_config_write_permissions")
+    @patch("vantage6.cli.server.check_config_writeable")
     @patch("vantage6.cli.server.ServerContext")
     def test_new(self, context, permissions, wizard):
         """New configuration without errors."""

--- a/vantage6/vantage6/cli/node.py
+++ b/vantage6/vantage6/cli/node.py
@@ -26,7 +26,7 @@ from colorama import Fore, Style
 
 from vantage6.common import (
     warning, error, info, debug,
-    bytes_to_base64s, check_config_write_permissions
+    bytes_to_base64s, check_config_writeable
 )
 from vantage6.common.globals import (
     STRING_ENCODING,
@@ -162,8 +162,8 @@ def cli_node_new_configuration(name, environment, system_folders):
         exit(1)
 
     # Check that we can write in this folder
-    if not check_config_write_permissions(system_folders):
-        error("Your user does not have write access to all folders. Exiting")
+    if not check_config_writeable(system_folders):
+        error("Cannot write configuration file. Exiting...")
         exit(1)
 
     # create config in ctx location

--- a/vantage6/vantage6/cli/server.py
+++ b/vantage6/vantage6/cli/server.py
@@ -12,7 +12,7 @@ from sqlalchemy.engine.url import make_url
 from docker.client import DockerClient
 
 from vantage6.common import (info, warning, error, debug as debug_msg,
-                             check_config_write_permissions)
+                             check_config_writeable)
 from vantage6.common.docker.addons import (
     pull_if_newer, check_docker_running, remove_container,
     get_server_config_name, get_container, get_num_nonempty_networks,
@@ -394,7 +394,7 @@ def cli_server_new(name, environment, system_folders):
         exit(1)
 
     # Check that we can write in this folder
-    if not check_config_write_permissions(system_folders):
+    if not check_config_writeable(system_folders):
         error("Your user does not have write access to all folders. Exiting")
         info(f"Create a new server using '{Fore.GREEN}vserver new "
              "--user{Style.RESET_ALL}' instead!")


### PR DESCRIPTION
Fix #1. Quite an old issue apparently

This is how it looks like now (I just added `lala` to my config dir to check for non-existent dir):
![image](https://user-images.githubusercontent.com/10533678/209122363-bb2b1de1-dc89-4d31-81b9-ca3a04226a5a.png)

People will get the same error if they don't have write permissions but a different warning above it