### PR TITLE
Assign rules to root automatically, extra check on role name in POST/PATCH role

### DIFF
--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -33,10 +33,8 @@ from vantage6.common import logger_name
 from vantage6.server.permission import RuleNeed, PermissionManager
 from vantage6.server.globals import (
     APPNAME,
-    CONTAINER_ROLE,
     JWT_ACCESS_TOKEN_EXPIRES,
     JWT_TEST_ACCESS_TOKEN_EXPIRES,
-    NODE_ROLE,
     RESOURCES,
     SUPER_USER_INFO,
     REFRESH_TOKENS_EXPIRE,
@@ -46,7 +44,7 @@ from vantage6.server.resource.common.swagger_templates import swagger_template
 from vantage6.server._version import __version__
 from vantage6.server.mail_service import MailService
 from vantage6.server.websockets import DefaultSocketNamespace
-from vantage6.server.default_roles import get_default_roles
+from vantage6.server.default_roles import get_default_roles, DefaultRole
 
 
 module_name = logger_name(__name__)
@@ -343,7 +341,7 @@ class ServerApp:
 
                 if isinstance(auth, db.Node):
 
-                    for rule in db.Role.get_by_name(NODE_ROLE).rules:
+                    for rule in db.Role.get_by_name(DefaultRole.NODE).rules:
                         auth_identity.provides.add(
                                 RuleNeed(
                                     name=rule.name,
@@ -381,7 +379,7 @@ class ServerApp:
                 return auth
             else:
 
-                for rule in db.Role.get_by_name(CONTAINER_ROLE).rules:
+                for rule in db.Role.get_by_name(DefaultRole.CONTAINER).rules:
                     auth_identity.provides.add(
                         RuleNeed(
                             name=rule.name,

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -33,8 +33,10 @@ from vantage6.common import logger_name
 from vantage6.server.permission import RuleNeed, PermissionManager
 from vantage6.server.globals import (
     APPNAME,
+    CONTAINER_ROLE,
     JWT_ACCESS_TOKEN_EXPIRES,
     JWT_TEST_ACCESS_TOKEN_EXPIRES,
+    NODE_ROLE,
     RESOURCES,
     SUPER_USER_INFO,
     REFRESH_TOKENS_EXPIRE,
@@ -341,7 +343,7 @@ class ServerApp:
 
                 if isinstance(auth, db.Node):
 
-                    for rule in db.Role.get_by_name("node").rules:
+                    for rule in db.Role.get_by_name(NODE_ROLE).rules:
                         auth_identity.provides.add(
                                 RuleNeed(
                                     name=rule.name,
@@ -379,7 +381,7 @@ class ServerApp:
                 return auth
             else:
 
-                for rule in db.Role.get_by_name("container").rules:
+                for rule in db.Role.get_by_name(CONTAINER_ROLE).rules:
                     auth_identity.provides.add(
                         RuleNeed(
                             name=rule.name,

--- a/vantage6-server/vantage6/server/default_roles.py
+++ b/vantage6-server/vantage6/server/default_roles.py
@@ -1,15 +1,17 @@
 from vantage6.server.model.rule import Operation, Scope
+from vantage6.server.globals import ROOT_ROLE
 
 
 # TODO BvB 22-06-07: we now have to pass this 'db' module as argument to a
 # function because that module has a connection to the database. This should
 # not be necessary. Fix that after fixing the circular imports described in
 # https://github.com/vantage6/vantage6/issues/53
+# Then simply do: import vantage6.server.db
 def get_default_roles(db):
     # Define default roles
     # 1. Root user
     SUPER_ROLE = {
-        'name': 'Root',
+        'name': ROOT_ROLE,
         'description': "Super role",
         'rules': db.Rule.get()
     }

--- a/vantage6-server/vantage6/server/default_roles.py
+++ b/vantage6-server/vantage6/server/default_roles.py
@@ -1,5 +1,17 @@
+from enum import Enum
+
 from vantage6.server.model.rule import Operation, Scope
-from vantage6.server.globals import ROOT_ROLE
+
+
+# Name of the default roles
+class DefaultRole(str, Enum):
+    ROOT = "Root"
+    CONTAINER = "container"
+    NODE = "node"
+    VIEWER = "Viewer"
+    RESEARCHER = "Researcher"
+    ORG_ADMIN = "Organization Admin"
+    COL_ADMIN = "Collaboration Admin"
 
 
 # TODO BvB 22-06-07: we now have to pass this 'db' module as argument to a
@@ -11,7 +23,7 @@ def get_default_roles(db):
     # Define default roles
     # 1. Root user
     SUPER_ROLE = {
-        'name': ROOT_ROLE,
+        'name': DefaultRole.ROOT,
         'description': "Super role",
         'rules': db.Rule.get()
     }
@@ -31,7 +43,7 @@ def get_default_roles(db):
         db.Rule.get_by_('event', Scope.ORGANIZATION, Operation.VIEW),
     ]
     VIEWER_ROLE = {
-        'name': 'Viewer',
+        'name': DefaultRole.VIEWER,
         'description': "Can manage their own account and view resources "
                        "related to their organization",
         'rules': VIEWER_RULES
@@ -42,7 +54,7 @@ def get_default_roles(db):
         db.Rule.get_by_('task', Scope.ORGANIZATION, Operation.DELETE),
     ]
     RESEARCHER_ROLE = {
-        'name': 'Researcher',
+        'name': DefaultRole.RESEARCHER,
         'description': "Can perform tasks, manage their own account, and "
                        "view resources related to their organization",
         'rules': RESEARCHER_RULES
@@ -60,7 +72,7 @@ def get_default_roles(db):
         db.Rule.get_by_('event', Scope.ORGANIZATION, Operation.CREATE),
     ]
     ORG_ADMIN_ROLE = {
-        'name': 'Organization Admin',
+        'name': DefaultRole.ORG_ADMIN,
         'description':
             "Can manage an organization including its users, roles, and nodes."
             " Also has all permissions of a researcher.",
@@ -83,7 +95,7 @@ def get_default_roles(db):
         db.Rule.get_by_('event', Scope.COLLABORATION, Operation.CREATE),
     ]
     COLLAB_ADMIN_ROLE = {
-        'name': 'Collaboration Admin',
+        'name': DefaultRole.COL_ADMIN,
         'description':
             "Can manage an collaboration including its organization and users."
             " Also has permissions of an organization admin.",

--- a/vantage6-server/vantage6/server/globals.py
+++ b/vantage6-server/vantage6/server/globals.py
@@ -33,10 +33,6 @@ SUPER_USER_INFO = {
     "username": "root",
     "password": "root"
 }
-# Name of the default roles
-ROOT_ROLE = "Root"
-CONTAINER_ROLE = "container"
-NODE_ROLE = "node"
 
 # Whenever the refresh tokens should expire. Note that setting this to true
 # would mean that nodes will disconnect after some time

--- a/vantage6-server/vantage6/server/globals.py
+++ b/vantage6-server/vantage6/server/globals.py
@@ -33,6 +33,10 @@ SUPER_USER_INFO = {
     "username": "root",
     "password": "root"
 }
+# Name of the default roles
+ROOT_ROLE = "Root"
+CONTAINER_ROLE = "container"
+NODE_ROLE = "node"
 
 # Whenever the refresh tokens should expire. Note that setting this to true
 # would mean that nodes will disconnect after some time

--- a/vantage6-server/vantage6/server/permission.py
+++ b/vantage6-server/vantage6/server/permission.py
@@ -4,9 +4,8 @@ import importlib
 from collections import namedtuple
 from flask_principal import Permission, PermissionDenied
 
-from vantage6.server.globals import (
-    CONTAINER_ROLE, NODE_ROLE, RESOURCES, ROOT_ROLE
-)
+from vantage6.server.globals import RESOURCES
+from vantage6.server.default_roles import DefaultRole
 from vantage6.server.model.role import Role
 from vantage6.server.model.rule import Rule, Operation, Scope
 from vantage6.server.model.base import DatabaseSessionManager
@@ -52,17 +51,20 @@ class PermissionManager:
     def assign_rule_to_node(self, name: str, scope: Scope,
                             operation: Operation):
         """Assign a rule to the Node role."""
-        self.assign_rule_to_fixed_role(NODE_ROLE, name, scope, operation)
+        self.assign_rule_to_fixed_role(DefaultRole.NODE, name, scope,
+                                       operation)
 
     def assign_rule_to_container(self, name: str, scope: Scope,
                                  operation: Operation):
         """Assign a rule to the container role."""
-        self.assign_rule_to_fixed_role(CONTAINER_ROLE, name, scope, operation)
+        self.assign_rule_to_fixed_role(DefaultRole.CONTAINER, name, scope,
+                                       operation)
 
     def assign_rule_to_root(self, name: str, scope: Scope,
                             operation: Operation):
         """Assign a rule to the container role."""
-        self.assign_rule_to_fixed_role(ROOT_ROLE, name, scope, operation)
+        self.assign_rule_to_fixed_role(DefaultRole.ROOT, name, scope,
+                                       operation)
 
     @staticmethod
     def assign_rule_to_fixed_role(fixedrole: str, name: str, scope: Scope,

--- a/vantage6-server/vantage6/server/permission.py
+++ b/vantage6-server/vantage6/server/permission.py
@@ -4,7 +4,9 @@ import importlib
 from collections import namedtuple
 from flask_principal import Permission, PermissionDenied
 
-from vantage6.server.globals import RESOURCES
+from vantage6.server.globals import (
+    CONTAINER_ROLE, NODE_ROLE, RESOURCES, ROOT_ROLE
+)
 from vantage6.server.model.role import Role
 from vantage6.server.model.rule import Rule, Operation, Scope
 from vantage6.server.model.base import DatabaseSessionManager
@@ -50,12 +52,17 @@ class PermissionManager:
     def assign_rule_to_node(self, name: str, scope: Scope,
                             operation: Operation):
         """Assign a rule to the Node role."""
-        self.assign_rule_to_fixed_role("node", name, scope, operation)
+        self.assign_rule_to_fixed_role(NODE_ROLE, name, scope, operation)
 
     def assign_rule_to_container(self, name: str, scope: Scope,
                                  operation: Operation):
         """Assign a rule to the container role."""
-        self.assign_rule_to_fixed_role("container", name, scope, operation)
+        self.assign_rule_to_fixed_role(CONTAINER_ROLE, name, scope, operation)
+
+    def assign_rule_to_root(self, name: str, scope: Scope,
+                            operation: Operation):
+        """Assign a rule to the container role."""
+        self.assign_rule_to_fixed_role(ROOT_ROLE, name, scope, operation)
 
     @staticmethod
     def assign_rule_to_fixed_role(fixedrole: str, name: str, scope: Scope,
@@ -117,6 +124,9 @@ class PermissionManager:
 
         if assign_to_node:
             self.assign_rule_to_node(collection, scope, operation)
+
+        # assign all new rules to root user
+        self.assign_rule_to_root(collection, scope, operation)
 
         self.collection(collection).add(rule.scope, rule.operation)
 

--- a/vantage6-server/vantage6/server/resource/role.py
+++ b/vantage6-server/vantage6/server/resource/role.py
@@ -304,7 +304,7 @@ class Roles(RoleBase):
         data = parser.parse_args()
 
         # check if role name is allowed (i.e. not a default role name)
-        if data['name'] in [role for role in DefaultRole]:
+        if 'name' in data and data['name'] in [role for role in DefaultRole]:
             return {
                 "msg": f"Cannot create role '{data['name']}' as it is a "
                        "reserved role name."
@@ -472,7 +472,7 @@ class Role(RoleBase):
                 HTTPStatus.NOT_FOUND
 
         # check if role name is allowed (i.e. not a default role name)
-        if data['name'] in [role for role in DefaultRole]:
+        if 'name' in data and data['name'] in [role for role in DefaultRole]:
             return {
                 "msg": f"Cannot change role name into '{data['name']}' as that"
                        " is a reserved role name."

--- a/vantage6-server/vantage6/server/resource/role.py
+++ b/vantage6-server/vantage6/server/resource/role.py
@@ -453,7 +453,7 @@ class Role(RoleBase):
           200:
             description: Ok
           400:
-            description: Non-allowed role name
+            description: Non-allowed role name change
           401:
             description: Unauthorized
           404:
@@ -476,6 +476,11 @@ class Role(RoleBase):
             return {
                 "msg": f"Cannot change role name into '{data['name']}' as that"
                        " is a reserved role name."
+            }, HTTPStatus.BAD_REQUEST
+        elif role.name in [role for role in DefaultRole]:
+            return {
+                "msg": f"This role ('{role.name}') is a default role. Its name"
+                       " cannot be changed."
             }, HTTPStatus.BAD_REQUEST
 
         # check permission of the user

--- a/vantage6-server/vantage6/server/resource/role.py
+++ b/vantage6-server/vantage6/server/resource/role.py
@@ -20,6 +20,7 @@ from vantage6.server.permission import (
 from vantage6.server.model.rule import Operation, Scope
 from vantage6.server.resource.common._schema import RoleSchema, RuleSchema
 from vantage6.server.resource.pagination import Pagination
+from vantage6.server.default_roles import DefaultRole
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
@@ -283,10 +284,12 @@ class Roles(RoleBase):
         responses:
           201:
             description: Created
-          404:
-            description: Organization or rule was not found
+          400:
+            description: Non-allowed role name
           401:
             description: Unauthorized
+          404:
+            description: Organization or rule was not found
 
         security:
           - bearerAuth: []
@@ -299,6 +302,13 @@ class Roles(RoleBase):
         parser.add_argument("rules", type=int, action='append', required=False)
         parser.add_argument("organization_id", type=int, required=False)
         data = parser.parse_args()
+
+        # check if role name is allowed (i.e. not a default role name)
+        if data['name'] in [role for role in DefaultRole]:
+            return {
+                "msg": f"Cannot create role '{data['name']}' as it is a "
+                       "reserved role name."
+            }, HTTPStatus.BAD_REQUEST
 
         # obtain the requested rules from the DB.
         rules = []
@@ -442,6 +452,8 @@ class Role(RoleBase):
         responses:
           200:
             description: Ok
+          400:
+            description: Non-allowed role name
           401:
             description: Unauthorized
           404:
@@ -458,6 +470,13 @@ class Role(RoleBase):
         if not role:
             return {"msg": f"Role with id={id} not found."}, \
                 HTTPStatus.NOT_FOUND
+
+        # check if role name is allowed (i.e. not a default role name)
+        if data['name'] in [role for role in DefaultRole]:
+            return {
+                "msg": f"Cannot change role name into '{data['name']}' as that"
+                       " is a reserved role name."
+            }, HTTPStatus.BAD_REQUEST
 
         # check permission of the user
         if not self.r.e_glo.can():


### PR DESCRIPTION
Fix #442 (in a different/better way than was originally intended)

- When a new rule is created, it is assigned to the Root user automatically

As this is done based on matching by name Root, also the following was changed:
- Users cannot create roles with any of the default role names
- Users cannot change names of existing roles into any of the default role names
- The names of default roles cannot be changed

Finally, this lead to the introduction of an Enum to keep track of the default role names, and use that wherever it should be used.