### PR TITLE
Upgraded dockerpy to 5.0.3, which allows us to automatically pull onl…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ contextlib2==0.5.5
 cryptography==3.3.2
 decorator==5.0.9
 dnspython==2.2.1
-docker==4.2.0
+docker==5.0.3
 eventlet==0.33.0
 flasgger==0.9.5
 Flask==2.0.2

--- a/vantage6-common/setup.py
+++ b/vantage6-common/setup.py
@@ -40,7 +40,7 @@ setup(
         'click==8.0.3',
         'PyYAML==5.4',
         'python-dateutil==2.8.1',
-        'docker==4.2.0',
+        'docker==5.0.3',
         'cryptography==3.3.2',
         'pyfiglet==0.8.post1',
     ],

--- a/vantage6-node/requirements.txt
+++ b/vantage6-node/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.25.1
 gevent==21.8.0
 python-socketio==5.5.0
-docker==4.2.0
+docker==5.0.3
 cryptography==3.3.2
 click==8.0.3
 termcolor==1.1.0

--- a/vantage6-node/setup.py
+++ b/vantage6-node/setup.py
@@ -36,7 +36,7 @@ setup(
         'requests==2.25.1',
         'gevent==21.8.0',
         'python-socketio[client]==5.5.0',
-        'docker==4.2.0',
+        'docker==5.0.3',
         'cryptography==3.3.2',
         'click==8.0.3',
         'termcolor==1.1.0',

--- a/vantage6/requirements.txt
+++ b/vantage6/requirements.txt
@@ -1,10 +1,10 @@
 schema==0.7.1
 click==8.0.3
 SQLAlchemy==1.3.15
-docker==4.2.0
+docker==5.0.3
 colorama==0.4.5
 questionary==1.5.2
 iPython==7.16.3
 SQLAlchemy==1.3.15
-docker==4.2.0
+docker==5.0.3
 colorama==0.4.5

--- a/vantage6/setup.py
+++ b/vantage6/setup.py
@@ -38,7 +38,7 @@ setup(
         'schema==0.7.1',
         'click==8.0.3',
         'SQLAlchemy==1.3.15',
-        'docker==4.2.0',
+        'docker==5.0.3',
         'colorama==0.4.5',
         'questionary==1.5.2',
         'iPython==7.16.3',


### PR DESCRIPTION
…y the 'latest' tag when doing docker.images.pull(some_image), instead of all tags

Upgrade to higher version of dockerpy (6.0.0) led to errors

Fix #473 