### PR TITLE
Use specific commit from the automatic release action where the node …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         ref: 'main'
 
     - name: Create a Release
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303
       with:
         repo_token: "${{ secrets.GITHUB_TOKEN }}"
         automatic_release_tag: "v${{ env.version }}"


### PR DESCRIPTION
…version is updated (so it won't get deprecated soon)

In line with suggestion by rtrad89 in https://github.com/marvinpinto/action-automatic-releases/pull/2

Fix #474 