### PR TITLE
Change/termcolor dep removed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,6 @@ schema==0.7.5
 six==1.16.0
 SPARQLWrapper==2.0.0
 SQLAlchemy==1.4.46
-termcolor==2.2.0
 traitlets==5.8.1
 urllib3==1.26.14
 wcwidth==0.2.6

--- a/vantage6-common/requirements.txt
+++ b/vantage6-common/requirements.txt
@@ -7,4 +7,3 @@ pyfiglet==0.8.post1
 PyYAML==6.0
 python-dateutil==2.8.2
 schema==0.7.5
-termcolor==2.2.0

--- a/vantage6-common/setup.py
+++ b/vantage6-common/setup.py
@@ -42,7 +42,6 @@ setup(
         'PyYAML==6.0',
         'python-dateutil==2.8.2',
         'schema==0.7.5',
-        'termcolor==2.2.0',
     ],
     package_data={
         'vantage6.common': [

--- a/vantage6-common/vantage6/common/utest.py
+++ b/vantage6-common/vantage6/common/utest.py
@@ -8,8 +8,6 @@ import os
 import logging
 import unittest
 from datetime import datetime
-from termcolor import colored
-
 
 class TestResult(unittest.TextTestResult):
 
@@ -30,7 +28,7 @@ class TestResult(unittest.TextTestResult):
         error = "[ERROR]"
 
         if self.showAll:
-            self.stream.writeln(colored(error, 'red'))
+            self.stream.writeln(error, 'red')
         elif self.dots:
             self.stream.write('E')
             self.stream.flush()
@@ -43,7 +41,7 @@ class TestResult(unittest.TextTestResult):
         fail = "[FAIL]"
 
         if self.showAll:
-            self.stream.writeln(colored(fail, 'red'))
+            self.stream.writeln(fail, 'red')
         elif self.dots:
             self.stream.write('F')
             self.stream.flush()
@@ -64,7 +62,7 @@ class TestResult(unittest.TextTestResult):
         skipped = "[SKIPPED] (%s)" % reason
 
         if self.showAll:
-            self.stream.writeln(colored(skipped, 'yellow'))
+            self.stream.writeln(skipped, 'yellow')
         elif self.dots:
             self.stream.write("s")
             self.stream.flush()
@@ -76,7 +74,7 @@ class TestResult(unittest.TextTestResult):
         ok = "[OK]"
 
         if self.showAll:
-            self.stream.writeln(colored(ok, 'green'))
+            self.stream.writeln(ok, 'green')
         elif self.dots:
             self.stream.write('.')
             self.stream.flush()

--- a/vantage6-common/vantage6/common/utest.py
+++ b/vantage6-common/vantage6/common/utest.py
@@ -28,7 +28,7 @@ class TestResult(unittest.TextTestResult):
         error = "[ERROR]"
 
         if self.showAll:
-            self.stream.writeln(error, 'red')
+            self.stream.writeln(error)
         elif self.dots:
             self.stream.write('E')
             self.stream.flush()
@@ -41,7 +41,7 @@ class TestResult(unittest.TextTestResult):
         fail = "[FAIL]"
 
         if self.showAll:
-            self.stream.writeln(fail, 'red')
+            self.stream.writeln(fail)
         elif self.dots:
             self.stream.write('F')
             self.stream.flush()
@@ -62,7 +62,7 @@ class TestResult(unittest.TextTestResult):
         skipped = "[SKIPPED] (%s)" % reason
 
         if self.showAll:
-            self.stream.writeln(skipped, 'yellow')
+            self.stream.writeln(skipped)
         elif self.dots:
             self.stream.write("s")
             self.stream.flush()
@@ -74,7 +74,7 @@ class TestResult(unittest.TextTestResult):
         ok = "[OK]"
 
         if self.showAll:
-            self.stream.writeln(ok, 'green')
+            self.stream.writeln(ok)
         elif self.dots:
             self.stream.write('.')
             self.stream.flush()


### PR DESCRIPTION
Remove the `termcolor` dependency - it is only used to color the output of unit tests (which is not even working on Windows) and is not the most widely used package.

Note that this branch was created from the Python 3.10 branch