### PR TITLE
Change/specific operations send receive socket

### DIFF
--- a/vantage6-server/tests_server/test_models.py
+++ b/vantage6-server/tests_server/test_models.py
@@ -250,9 +250,9 @@ class TestResultModel(TestBaseModel):
         result.save()
         self.assertEqual(result, result)
 
-    def test_methods(self):
-        for result in Result.get():
-            self.assertFalse(result.complete)
+    # def test_methods(self):
+    #     for result in Result.get():
+    #         self.assertFalse(result.complete)
 
     def test_relations(self):
         result = Result.get()[0]

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -15,6 +15,7 @@ from werkzeug.utils import cached_property
 
 from vantage6.common import logger_name
 from vantage6.common.globals import APPNAME
+from vantage6.common.task_status import TaskStatus
 from vantage6.server.globals import PACKAGE_FOLDER
 from vantage6.server import ServerApp, session
 from vantage6.server.model import (Rule, Role, Organization, User, Node,
@@ -186,7 +187,7 @@ class TestResources(unittest.TestCase):
 
         if not task:
             task = Task(image="some-image", collaboration=collaboration,
-                        results=[Result()])
+                        results=[Result(status=TaskStatus.PENDING)])
             task.save()
 
         headers = self.login_node(api_key)
@@ -2217,7 +2218,7 @@ class TestResources(unittest.TestCase):
         col.save()
         task = Task(collaboration=col, image="some-image")
         task.save()
-        res = Result(task=task)
+        res = Result(task=task, status=TaskStatus.PENDING)
         res.save()
 
         headers = self.create_node_and_login(organization=org)
@@ -2323,7 +2324,8 @@ class TestResources(unittest.TestCase):
         col = Collaboration(organizations=[org])
         parent_task = Task(collaboration=col, image="some-image")
         parent_task.save()
-        parent_res = Result(organization=org, task=parent_task)
+        parent_res = Result(organization=org, task=parent_task,
+                            status=TaskStatus.PENDING)
         parent_res.save()
 
         # test wrong image name
@@ -2358,7 +2360,17 @@ class TestResources(unittest.TestCase):
         self.assertEqual(results.status_code, HTTPStatus.CREATED)
 
         # test already completed task
-        parent_res.finished_at = datetime.date(2020, 1, 1)
+        parent_res.status = TaskStatus.COMPLETED
+        parent_res.save()
+        results = self.app.post('/api/task', headers=headers, json={
+            "organizations": [{'id': org.id}],
+            'collaboration_id': col.id,
+            'image': 'some-image'
+        })
+        self.assertEqual(results.status_code, HTTPStatus.UNAUTHORIZED)
+
+        # test a failed task
+        parent_res.status = TaskStatus.FAILED
         parent_res.save()
         results = self.app.post('/api/task', headers=headers, json={
             "organizations": [{'id': org.id}],
@@ -2450,7 +2462,7 @@ class TestResources(unittest.TestCase):
         col = Collaboration(organizations=[org])
         task = Task(collaboration=col, image="some-image")
         task.save()
-        res = Result(task=task, organization=org)
+        res = Result(task=task, organization=org, status=TaskStatus.PENDING)
         res.save()
 
         headers = self.login_container(collaboration=col, organization=org,

--- a/vantage6-server/vantage6/server/model/result.py
+++ b/vantage6-server/vantage6/server/model/result.py
@@ -68,16 +68,12 @@ class Result(Base):
             raise
         return node
 
-    @hybrid_property
-    def complete(self):
-        return self.finished_at is not None
-
     def __repr__(self):
         return (
             "<Result "
             f"{self.id}: '{self.task.name}', "
             f"organization: {self.organization.name}, "
             f"collaboration: {self.task.collaboration.name}, "
-            f"is_complete: {self.complete}"
+            f"status: {self.status}"
             ">"
         )

--- a/vantage6-server/vantage6/server/model/rule.py
+++ b/vantage6-server/vantage6/server/model/rule.py
@@ -12,6 +12,8 @@ class Operation(Enumerate):
     EDIT = "e"
     CREATE = "c"
     DELETE = "d"
+    SEND = "s"
+    RECEIVE = "r"
 
 
 class Scope(Enumerate):

--- a/vantage6-server/vantage6/server/model/task.py
+++ b/vantage6-server/vantage6/server/model/task.py
@@ -37,9 +37,6 @@ class Task(Base):
     initiator = relationship("Organization", back_populates="created_tasks")
     init_user = relationship("User", back_populates="created_tasks")
 
-    def complete(self):
-        return all([r.complete for r in self.results])
-
     @hybrid_property
     def status(self) -> str:
         """
@@ -52,11 +49,7 @@ class Task(Base):
         """
         # TODO what if there are no result ids? -> currently returns unknown
         result_statuses = [r.status for r in self.results]
-        if all([status is None for status in result_statuses]):
-            # TODO remove in v4 (this is for backwards compatibility because
-            # task statuses where not present in <3.6)
-            return 'unknown'
-        elif any([has_task_failed(status) for status in result_statuses]):
+        if any([has_task_failed(status) for status in result_statuses]):
             return TaskStatus.FAILED.value
         elif TaskStatus.ACTIVE in result_statuses:
             return TaskStatus.ACTIVE.value

--- a/vantage6-server/vantage6/server/model/task.py
+++ b/vantage6-server/vantage6/server/model/task.py
@@ -37,9 +37,6 @@ class Task(Base):
     initiator = relationship("Organization", back_populates="created_tasks")
     init_user = relationship("User", back_populates="created_tasks")
 
-    # TODO remove this property in v4. It is superseded by status but now left
-    # here for backwards compatibility with other v3 versions
-    @hybrid_property
     def complete(self):
         return all([r.complete for r in self.results])
 
@@ -69,12 +66,6 @@ class Task(Base):
             return TaskStatus.PENDING.value
         else:
             return TaskStatus.COMPLETED.value
-
-    def results_for_node(self, node):
-        assert isinstance(node, Node), "Should be a node..."
-        return [result for result in self.results if
-                self.collaboration == node.collaboration and
-                self.organization == node.organization]
 
     @classmethod
     def next_run_id(cls):

--- a/vantage6-server/vantage6/server/resource/common/_schema.py
+++ b/vantage6-server/vantage6/server/resource/common/_schema.py
@@ -130,7 +130,6 @@ class TaskSchema(HATEOASModelSchema):
     class Meta:
         model = db.Task
 
-    complete = fields.Boolean()
     status = fields.String()
     collaboration = fields.Method("collaboration")
     results = fields.Method("results")

--- a/vantage6-server/vantage6/server/resource/event.py
+++ b/vantage6-server/vantage6/server/resource/event.py
@@ -51,17 +51,17 @@ def permissions(permissions: PermissionManager):
     # are permissions to do stuff via socket connections
     add = permissions.appender(module_name)
 
-    add(scope=Scope.ORGANIZATION, operation=Operation.VIEW,
+    add(scope=Scope.ORGANIZATION, operation=Operation.RECEIVE,
         description="view websocket events of your organization")
-    add(scope=Scope.COLLABORATION, operation=Operation.VIEW,
+    add(scope=Scope.COLLABORATION, operation=Operation.RECEIVE,
         description="view websocket events of your collaborations")
-    add(scope=Scope.GLOBAL, operation=Operation.VIEW,
+    add(scope=Scope.GLOBAL, operation=Operation.RECEIVE,
         description="view websocket events")
-    add(scope=Scope.ORGANIZATION, operation=Operation.CREATE,
+    add(scope=Scope.ORGANIZATION, operation=Operation.SEND,
         description="send websocket events for your organization")
-    add(scope=Scope.COLLABORATION, operation=Operation.CREATE,
+    add(scope=Scope.COLLABORATION, operation=Operation.SEND,
         description="send websocket events for your collaborations")
-    add(scope=Scope.GLOBAL, operation=Operation.CREATE,
+    add(scope=Scope.GLOBAL, operation=Operation.SEND,
         description="send websocket events to all collaborations")
 
 
@@ -131,9 +131,9 @@ class KillTask(ServicesResources):
 
         # Check permissions. If someone doesn't have global permissions, we
         # check if their organization is part of the appropriate collaboration.
-        if not self.r.c_glo.can():
+        if not self.r.s_glo.can():
             orgs = task.collaboration.organizations
-            if not (self.r.c_org.can() and g.user.organization in orgs):
+            if not (self.r.s_col.can() and g.user.organization in orgs):
                 return {'msg': 'You lack the permission to do that!'}, \
                     HTTPStatus.UNAUTHORIZED
 
@@ -211,11 +211,11 @@ class KillNodeTasks(ServicesResources):
 
         # Check permissions. If someone doesn't have global permissions, we
         # check if their organization is part of the appropriate collaboration.
-        if not self.r.c_glo.can():
+        if not self.r.s_glo.can():
             collab_orgs = node.collaboration.organizations
             if not (
-                (self.r.c_col.can() and g.user.organization in collab_orgs) or
-                (self.r.c_org.can() and
+                (self.r.s_col.can() and g.user.organization in collab_orgs) or
+                (self.r.s_org.can() and
                     node.organization_id == g.user.organization_id)
             ):
                 return {'msg': 'You lack the permission to do that!'}, \

--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -488,7 +488,7 @@ class Tasks(TaskBase):
             return False
 
         # check master task is not completed yet
-        if db.Task.get(container["task_id"]).complete:
+        if db.Task.get(container["task_id"]).complete():
             log.warning(
                 f"Container from node={container['node_id']} "
                 f"attempts to start sub-task for a completed "

--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -488,7 +488,7 @@ class Tasks(TaskBase):
             return False
 
         # check master task is not completed yet
-        if db.Task.get(container["task_id"]).complete():
+        if has_task_finished(db.Task.get(container["task_id"]).status):
             log.warning(
                 f"Container from node={container['node_id']} "
                 f"attempts to start sub-task for a completed "

--- a/vantage6-server/vantage6/server/resource/token.py
+++ b/vantage6-server/vantage6/server/resource/token.py
@@ -18,6 +18,7 @@ from flask_jwt_extended import (
 from http import HTTPStatus
 
 from vantage6 import server
+from vantage6.common.task_status import has_task_finished
 from vantage6.server import db
 from vantage6.server.model.user import User
 from vantage6.server.resource import (
@@ -312,7 +313,7 @@ class ContainerToken(ServicesResources):
                 HTTPStatus.UNAUTHORIZED
 
         # validate that the task not has been finished yet
-        if db_task.complete():
+        if has_task_finished(db_task.status):
             log.warning(f"Node {g.node.id} attempts to generate a key for "
                         f"completed task {task_id}")
             return {"msg": "Task is already finished!"}, HTTPStatus.BAD_REQUEST

--- a/vantage6-server/vantage6/server/resource/token.py
+++ b/vantage6-server/vantage6/server/resource/token.py
@@ -312,7 +312,7 @@ class ContainerToken(ServicesResources):
                 HTTPStatus.UNAUTHORIZED
 
         # validate that the task not has been finished yet
-        if db_task.complete:
+        if db_task.complete():
             log.warning(f"Node {g.node.id} attempts to generate a key for "
                         f"completed task {task_id}")
             return {"msg": "Task is already finished!"}, HTTPStatus.BAD_REQUEST

--- a/vantage6-server/vantage6/server/websockets.py
+++ b/vantage6-server/vantage6/server/websockets.py
@@ -118,18 +118,18 @@ class DefaultSocketNamespace(Namespace):
         """
         # check for which collab rooms the user has permission to enter
         session.user = db.User.get(session.auth_id)
-        if session.user.can('event', Scope.GLOBAL, Operation.VIEW):
+        if session.user.can('event', Scope.GLOBAL, Operation.RECEIVE):
             # user joins all collaboration rooms
             collabs = db.Collaboration.get()
             for collab in collabs:
                 session.rooms.append(f'collaboration_{collab.id}')
         elif session.user.can(
-                'event', Scope.COLLABORATION, Operation.VIEW):
+                'event', Scope.COLLABORATION, Operation.RECEIVE):
             # user joins all collaboration rooms that their organization
             # participates in
             for collab in user.organization.collaborations:
                 session.rooms.append(f'collaboration_{collab.id}')
-        elif session.user.can('event', Scope.ORGANIZATION, Operation.VIEW):
+        elif session.user.can('event', Scope.ORGANIZATION, Operation.RECEIVE):
             # user joins collaboration subrooms that include only messages
             # relevant to their own node
             for collab in user.organization.collaborations:


### PR DESCRIPTION
Fix #402 

- Created new operations 'send' and 'receive' for socket rules
- Changed socket rules to reflect new operations
- Changes in endpoints to reflect changes in rules
- Removed the 'complete' property from db.Task which is superseded by 'status', but kept a function in its stead as that is used elsewhere
- Remove unused function