### PR TITLE
Change/rename initiator

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -1675,7 +1675,7 @@ class UserClient(ClientBase):
             return self.parent.request(f'task/{id_}', params=params)
 
         @post_filtering()
-        def list(self, initiator: int = None, initiating_user: int = None,
+        def list(self, initiating_org: int = None, initiating_user: int = None,
                  collaboration: int = None, image: str = None,
                  parent: int = None, run: int = None,
                  name: str = None, include_results: bool = False,
@@ -1690,7 +1690,7 @@ class UserClient(ClientBase):
                 Filter by the name of the task. It will match with a
                 Like operator. I.e. E% will search for task names that
                 start with an 'E'.
-            initiator: int, optional
+            initiating_org: int, optional
                 Filter by initiating organization
             initiating_user: int, optional
                 Filter by initiating user
@@ -1743,7 +1743,7 @@ class UserClient(ClientBase):
             # a name that distinguishes it better from the initiating user.
             # Then, we should also change it in the server
             params = {
-                'initiator_id': initiator, 'init_user_id': initiating_user,
+                'init_org_id': initiating_org, 'init_user_id': initiating_user,
                 'collaboration_id': collaboration,
                 'image': image, 'parent_id': parent, 'run_id': run,
                 'name': name, 'page': page, 'per_page': per_page,

--- a/vantage6-node/vantage6/node/server_io.py
+++ b/vantage6-node/vantage6/node/server_io.py
@@ -119,8 +119,6 @@ class NodeClient(ClientBase):
             started, and is waiting for restuls.
 
             :param id: id of the task to set the start-time of
-
-            TODO the initiator_id does not make sens here...
         """
         self.patch_results(id, result={
             "started_at": datetime.datetime.now().isoformat()

--- a/vantage6-server/vantage6/server/controller/fixture.py
+++ b/vantage6-server/vantage6/server/controller/fixture.py
@@ -106,7 +106,7 @@ def load(fixtures, drop_all=False):
                 image=image,
                 collaboration=collaboration,
                 run_id=db.Task.next_run_id(),
-                initiator=init_org
+                init_org=init_org
             )
 
             for organization in collaboration.organizations:

--- a/vantage6-server/vantage6/server/model/organization.py
+++ b/vantage6-server/vantage6/server/model/organization.py
@@ -32,7 +32,7 @@ class Organization(Base):
     results = relationship("Result", back_populates="organization")
     nodes = relationship("Node", back_populates="organization")
     users = relationship("User", back_populates="organization")
-    created_tasks = relationship("Task", back_populates="initiator")
+    created_tasks = relationship("Task", back_populates="init_org")
     roles = relationship("Role", back_populates="organization")
 
     def get_result_ids(self):

--- a/vantage6-server/vantage6/server/model/task.py
+++ b/vantage6-server/vantage6/server/model/task.py
@@ -25,16 +25,14 @@ class Task(Base):
     run_id = Column(Integer)
     parent_id = Column(Integer, ForeignKey("task.id"))
     database = Column(String)
-    initiator_id = Column(Integer, ForeignKey("organization.id"))
+    init_org_id = Column(Integer, ForeignKey("organization.id"))
     init_user_id = Column(Integer, ForeignKey("user.id"))
 
     # relationships
     collaboration = relationship("Collaboration", back_populates="tasks")
     parent = relationship("Task", remote_side="Task.id", backref="children")
     results = relationship("Result", back_populates="task")
-    # TODO in v4, rename the 'initiator' column so that there is a clear
-    # distinction between initiating organization and user
-    initiator = relationship("Organization", back_populates="created_tasks")
+    init_org = relationship("Organization", back_populates="created_tasks")
     init_user = relationship("User", back_populates="created_tasks")
 
     # TODO remove this property in v4. It is superseded by status but now left

--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -119,7 +119,7 @@ class Tasks(TaskBase):
 
         parameters:
           - in: query
-            name: initiator_id
+            name: init_org_id
             schema:
               type: int
             description: The organization id of the origin of the request
@@ -240,7 +240,7 @@ class Tasks(TaskBase):
                     HTTPStatus.UNAUTHORIZED
 
         # filter based on arguments
-        for param in ['initiator_id', 'init_user_id', 'collaboration_id',
+        for param in ['init_org_id', 'init_user_id', 'collaboration_id',
                       'parent_id', 'run_id']:
             if param in args:
                 q = q.filter(getattr(db.Task, param) == args[param])
@@ -382,7 +382,7 @@ class Tasks(TaskBase):
         task = db.Task(collaboration=collaboration, name=data.get('name', ''),
                        description=data.get('description', ''), image=image,
                        database=data.get('database', ''),
-                       initiator=init_org)
+                       init_org=init_org)
 
         # create run_id. Users can only create top-level -tasks (they will not
         # have sub-tasks). Therefore, always create a new run_id. Tasks created


### PR DESCRIPTION
Fix #416 

Rename `task.initiator_id` to `task.init_org_id` (and similar others)