### PR TITLE
Cleanup database sessions after socket events

### DIFF
--- a/vantage6-server/vantage6/server/model/base.py
+++ b/vantage6-server/vantage6/server/model/base.py
@@ -252,7 +252,6 @@ class DatabaseSessionManager:
     def new_session():
         # log.critical('Create new DB session')
         if DatabaseSessionManager.in_flask_request():
-
             g.session = Database().session_a
 
             # g.session.refresh()


### PR DESCRIPTION
Socket events were opening database sessions but not closing them - e.g. to check user permissions in JWT decorators

New attempt:
Fix #534 