### PR TITLE
Improved ping/pong between server and nodes

### DIFF
--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 from unittest.mock import patch
 from flask import Response as BaseResponse
 from flask.testing import FlaskClient
+from flask_socketio import SocketIO
 from werkzeug.utils import cached_property
 
 from vantage6.common import logger_name
@@ -54,7 +55,11 @@ class TestResources(unittest.TestCase):
         ctx = context.TestContext.from_external_config_file(
             "unittest_config.yaml")
 
-        server = ServerApp(ctx)
+        # create server instance. Patch the start_background_task method
+        # to prevent the server from starting a ping/pong thread that will
+        # prevent the tests from starting
+        with patch.object(SocketIO, 'start_background_task'):
+            server = ServerApp(ctx)
         cls.server = server
 
         file_ = str(PACKAGE_FOLDER / APPNAME / "server" / "_data" /

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -107,8 +107,7 @@ class ServerApp:
         # set up socket ping/pong
         log.debug(
             "Starting thread for socket ping/pong between server and nodes")
-        t = Thread(target=self.__socket_pingpong_worker, daemon=True)
-        t.start()
+        self.socketio.start_background_task(self.__socket_pingpong_worker)
 
         log.info("Initialization done")
 
@@ -485,7 +484,7 @@ class ServerApp:
         while True:
             # Send ping event
             try:
-                self.__pong_node_ids = []
+                ping_time = dt.datetime.utcnow()
                 self.socketio.emit(
                     'ping', namespace='/tasks', room='all_nodes',
                     callback=self.__pong_response
@@ -498,7 +497,7 @@ class ServerApp:
                 # Otherwise set them to offline.
                 online_status_nodes = db.Node.get_online_nodes()
                 for node in online_status_nodes:
-                    if node.id not in self.__pong_node_ids:
+                    if node.last_seen < ping_time:
                         node.status = 'offline'
                         node.save()
 
@@ -515,7 +514,6 @@ class ServerApp:
         node.status = 'online'
         node.last_seen = dt.datetime.utcnow()
         node.save()
-        self.__pong_node_ids.append(node_id)
 
 
 def run_server(config: str, environment: str = 'prod',


### PR DESCRIPTION
- No longer starting ping/pong in a separate thread but in a socketio background task to prevent complications
- Whether nodes responded to ping is now based on last_seen state and not on a list. The latter is not reliable with multiple server instances