### PR TITLE
replaced legacy settings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,14 @@
+# readthedocs configuration file version
 version: 2
+
 build:
-  image: latest
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
 
 python:
-  version: "3.10"
   install:
     - requirements: docs/requirements.txt
 
+# Build the docs in all formats (html, pdf, epub, etc.)
 formats: all


### PR DESCRIPTION
See that it is working here:
https://docs.vantage6.ai/en/bugfix-readthedocs-fails/technical-documentation/api/server.html