### PR TITLE
Fixed broken discord links

### DIFF
--- a/tools/update-discord.py
+++ b/tools/update-discord.py
@@ -46,7 +46,7 @@ class PostUpdates(commands.Cog):
             ':triangular_flag_on_post:\n\n'
             f'{summary}'
             '\nSee the complete release notes [here]('
-            'https://docs.vantage6.ai/about-background/release-notes)\n\n'
+            'https://docs.vantage6.ai/en/main/release_notes.html)\n\n'
             'To upgrade:'
             '```'
             f'pip install vantage6=={version}'
@@ -62,11 +62,10 @@ class PostUpdates(commands.Cog):
         documentation = (
             '[Latest release notes](https://docs.vantage6.ai/en/main/'
             'release_notes.html)\n'
-            '[Installation instructions](https://docs.vantage6.ai/en/main/'
-            'install/index.html)\n'
+            '[User documentation](https://docs.vantage6.ai/en/main/index.html'
+            '\n'
             '[How to contribute](https://docs.vantage6.ai/en/main/devops/'
             'contribute.html)\n'
-            '[Discourse](https://vantage6.discourse.group/)\n'
         )
 
         links = (


### PR DESCRIPTION
Fix #584 

Notes
- Merging this into main so that it's fixed in next release (also if that's a patch)
- Changed link to installation instructions to generic docs link since our installation instructions are not on a single page anymore
- Removed (broken) link to discord itself - not sure we need a discord link in discord itself