### PR TITLE
rename result to run - more changes

### DIFF
--- a/docs/algorithms/classic_tutorial.rst
+++ b/docs/algorithms/classic_tutorial.rst
@@ -370,16 +370,7 @@ For our average algorithm the implementation will look as follows:
        # also possible to subscribe to a websocket channel to get status
        # updates.
        info("Waiting for results")
-       task_id = task.get("id")
-       task = client.get_task(task_id)
-       while not task.get("complete"):
-           task = client.get_task(task_id)
-           info("Waiting for results")
-           time.sleep(1)
-
-       # Once we now the partials are complete, we can collect them.
-       info("Obtaining results")
-       results = client.get_results(task_id=task.get("id"))
+       results = client.wait_for_results(task_id=task.get("id"))
 
        # Now we can combine the partials to a global average.
        global_sum = 0
@@ -468,7 +459,7 @@ Then create a script to test the algorithm:
 
    # You can directly obtain the result (we dont have to wait for nodes to
    # complete the tasks)
-   results = client.get_results(average_partial_task.get("id"))
+   results = client.result.from_task(average_partial_task.get("id"))
    print(results)
 
    # To trigger the master method you also need to supply the `master`-flag
@@ -485,7 +476,7 @@ Then create a script to test the algorithm:
        },
        organization_ids=[org_ids[0]]
    )
-   results = client.get_results(average_task.get("id"))
+   results = client.result.from_task(average_task.get("id"))
    print(results)
 
 Building and Distributing

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -780,7 +780,7 @@ class UserClient(ClientBase):
         animation = itertools.cycle(['|', '/', '-', '\\'])
         t = time.time()
 
-        while self.task.get(task_id)['status'] != TaskStatus.COMPLETED.value:
+        while self.task.get(task_id)['status'] != TaskStatus.COMPLETED:
             frame = next(animation)
             sys.stdout.write(
                 f'\r{frame} Waiting for task {task_id} ({int(time.time()-t)}s)'

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -513,122 +513,6 @@ class ClientBase(object):
             'database': database
         })
 
-    # TODO BvB 23-01-23 remove this method in v4+ (or make it private?). It is
-    # only here for backwards compatibility.
-    def get_results(self, id: int = None, state: str = None,
-                    include_task: bool = False, task_id: int = None,
-                    node_id: int = None, params: dict = {}) -> dict:
-        """Get task's algorithm run(s) from the central server
-
-        Depending if a `id` is specified or not, either a single or a
-        list of runs is returned. The input and result field of the
-        run are attempted to be decrypted. This fails if the public
-        key at the server is not derived from the currently private key
-        or when the run is not from your organization.
-
-        Parameters
-        ----------
-        id : int, optional
-            Id of the algorithm run, by default None
-        state : str, optional
-            The state of the task (e.g. `open`), by default None
-        include_task : bool, optional
-            Whenever to include the orginating task, by default False
-        task_id : int, optional
-            The id of the originating task, this will return all runs
-            belonging to this task, by default None
-        node_id : int, optional
-            The id of the node at which this run has been produced,
-            this will return all runs from this node, by default None
-        params : dict, optional
-            Additional query parameters, by default {}
-
-        Returns
-        -------
-        dict
-            Containing data on the algorithm run(s)
-        """
-        # Determine endpoint and create dict with query parameters
-        endpoint = 'run' if not id else f'run/{id}'
-
-        if state:
-            params['state'] = state
-        if include_task:
-            params['include'] = 'task'
-        if task_id:
-            params['task_id'] = task_id
-        if node_id:
-            params['node_id'] = node_id
-
-        # self.log.debug(f"Retrieving results using query parameters:{params}")
-        run_data = self.request(endpoint=endpoint, params=params)
-
-        if isinstance(run_data, str):
-            self.log.warn("Requesting results failed")
-            self.log.debug(f"Results message: {run_data}")
-            return {}
-
-        # hack: in the case that the pagination metadata is included we
-        # need to strip that for decrypting
-        if isinstance(run_data, dict) and 'data' in run_data:
-            wrapper = run_data
-            run_data = run_data['data']
-
-        if id:
-            # Single run
-            run_data['input'] = self._decrypt_input(run_data['input'])
-        else:
-            # Multiple runs
-            for run in run_data:
-                run['input'] = self._decrypt_input(run['input'])
-
-        if 'wrapper' in locals():
-            wrapper['data'] = run_data
-            run_data = wrapper
-
-        return run_data
-
-    # TODO I think this method will be superfluous as the result is now
-    # in a separate endpoint
-    def _decrypt_run(self, run):
-        """Helper to decrypt the keys 'input' and 'result' in dict.
-
-        Keys are replaced, but object reference remains intact: changes are
-        made *in-place*.
-
-        Parameters
-        ----------
-        run : dict
-            The result dict to decrypt
-
-        Raises
-        ------
-        AssertionError
-            Encryption has not been initialized
-        """
-        assert self.cryptor, "Encryption has not been initialized"
-        cryptor = self.cryptor
-        try:
-            self.log.info('Decrypting input')
-            # TODO this only works when the runs belong to the
-            # same organization... We should make different implementation
-            # of get_results
-            run["input"] = cryptor.decrypt_str_to_bytes(run["input"])
-
-        except Exception as e:
-            self.log.debug(e)
-
-        try:
-            if run["result"]:
-                self.log.info('Decrypting result')
-                run["run"] = \
-                    cryptor.decrypt_str_to_bytes(run["result"])
-
-        except ValueError as e:
-            self.log.error("Could not decrypt/decode result.")
-            self.log.error(e)
-            # raise
-
     def _decrypt_input(self, input_: str) -> bytes:
         """Helper to decrypt the input of an algorithm run
 
@@ -653,7 +537,6 @@ class ClientBase(object):
         assert self.cryptor, "Encryption has not been initialized"
         cryptor = self.cryptor
         try:
-            self.log.info('Decrypting input')
             # TODO this only works when the runs belong to the
             # same organization... We should make different implementation
             # of get_results
@@ -664,35 +547,53 @@ class ClientBase(object):
 
         return input_
 
-    def _decrypt_result(self, result: str) -> bytes:
+    def _decrypt_field(self, data: dict, field: str,
+                       is_single_resource: bool) -> dict:
         """
-        Helper to decrypt an algorithm's result
+        Wrapper function to decrypt and deserialize the a field of one or more
+        resources
+
+        This can be used to decrypt and deserialize input and results of
+        algorithm runs.
 
         Parameters
         ----------
-        result : str
-            The encrypted algorithm result
+        run_data : dict
+            The data of which to decrypt a field
+        field : str
+            The field to decrypt and deserialize
+        is_single_resource : bool
+            Whether the data is of a single resource or a list of resources
 
         Returns
         -------
-        bytes
-            The decrypted algorithm result
-
-        Raises
-        ------
-        AssertionError
-            Encryption has not been initialized
+        dict
+            Data on the algorithm run(s) with decrypted input
         """
-        assert self.cryptor, "Encryption has not been initialized"
-        cryptor = self.cryptor
-        try:
-            self.log.info('Decrypting result')
-            result = cryptor.decrypt_str_to_bytes(run["result"])
+        # TODO change in v4+ when pagination is default
+        # hack: in the case that the pagination metadata is included we
+        # need to strip that for decrypting
+        if isinstance(data, dict) and 'data' in data:
+            wrapper = data
+            data = data['data']
 
-        except ValueError as e:
-            self.log.error("Could not decrypt/decode result.")
-            self.log.error(e)
-        return result
+        if is_single_resource:
+            data[field] = deserialization.load_data(
+                self._decrypt_input(
+                    data[field]
+                )
+            )
+        else:
+            for resource in data:
+                resource[field] = deserialization.load_data(
+                    self._decrypt_input(resource[field])
+                )
+
+        if 'wrapper' in locals():
+            wrapper['data'] = data
+            data = wrapper
+
+        return data
 
     class SubClient:
         """
@@ -893,7 +794,7 @@ class UserClient(ClientBase):
         elif isinstance(self.log, UserClient.Log):
             self.log.enabled = prev_level
 
-        return self.get_results(task_id=task_id)
+        return self.request('result', params={'task_id': task_id})
 
     class Util(ClientBase.SubClient):
         """Collection of general utilities"""
@@ -2021,15 +1922,12 @@ class UserClient(ClientBase):
             """
             self.parent.log.info('--> Attempting to decrypt results!')
 
-            # get_results also handles decryption
-            run = self.parent.get_results(id=id_, include_task=include_task)
-            result_data = run.get('result')
-            if result_data:
-                try:
-                    run['result'] = deserialization.load_data(result_data)
-                except Exception as e:
-                    self.parent.log.warn('--> Failed to deserialize')
-                    self.parent.log.debug(e)
+            # get run from the API
+            params = {'include': 'task'} if include_task else {}
+            run = self.parent.request(endpoint=f'run/{id_}', params=params)
+
+            # decrypt input
+            run = self._decrypt_input(run_data=run, is_single_run=True)
 
             return run
 
@@ -2101,33 +1999,13 @@ class UserClient(ClientBase):
                 'port': port
             }
 
-            runs = self.parent.get_results(params=params)
+            # get runs from the API
+            runs = self.parent.request(endpoint='run', params=params)
 
-            if isinstance(runs, dict):
-                wrapper = runs
-                runs = runs['data']
+            # decrypt input data
+            runs = self._decrypt_input(run_data=runs, is_single_run=False)
 
-            cleaned_runs = []
-            for run in runs:
-                if run.get('result'):
-                    try:
-                        des_res = deserialization.load_data(
-                            run.get('result')
-                        )
-                    except Exception as e:
-                        id_ = run.get('id')
-                        self.parent.log.warn('Could not deserialize run id='
-                                             f'{id_}')
-                        self.parent.log.debug(e)
-                        continue
-                    run['result'] = des_res
-                cleaned_runs.append(run)
-
-            if 'wrapper' in locals():
-                wrapper['data'] = cleaned_runs
-                cleaned_runs = wrapper
-
-            return cleaned_runs
+            return runs
 
         # note: using typing.List instead of `list` to prevent referring
         # to the list() function in an incorrect manner
@@ -2135,7 +2013,7 @@ class UserClient(ClientBase):
             self, task_id: int, include_task: bool = False
         ) -> typing.List[dict]:
             """
-            Get all results from a specific task
+            Get all algorithm runs from a specific task
 
             Parameters
             ----------
@@ -2151,23 +2029,44 @@ class UserClient(ClientBase):
             """
             self.parent.log.info('--> Attempting to decrypt results!')
 
-            # get_results also handles decryption
-            runs = self.parent.get_results(task_id=task_id,
-                                           include_task=include_task)
-            cleaned_runs = []
-            for run in runs:
-                if run.get('result'):
-                    des_res = deserialization.load_data(run.get('result'))
-                    run['result'] = des_res
-                cleaned_runs.append(run)
+            # get all algorithm runs from a specific task
+            params = {}
+            if include_task:
+                params['include'] = 'task'
+            if task_id:
+                params['task_id'] = task_id
+            runs = self.parent.request(endpoint='run', params=params)
 
-            return cleaned_runs
+            # decrypt input data
+            runs = self._decrypt_input(run_data=runs, is_single_run=False)
+
+            return runs
+
+        def _decrypt_input(self, run_data: dict, is_single_run: bool) -> dict:
+            """
+            Wrapper function to decrypt and deserialize the input of one or
+            more runs
+
+            Parameters
+            ----------
+            run_data : dict
+                The data of the run(s) to decrypt
+            is_single_run : bool
+                Whether the run_data is a single run or a list of runs
+
+            Returns
+            -------
+            dict
+                Data on the algorithm run(s) with decrypted input
+            """
+            return self.parent._decrypt_field(
+                data=run_data, field='input', is_single_resource=is_single_run
+            )
 
     class Result(ClientBase.SubClient):
         """
         Client to get the results of one or multiple algorithm runs
         """
-
         @post_filtering(iterable=False)
         def get(self, id_: int) -> dict:
             """View a specific result
@@ -2184,30 +2083,42 @@ class UserClient(ClientBase):
             """
             self.parent.log.info('--> Attempting to decrypt results!')
 
-            # get_results also handles decryption
-            run = self.parent.get_results(id=id_)
-            result_data = run.get('result')
-            if result_data:
-                try:
-                    run['result'] = deserialization.load_data(result_data)
-                except Exception as e:
-                    self.parent.log.warn('--> Failed to deserialize')
-                    self.parent.log.debug(e)
+            result = self.parent.request(endpoint=f'result/{id_}')
+            result = self._decrypt_result(
+                result_data=result, is_single_result=True
+            )
 
-            return run['result']
+            return result['result']
 
         def from_task(self, task_id: int):
             self.parent.log.info('--> Attempting to decrypt results!')
 
-            # get_results also handles decryption
-            runs = self.parent.get_results(task_id=task_id)
-            cleaned_results = []
-            for run in runs:
-                if run.get('result'):
-                    des_res = deserialization.load_data(run.get('result'))
-                    run['result'] = des_res
-                    cleaned_results.append(run['result'])
-            return cleaned_results
+            results = self.parent.request('result', {'task_id': task_id})
+            results = self._decrypt_result(results, False)
+            return results
+
+        def _decrypt_result(self, result_data: dict,
+                            is_single_result: bool) -> dict:
+            """
+            Wrapper function to decrypt and deserialize the input of one or
+            more runs
+
+            Parameters
+            ----------
+            result_data : dict
+                The data of the run(s) to decrypt
+            is_single_result : bool
+                Whether the result_data is a single result or a list of results
+
+            Returns
+            -------
+            dict
+                Data on the algorithm run(s) with decrypted input
+            """
+            return self.parent._decrypt_field(
+                data=result_data, field='result',
+                is_single_resource=is_single_result
+            )
 
     class Rule(ClientBase.SubClient):
 

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -316,14 +316,14 @@ def proxy_task_run(id: int) -> Response:
 
 
 @app.route('/run/<int:id>', methods=["GET"])
-def proxy_runs(id: int) -> Response:
+def proxy_runs(id_: int) -> Response:
     """
     Obtain and decrypt the algorithm run from the vantage6 server to be used by
     an algorithm container.
 
     Parameters
     ----------
-    id : int
+    id_ : int
         Id of the run to be obtained
 
     Returns
@@ -339,7 +339,7 @@ def proxy_runs(id: int) -> Response:
 
     # Make the proxied request
     try:
-        response: Response = make_proxied_request(f"run/{id}")
+        response: Response = make_proxied_request(f"run/{id_}")
     except Exception:
         log.exception('Error on /run/<int:id>')
         return {'msg': 'Request failed, see node logs...'},\

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -276,7 +276,7 @@ def proxy_task():
 
 
 @app.route('/task/<int:id>/run', methods=["GET"])
-def proxy_task_result(id: int) -> Response:
+def proxy_task_run(id: int) -> Response:
     """
     Obtain and decrypt all results to belong to a certain task
 
@@ -311,13 +311,12 @@ def proxy_task_result(id: int) -> Response:
     for run in runs:
         run = decrypt_result(run)
         unencrypted.append(run)
-    print('runs', runs)
 
     return jsonify(unencrypted), HTTPStatus.OK
 
 
 @app.route('/run/<int:id>', methods=["GET"])
-def proxy_results(id: int) -> Response:
+def proxy_runs(id: int) -> Response:
     """
     Obtain and decrypt the algorithm run from the vantage6 server to be used by
     an algorithm container.
@@ -349,7 +348,6 @@ def proxy_results(id: int) -> Response:
     # Try to decrypt the results
     run = get_response_json_and_handle_exceptions(response)
     run = decrypt_result(run)
-    print('run', run)
 
     return run, HTTPStatus.OK
 

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -35,6 +35,7 @@ from flask_restful import Api
 from flask_mail import Mail
 from flask_principal import Principal, Identity, identity_changed
 from flask_socketio import SocketIO
+from threading import Thread
 
 from vantage6.common import logger_name
 from vantage6.common.globals import PING_INTERVAL_SECONDS


### PR DESCRIPTION
This should be everything to rename result to run

We only should have a discussion regarding the endpoint `/task/<id>/run`. This now gives all run details including the result. We may consider creating a separate `/task/<id>/result` just for the result