### PR TITLE
In 'vnode files', take the reformatted structure of the databases in …

### DIFF
--- a/vantage6/vantage6/cli/node.py
+++ b/vantage6/vantage6/cli/node.py
@@ -228,8 +228,13 @@ def cli_node_files(name: str, environment: str, system_folders: bool) -> None:
     info(f"Log file           = {ctx.log_file}")
     info(f"data folders       = {ctx.data_dir}")
     info("Database labels and files")
-    for label, path in ctx.databases.items():
-        info(f" - {label:15} = {path}")
+    # TODO in v4+, this will always be a list so remove next few lines
+    if isinstance(ctx.databases, dict):
+        for label, path in ctx.databases.items():
+            info(f" - {label:15} = {path}")
+    else:
+        for db in ctx.databases:
+            info(f" - {db['label']:15} = {db['uri']} (type: {db['type']})")
 
 
 #


### PR DESCRIPTION
…the node configuration into account

I got the error `AttributeError: 'list' object has no attribute 'items'` when doing `vnode files` with v3.8.0, which is because we've changed the way the databases are configured in the node (including 'type' now)

Fixing that here