### PR TITLE
Use different github action to create a Github release, since marvinp…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,14 +105,8 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{env.branch}}
-
-    - name: Create a Release
-      uses: marvinpinto/action-automatic-releases@6273874b61ebc8c71f1a61b2d98e234cf389b303
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "v${{ env.version }}"
-        prerelease: ${{ env.stage != '' }}
-        title: "${{ env.version }}"
+    - name: Release
+      uses: softprops/action-gh-release@v1
 
   support-images:
     name: Build support images


### PR DESCRIPTION
…into/action-automatic-releases is no longer maintained

This intends to fix #474 