### PR TITLE
Specific error message in case no nodes are running when user types '…

### DIFF
--- a/vantage6/vantage6/cli/node.py
+++ b/vantage6/vantage6/cli/node.py
@@ -622,6 +622,10 @@ def cli_node_attach(name: str, system_folders: bool) -> None:
 
     running_node_names = find_running_node_names(client)
 
+    if not running_node_names:
+        warning("No nodes are currently running. Cannot show any logs!")
+        return
+
     if not name:
         name = q.select("Select the node you wish to inspect:",
                         choices=running_node_names).ask()


### PR DESCRIPTION
…vnode attach'

Fix #606 