### PR TITLE
Wait a few seconds after socket connection for first ping, to prevent…

### DIFF
--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -807,6 +807,9 @@ class Node(object):
         Send ping messages periodically to the server over the socketIO
         connection to notify the server that this node is online
         """
+        # Wait for the socket to be connected to the namespaces on startup
+        time.sleep(5)
+
         while True:
             try:
                 self.socketIO.emit('ping', namespace='/tasks')


### PR DESCRIPTION
… non-connected namespace error

This prevents this error directly after startup:
```
2023-03-23 14:18:33 - node           - ERROR    - Ping thread had an exception
Traceback (most recent call last):
  File "/vantage6/vantage6-node/vantage6/node/__init__.py", line 812, in __socket_ping_worker
    self.socketIO.emit('ping', namespace='/tasks')
  File "/usr/local/lib/python3.10/site-packages/socketio/client.py", line 393, in emit
    raise exceptions.BadNamespaceError(
socketio.exceptions.BadNamespaceError: /tasks is not a connected namespace.
```