### PR TITLE
Last changes for renaming result to run

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -21,14 +21,12 @@ import traceback
 from pathlib import Path
 
 from vantage6.common.exceptions import AuthenticationException
-from vantage6.common import bytes_to_base64s, base64s_to_bytes
 from vantage6.common.globals import APPNAME
 from vantage6.common.encryption import RSACryptor, DummyCryptor
 from vantage6.common import WhoAmI
 from vantage6.client import serialization, deserialization
 from vantage6.client.filter import post_filtering
 from vantage6.client.utils import print_qr_code, LogLevel
-from vantage6.client.algorithm_client import AlgorithmClient
 from vantage6.common.task_status import TaskStatus
 
 

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -608,7 +608,7 @@ class ClientBase(object):
         parent : UserClient | AlgorithmClient
             The parent client
         """
-        def __init__(self, parent: UserClient | AlgorithmClient) -> None:
+        def __init__(self, parent) -> None:
             self.parent = parent
 
 

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -4,6 +4,8 @@ vantage6 clients
 This module is contains a base client. From this base client the container
 client (client used by master algorithms) and the user client are derived.
 """
+from __future__ import annotations
+
 import logging
 import pickle
 import time
@@ -26,6 +28,7 @@ from vantage6.common import WhoAmI
 from vantage6.client import serialization, deserialization
 from vantage6.client.filter import post_filtering
 from vantage6.client.utils import print_qr_code, LogLevel
+from vantage6.client.algorithm_client import AlgorithmClient
 from vantage6.common.task_status import TaskStatus
 
 
@@ -602,11 +605,11 @@ class ClientBase(object):
 
         Parameters
         ----------
-        parent : UserClient
+        parent : UserClient | AlgorithmClient
             The parent client
         """
-        def __init__(self, parent) -> None:
-            self.parent: UserClient = parent
+        def __init__(self, parent: UserClient | AlgorithmClient) -> None:
+            self.parent = parent
 
 
 class UserClient(ClientBase):

--- a/vantage6-client/vantage6/client/algorithm_client.py
+++ b/vantage6-client/vantage6/client/algorithm_client.py
@@ -146,7 +146,9 @@ class AlgorithmClient(ClientBase):
             # TODO do we need this function? It may be used to collect data
             # on subtasks but usually only the results are accessed, which is
             # done with the function below.
-            return self.parent.multi_page_request(f"run?task_id={task_id}")
+            return self.parent.multi_page_request(
+                "run", params={"task_id": task_id}
+            )
 
     class Result(ClientBase.SubClient):
         """
@@ -177,7 +179,7 @@ class AlgorithmClient(ClientBase):
                 algorithm.
             """
             results = self.parent.multi_page_request(
-                endpoint=f"result?task_id={task_id}"
+                "result", params={"task_id": task_id}
             )
 
             decoded_results = []

--- a/vantage6-client/vantage6/client/algorithm_client.py
+++ b/vantage6-client/vantage6/client/algorithm_client.py
@@ -81,7 +81,7 @@ class AlgorithmClient(ClientBase):
         """
         return super().request(*args, **kwargs, retry=False)
 
-    def multi_page_request(self, endpoint: str, params: dict = {}) -> dict:
+    def multi_page_request(self, endpoint: str, params: dict = None) -> dict:
         """
         Make multiple requests to the central server to get all pages of a list
         of results.
@@ -98,6 +98,8 @@ class AlgorithmClient(ClientBase):
         dict
             Response from the central server.
         """
+        if params is None:
+            params = {}
         # get first page
         page = 1
         params["page"] = page

--- a/vantage6-client/vantage6/client/algorithm_client.py
+++ b/vantage6-client/vantage6/client/algorithm_client.py
@@ -54,6 +54,7 @@ class AlgorithmClient(ClientBase):
 
         # attach sub-clients
         self.run = self.Run(self)
+        self.result = self.Result(self)
         self.task = self.Task(self)
         self.vpn = self.VPN(self)
         self.organization = self.Organization(self)
@@ -79,6 +80,38 @@ class AlgorithmClient(ClientBase):
             Response from the central server.
         """
         return super().request(*args, **kwargs, retry=False)
+
+    def multi_page_request(self, endpoint: str, params: dict = {}) -> dict:
+        """
+        Make multiple requests to the central server to get all pages of a list
+        of results.
+
+        Parameters
+        ----------
+        endpoint: str
+            Endpoint to which the request should be made.
+        params: dict
+            Parameters to be passed to the request.
+
+        Returns
+        -------
+        dict
+            Response from the central server.
+        """
+        # get first page
+        page = 1
+        params["page"] = page
+        response = self.request(endpoint, params=params)
+
+        # append next pages (if any)
+        links = response.get("links")
+        while links and links.get("next"):
+            page += 1
+            params["page"] = page
+            response["data"] += self.request(endpoint, params=params)["data"]
+            links = response.get("links")
+
+        return response['data']
 
     class Run(ClientBase.SubClient):
         """
@@ -110,18 +143,52 @@ class AlgorithmClient(ClientBase):
                 List of algorithm run data. The type of the results depends on
                 the algorithm.
             """
-            runs = self.parent.request(
-                f"task/{task_id}/run"
+            # TODO do we need this function? It may be used to collect data
+            # on subtasks but usually only the results are accessed, which is
+            # done with the function below.
+            return self.parent.multi_page_request(f"run?task_id={task_id}")
+
+    class Result(ClientBase.SubClient):
+        """
+        Result client for the algorithm container.
+
+        This client is used to get results from the central server.
+        """
+        def get(self, task_id: int) -> list:
+            """
+            Obtain results from a specific task at the server.
+
+            Containers are allowed to obtain the results of their children
+            (having the same job_id at the server). The permissions are checked
+            at te central server.
+
+            Results are decrypted by the proxy server and decoded here before
+            returning them to the algorithm.
+
+            Parameters
+            ----------
+            task_id: int
+                ID of the task from which you want to obtain the results
+
+            Returns
+            -------
+            list
+                List of results. The type of the results depends on the
+                algorithm.
+            """
+            results = self.parent.multi_page_request(
+                endpoint=f"result?task_id={task_id}"
             )
 
             decoded_results = []
             # Encryption is not done at the client level for the container. The
             # algorithm developer is responsible for decrypting the results.
             # FIXME Are we completely sure that the format is always a pickle?
+            # TODO update with v4+ changes
             try:
                 decoded_results = [
-                    pickle.loads(base64s_to_bytes(run.get("result")))
-                    for run in runs if run.get("result")
+                    pickle.loads(base64s_to_bytes(result.get("result")))
+                    for result in results if result.get("result")
                 ]
             except Exception as e:
                 self.parent.log.error('Unable to unpickle result')
@@ -333,27 +400,11 @@ class AlgorithmClient(ClientBase):
             list[dict]
                 List of organizations in the collaboration.
             """
-            page = 1
-            organizations = self.parent.request(
-                "organization",
-                params={
-                    "collaboration_id": self.parent.collaboration_id,
-                    "page": page,
+            return self.parent.multi_page_request(
+                endpoint="organization", params={
+                    "collaboration_id": self.parent.collaboration_id
                 }
             )
-            links = organizations.get("links")
-            while links and links.get("next"):
-                page += 1
-                organizations["data"] += self.parent.request(
-                    "organization",
-                    params={
-                        "collaboration_id": self.parent.collaboration_id,
-                        "page": page,
-                    }
-                )["data"]
-                links = organizations.get("links")
-
-            return organizations['data']
 
     class Collaboration(ClientBase.SubClient):
         """

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -147,6 +147,7 @@ def decrypt_result(run: dict) -> dict:
     dict
         Run dict with the `result` decrypted
     """
+    # FIXME check if this function is not implemented in several places
     server_io: NodeClient = app.config.get('SERVER_IO')
 
     # if the result is a None, there is no need to decrypt that..

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -275,9 +275,11 @@ def proxy_task():
 
     return response.json(), HTTPStatus.OK
 
-
-@app.route('/task/<int:id>/run', methods=["GET"])
-def proxy_task_run(id: int) -> Response:
+# TODO test whether this function is accessed from the algorithm client's
+# result.get() function. It may not be because now we call a different path
+# on the server, that includes the ID as parameter instead of part of the URL.
+@app.route('/result?task_id=<int:id_>', methods=["GET"])
+def proxy_result(id_: int) -> Response:
     """
     Obtain and decrypt all results to belong to a certain task
 
@@ -299,9 +301,9 @@ def proxy_task_run(id: int) -> Response:
 
     # Forward the request
     try:
-        response: Response = make_proxied_request(f"task/{id}/run")
+        response: Response = make_proxied_request(f"result?task_id={id_}")
     except Exception:
-        log.exception('Error on "task/<id>/run"')
+        log.exception(f'Error on "result?task_id={id_}"')
         return {'msg': 'Request failed, see node logs'},\
             HTTPStatus.INTERNAL_SERVER_ERROR
 

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -275,9 +275,6 @@ def proxy_task():
 
     return response.json(), HTTPStatus.OK
 
-# TODO test whether this function is accessed from the algorithm client's
-# result.get() function. It may not be because now we call a different path
-# on the server, that includes the ID as parameter instead of part of the URL.
 @app.route('/result?task_id=<int:id_>', methods=["GET"])
 def proxy_result(id_: int) -> Response:
     """

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -2479,7 +2479,7 @@ class TestResources(unittest.TestCase):
         rule = Rule.get_by_("run", Scope.ORGANIZATION, Operation.VIEW)
         headers = self.create_user_and_login(rules=[rule])
         result = self.app.get(f'/api/run?task_id={task.id}', headers=headers)
-        self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(len(result.json['data']), 0)
 
         # test with organization permission
         headers = self.create_user_and_login(org, [rule])
@@ -2497,7 +2497,7 @@ class TestResources(unittest.TestCase):
         headers = self.create_user_and_login(rules=[rule])
         result = self.app.get(
             f'/api/result?task_id={task.id}', headers=headers)
-        self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
+        self.assertEqual(len(result.json['data']), 0)
 
         # test with organization permission
         headers = self.create_user_and_login(org, [rule])
@@ -2526,5 +2526,5 @@ class TestResources(unittest.TestCase):
 
         headers = self.login_container(collaboration=col, organization=org,
                                        task=task)
-        results = self.app.get(f'/api/task/{task.id}/run', headers=headers)
+        results = self.app.get(f'/api/run?task_id={task.id}', headers=headers)
         self.assertEqual(results.status_code, HTTPStatus.OK)

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -2478,18 +2478,38 @@ class TestResources(unittest.TestCase):
 
         rule = Rule.get_by_("run", Scope.ORGANIZATION, Operation.VIEW)
         headers = self.create_user_and_login(rules=[rule])
-        result = self.app.get(f'/api/task/{task.id}/run', headers=headers)
+        result = self.app.get(f'/api/run?task_id={task.id}', headers=headers)
         self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
 
         # test with organization permission
         headers = self.create_user_and_login(org, [rule])
-        result = self.app.get(f'/api/task/{task.id}/run', headers=headers)
+        result = self.app.get(f'/api/run?task_id={task.id}', headers=headers)
         self.assertEqual(result.status_code, HTTPStatus.OK)
 
         # test with global permission
         rule = Rule.get_by_("run", Scope.GLOBAL, Operation.VIEW)
         headers = self.create_user_and_login(rules=[rule])
-        result = self.app.get(f'/api/task/{task.id}/run', headers=headers)
+        result = self.app.get(f'/api/run?task_id={task.id}', headers=headers)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+
+        # test also result endpoint
+        rule = Rule.get_by_("run", Scope.ORGANIZATION, Operation.VIEW)
+        headers = self.create_user_and_login(rules=[rule])
+        result = self.app.get(
+            f'/api/result?task_id={task.id}', headers=headers)
+        self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
+
+        # test with organization permission
+        headers = self.create_user_and_login(org, [rule])
+        result = self.app.get(
+            f'/api/result?task_id={task.id}', headers=headers)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+
+        # test with global permission
+        rule = Rule.get_by_("run", Scope.GLOBAL, Operation.VIEW)
+        headers = self.create_user_and_login(rules=[rule])
+        result = self.app.get(
+            f'/api/result?task_id={task.id}', headers=headers)
         self.assertEqual(result.status_code, HTTPStatus.OK)
 
         # cleanup

--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -99,7 +99,7 @@ def permissions(permissions: PermissionManager) -> None:
 # Resources / API's
 # ------------------------------------------------------------------------------
 task_schema = TaskSchema()
-task_run_schema = TaskIncludedSchema()
+task_result_schema = TaskIncludedSchema()
 
 
 class TaskBase(ServicesResources):
@@ -295,7 +295,7 @@ class Tasks(TaskBase):
 
         # serialization schema
         # TODO BvB 2023-02-08: does this work?
-        schema = task_run_schema if self.is_included('result') else\
+        schema = task_result_schema if self.is_included('result') else\
             task_schema
 
         return self.response(page, schema)
@@ -646,7 +646,7 @@ class Task(TaskBase):
         auth_org = self.obtain_auth_organization()
 
         # obtain schema
-        schema = task_run_schema if request.args.get('include') == \
+        schema = task_result_schema if request.args.get('include') == \
             'results' else task_schema
 
         # check permissions


### PR DESCRIPTION
- Removed endpoint /task/<id>/run, which is superseded by modern alternative /run?task_id=<id>
- Adapted proxy server and algorithm client to that
- `/task?include=results` now only includes the result, not all other fields

I think with this, all changes required for #436 are done.