### PR TITLE
Feature/gpu support

### DIFF
--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -14,6 +14,10 @@ application:
   # subnet of the VPN server
   vpn_subnet: 10.76.0.0/16
 
+  # set the devices the algorithm container is allowed to request.
+  algorithm_device_requests:
+    gpu: true
+
   # add additional environment variables to the algorithm containers.
   # this could be usefull for passwords or other things that algorithms
   # need to know about the node it is running on

--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -16,7 +16,7 @@ application:
 
   # set the devices the algorithm container is allowed to request.
   algorithm_device_requests:
-    gpu: true
+    gpu: false
 
   # add additional environment variables to the algorithm containers.
   # this could be usefull for passwords or other things that algorithms

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -206,7 +206,7 @@ class DockerManager(DockerBaseManager):
                                      'type': db_type}
         self.log.debug(f"Databases: {self.databases}")
 
-    def _set_algorithm_device_access(self, device_requests_config: Dict):
+    def _set_algorithm_device_requests(self, device_requests_config: Dict):
         """
         Configure device access for the algorithm container.
 

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -207,6 +207,15 @@ class DockerManager(DockerBaseManager):
         self.log.debug(f"Databases: {self.databases}")
 
     def _set_algorithm_device_access(self, device_requests_config: Dict):
+        """
+        Configure device access for the algorithm container.
+
+        Parameters
+        ----------
+        device_requests_config: Dict
+           A dictionary containing configuration options for device access. Supported keys:
+           - 'gpu': A boolean value indicating whether GPU access is required.
+        """
         device_requests = []
         if device_requests_config.get('gpu', False):
             device_requests.append(docker.types.DeviceRequest(count=-1, capabilities=[['gpu']]))

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 import docker.errors
+from docker.types import DeviceRequest
 import json
 
 from typing import Dict, List, Union
@@ -283,7 +284,10 @@ class DockerTaskManager(DockerBaseManager):
                 network='container:' + self.helper_container.id,
                 volumes=self.volumes,
                 name=container_name,
-                labels=self.labels
+                labels=self.labels,
+                device_requests=[
+                  DeviceRequest(count=-1, capabilities=[['gpu']])
+                ] 
             )
 
         except Exception as e:

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 import docker.errors
+from docker.types import DeviceRequest
 import json
 
 from typing import Dict, List, Union
@@ -42,7 +43,7 @@ class DockerTaskManager(DockerBaseManager):
                  isolated_network_mgr: NetworkManager,
                  databases: dict, docker_volume_name: str,
                  alpine_image: Union[str, None] = None,
-                 device_requests: Union[List, None] = None):
+                 device_requests: Union[List[DeviceRequest], None] = None):
         """
         Initialization creates DockerTaskManager instance
 
@@ -68,6 +69,9 @@ class DockerTaskManager(DockerBaseManager):
             Name of the docker volume
         alpine_image: str or None
             Name of alternative Alpine image to be used
+        device_requests: List or None
+            List of DeviceRequest objects to be passed to the algorithm
+            container
         """
         super().__init__(isolated_network_mgr)
         self.image = image

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -43,7 +43,7 @@ class DockerTaskManager(DockerBaseManager):
                  isolated_network_mgr: NetworkManager,
                  databases: dict, docker_volume_name: str,
                  alpine_image: Union[str, None] = None,
-                 device_requests: Union[List[DeviceRequest], None] = None):
+                 device_requests: Union[List, None] = None):
         """
         Initialization creates DockerTaskManager instance
 
@@ -439,7 +439,7 @@ class DockerTaskManager(DockerBaseManager):
                              "exist. Available databases are: "
                              f"{self.databases.keys()}. This is likely to "
                              "result in an algorithm crash.")
-            self.debug(f"User specified database: {database}")
+            self.log.debug(f"User specified database: {database}")
 
         # Only prepend the data_folder is it is a file-based database
         # This allows algorithms to access multiple data sources at the

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -4,7 +4,6 @@ import logging
 import os
 import pickle
 import docker.errors
-from docker.types import DeviceRequest
 import json
 
 from typing import Dict, List, Union
@@ -42,7 +41,8 @@ class DockerTaskManager(DockerBaseManager):
                  result_id: int, task_info: Dict, tasks_dir: Path,
                  isolated_network_mgr: NetworkManager,
                  databases: dict, docker_volume_name: str,
-                 alpine_image: Union[str, None] = None):
+                 alpine_image: Union[str, None] = None,
+                 device_requests: Union[List, None] = None):
         """
         Initialization creates DockerTaskManager instance
 
@@ -101,6 +101,12 @@ class DockerTaskManager(DockerBaseManager):
 
         # keep track of the task status
         self.status: TaskStatus = TaskStatus.INITIALIZING
+
+        # set device requests
+        self.device_requests = []
+        if device_requests is not None:
+            self.device_requests = device_requests
+
 
     def is_finished(self) -> bool:
         """
@@ -285,9 +291,7 @@ class DockerTaskManager(DockerBaseManager):
                 volumes=self.volumes,
                 name=container_name,
                 labels=self.labels,
-                device_requests=[
-                  DeviceRequest(count=-1, capabilities=[['gpu']])
-                ] 
+                device_requests=self.device_requests
             )
 
         except Exception as e:


### PR DESCRIPTION
# Feature/GPU Support

This pull request addresses issue #597 by adding a configuration option for the Node to allow the algorithm container access to the GPUs. This is done by creating and passing on a list of DeviceRequest objects from the docker-py package. Currently the only options are to block GPU access or allow access to all the GPUs on a machine, but there is an opportunity to make extend the configurability.

To interpret the Node configuration in DockerManager and then get the DeviceRequest to the algorithm container, I had to modify the arguments of DockerTaskManager. An alternative without this alteration would be to pass along the configuration through the algorithm environment variables, but seen as these configuration variables do not play a role _inside_ the container, I didn't think this was the best place to put this. 

It was not really clear to me which branch I should create the pull request for, dev3 seems to be somewhat behind main and I didn't want to make the choice for a release for you. If the PR should go somewhere else, please let me know.