### PR TITLE
Fix missing class attribute instance_type in servercontext

### DIFF
--- a/vantage6-common/vantage6/common/context.py
+++ b/vantage6-common/vantage6/common/context.py
@@ -141,6 +141,7 @@ class AppContext(metaclass=Singleton):
         self_.config_dir = Path(path).parent
         self_.config_file = path
         self_.environment = environment
+        self_.instance_type = instance_type
         self_.set_folders(instance_type, instance_name, system_folders)
         module_name = logger_name(__name__)
         self_.log = logging.getLogger(module_name)


### PR DESCRIPTION
Small error introduced earlier in release/3.9 branch