### PR TITLE
In getting VPN IP address, use has_connection() to wait for establish…

### DIFF
--- a/vantage6-node/vantage6/node/docker/vpn_manager.py
+++ b/vantage6-node/vantage6/node/docker/vpn_manager.py
@@ -221,10 +221,14 @@ class VPNManager(DockerBaseManager):
             IP address assigned to VPN client container by VPN server
         """
         try:
-            _, vpn_interface = self.vpn_client_container.exec_run(
-                'ip --json addr show dev tun0'
-            )
-            vpn_interface = json.loads(vpn_interface)
+            # use has_connection() to check if VPN is active. This function
+            # also waits for a connection to be established, which is helpful
+            # for unstable connections
+            if self.has_connection():
+                _, vpn_interface = self.vpn_client_container.exec_run(
+                    'ip --json addr show dev tun0'
+                )
+                vpn_interface = json.loads(vpn_interface)
         except (JSONDecodeError, docker.errors.APIError):
             # JSONDecodeError if VPN is not setup yet, APIError if VPN
             # container is restarting (e.g. due to connection errors)


### PR DESCRIPTION
…ing connection. This is useful for unstable connections that may temporarily lose VPN connectivity

Fix #656 