### PR TITLE
Fix check whether a database is an existing file. In a docker contain…

### DIFF
--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -199,9 +199,12 @@ class DockerManager(DockerBaseManager):
             else:
                 uri = db_config['uri']
 
-            db_is_file = Path(uri).exists()
-            if running_in_docker() and db_is_file:
-                uri = f'/mnt/{uri}'
+            if running_in_docker():
+                db_is_file = Path(f'/mnt/{uri}').exists()
+                if db_is_file:
+                    uri = f'/mnt/{uri}'
+            else:
+                db_is_file = Path(uri).exists()
 
             if db_is_file:
                 # We'll copy the file to the folder `data` in our task_dir.


### PR DESCRIPTION
…er, the path should be prepended with /mnt

We can also merge this into main and release a hotfix if 3.9 takes too long