### PR TITLE
Startup the node with the same image version as the server is running on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,8 @@ jobs:
     needs: [version, infrastructure-images]
     env:
       version: ${{ needs.version.outputs.version }}
+      major: ${{ needs.version.outputs.major }}
+      minor: ${{ needs.version.outputs.minor }}
       stage: ${{ needs.version.outputs.stage }}
       major_name: ${{ needs.version.outputs.major_name }}
     steps:
@@ -261,6 +263,15 @@ jobs:
           docker push harbor2.vantage6.ai/infrastructure/server:${major_name}
           docker push harbor2.vantage6.ai/infrastructure/server:${major_name}-live
           docker push harbor2.vantage6.ai/infrastructure/node:${major_name}
+
+      - # Release a node image for major.minor. This is released for any
+        # non-candidate release or if no non-candidate release has been made yet
+        # for the current minor version
+        name: Build Docker base image
+        if: ${{ env.stage == 0 || env.minor == 0 }}
+        run: |
+          docker tag harbor2.vantage6.ai/infrastructure/node:${version} harbor2.vantage6.ai/infrastructure/node:${major}.${minor}
+          docker push harbor2.vantage6.ai/infrastructure/node:${major}.${minor}
 
   # Build an release all the vantage6 infrastructure packages. For all
   # the packages it will (1) update the version as specified in the tag,

--- a/docs/node/use.rst
+++ b/docs/node/use.rst
@@ -29,6 +29,14 @@ Finally, a node can be stopped again with:
 
    vnode stop --name <your_node>
 
+.. note::
+
+   Before the node is started, it is attempted to obtain the server version.
+   For a server of version ``x.y.z``, a node of version ``x.y.<latest>`` is
+   started - this is the latest available node version for the server version.
+   If no server version can be obtained, the latest node of the same major
+   version as the command-line interface installation is started.
+
 Available commands
 ^^^^^^^^^^^^^^^^^^
 

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -200,7 +200,7 @@ class ClientBase(object):
 
     def request(self, endpoint: str, json: dict = None, method: str = 'get',
                 params: dict = None, first_try: bool = True,
-                retry: bool = True) -> dict:
+                retry: bool = True, attempts_on_timeout: int = None) -> dict:
         """Create http(s) request to the vantage6 server
 
         Parameters
@@ -217,6 +217,9 @@ class ClientBase(object):
             Whether this is the first attempt of this request. Default True.
         retry: bool, optional
             Try request again after refreshing the token. Default True.
+        attempts_on_timeout: int, optional
+            Number of attempts to make when a timeout occurs. Default None
+            which leads to unlimited amount of attempts.
 
         Returns
         -------
@@ -237,16 +240,22 @@ class ClientBase(object):
         url = self.generate_path_to(endpoint)
         self.log.debug(f'Making request: {method.upper()} | {url} | {params}')
 
-        try:
-            response = rest_method(url, json=json, headers=self.headers,
-                                   params=params)
-        except requests.exceptions.ConnectionError as e:
-            # we can safely retry as this is a connection error. And we
-            # keep trying!
-            self.log.error('Connection error... Retrying')
-            self.log.debug(e)
-            time.sleep(1)
-            return self.request(endpoint, json, method, params)
+        timeout_attempts = 0
+        while True:
+            try:
+                response = rest_method(url, json=json, headers=self.headers,
+                                       params=params)
+                break
+            except requests.exceptions.ConnectionError as e:
+                # we can safely retry as this is a connection error. And we
+                # keep trying (unless a max number of attempts is given)!
+                timeout_attempts += 1
+                if attempts_on_timeout is not None \
+                        and timeout_attempts > attempts_on_timeout:
+                    return {'msg': 'Connection error'}
+                self.log.error('Connection error... Retrying')
+                self.log.debug(e)
+                time.sleep(1)
 
         # TODO: should check for a non 2xx response
         if response.status_code > 210:
@@ -261,8 +270,10 @@ class ClientBase(object):
             if retry:
                 if first_try:
                     self.refresh_token()
-                    return self.request(endpoint, json, method, params,
-                                        first_try=False)
+                    return self.request(
+                        endpoint, json, method, params, first_try=False,
+                        attempts_on_timeout=attempts_on_timeout
+                    )
                 else:
                     self.log.error("Nope, refreshing the token didn't fix it.")
 
@@ -840,15 +851,23 @@ class UserClient(ClientBase):
     class Util(ClientBase.SubClient):
         """Collection of general utilities"""
 
-        def get_server_version(self) -> dict:
+        def get_server_version(self, attempts_on_timeout: int = None) -> dict:
             """View the version number of the vantage6-server
+
+            Parameters
+            ----------
+            attempts_on_timeout : int
+                Number of attempts to make when the server is not responding.
+                Default is unlimited.
 
             Returns
             -------
             dict
                 A dict containing the version number
             """
-            return self.parent.request('version')
+            return self.parent.request(
+                'version', attempts_on_timeout=attempts_on_timeout
+            )
 
         def get_server_health(self) -> dict:
             """View the health of the vantage6-server

--- a/vantage6-client/vantage6/client/_version.py
+++ b/vantage6-client/vantage6/client/_version.py
@@ -13,7 +13,7 @@ version_info = (3, 9, 0, 'candidate', __build__, 0)
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 version = f'{version_info[0]}.{version_info[1]}.{version_info[2]}'
 pre_release = '' if version_info[3] == 'final' else \
-  '.'+_specifier_[version_info[3]]+str(version_info[4])
+  _specifier_[version_info[3]]+str(version_info[4])
 post_release = '' if not version_info[5] else f'.post{version_info[5]}'
 
 # Module version accessible using thomas.__version__

--- a/vantage6-common/vantage6/common/_version.py
+++ b/vantage6-common/vantage6/common/_version.py
@@ -13,7 +13,7 @@ version_info = (3, 9, 0, 'candidate', __build__, 0)
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 version = f'{version_info[0]}.{version_info[1]}.{version_info[2]}'
 pre_release = '' if version_info[3] == 'final' else \
-  '.'+_specifier_[version_info[3]]+str(version_info[4])
+  _specifier_[version_info[3]]+str(version_info[4])
 post_release = '' if not version_info[5] else f'.post{version_info[5]}'
 
 # Module version accessible using thomas.__version__

--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -15,6 +15,8 @@ DEFAULT_DOCKER_REGISTRY = "harbor2.vantage6.ai"
 
 DEFAULT_NODE_IMAGE = f"infrastructure/node:{MAIN_VERSION_NAME}"
 
+DEFAULT_NODE_IMAGE_WO_TAG = "infrastructure/node"
+
 DEFAULT_SERVER_IMAGE = f"infrastructure/server:{MAIN_VERSION_NAME}"
 
 

--- a/vantage6-node/vantage6/node/_version.py
+++ b/vantage6-node/vantage6/node/_version.py
@@ -12,9 +12,9 @@ version_info = (3, 9, 0, 'candidate', __build__, 0)
 # Module version stage suffix map
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 version = f'{version_info[0]}.{version_info[1]}.{version_info[2]}'
-pre_release = f'' if version_info[3] == 'final' else \
-  '.'+_specifier_[version_info[3]]+str(version_info[4])
-post_release = f'' if not version_info[5] else f'.post{version_info[5]}'
+pre_release = '' if version_info[3] == 'final' else \
+  _specifier_[version_info[3]]+str(version_info[4])
+post_release = '' if not version_info[5] else f'.post{version_info[5]}'
 
 # Module version accessible using thomas.__version__
 __version__ = f'{version}{pre_release}{post_release}'

--- a/vantage6-server/vantage6/server/_version.py
+++ b/vantage6-server/vantage6/server/_version.py
@@ -13,7 +13,7 @@ version_info = (3, 9, 0, 'candidate', __build__, 0)
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 version = f'{version_info[0]}.{version_info[1]}.{version_info[2]}'
 pre_release = '' if version_info[3] == 'final' else \
-  '.'+_specifier_[version_info[3]]+str(version_info[4])
+  _specifier_[version_info[3]]+str(version_info[4])
 post_release = '' if not version_info[5] else f'.post{version_info[5]}'
 
 # Module version accessible using thomas.__version__

--- a/vantage6/tests_cli/test_node_cli.py
+++ b/vantage6/tests_cli/test_node_cli.py
@@ -392,7 +392,7 @@ class NodeCLITest(unittest.TestCase):
     @patch("vantage6.cli.node.info")
     @patch("vantage6.cli.node.debug")
     @patch("vantage6.cli.node.error")
-    @patch("vantage6.cli.node.Client")
+    @patch("vantage6.cli.node.UserClient")
     @patch("vantage6.cli.node.q")
     def test_client(self, q, client, error, debug, info):
 

--- a/vantage6/vantage6/cli/_version.py
+++ b/vantage6/vantage6/cli/_version.py
@@ -13,7 +13,7 @@ version_info = (3, 9, 0, 'candidate', __build__, 0)
 _specifier_ = {'alpha': 'a', 'beta': 'b', 'candidate': 'rc', 'final': ''}
 version = f'{version_info[0]}.{version_info[1]}.{version_info[2]}'
 pre_release = '' if version_info[3] == 'final' else \
-  '.'+_specifier_[version_info[3]]+str(version_info[4])
+  _specifier_[version_info[3]]+str(version_info[4])
 post_release = '' if not version_info[5] else f'.post{version_info[5]}'
 
 # Module version accessible using thomas.__version__

--- a/vantage6/vantage6/cli/node.py
+++ b/vantage6/vantage6/cli/node.py
@@ -357,7 +357,10 @@ def cli_node_start(name: str, config: str, environment: str,
         client = _create_client(ctx)
         major_minor = None
         try:
-            version = client.util.get_server_version()['version']
+            # try to get server version, skip if can't get a connection
+            version = client.util.get_server_version(
+                attempts_on_timeout=3
+            )['version']
             major_minor = '.'.join(version.split('.')[:2])
             image = (f"{DEFAULT_DOCKER_REGISTRY}/{DEFAULT_NODE_IMAGE_WO_TAG}"
                      f":{major_minor}")


### PR DESCRIPTION
Also, delete an extra dot in the version for pre-releases

Fix #700 

**Don't merge this yet, we may need to upgrade the policy (now using exact server version**