### PR TITLE
Results were not included with 'include=results' but with 'include=re…

### DIFF
--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -275,7 +275,7 @@ class Tasks(TaskBase):
         page = Pagination.from_query(q, request)
 
         # serialization schema
-        schema = task_result_schema if self.is_included('result') else\
+        schema = task_result_schema if self.is_included('results') else\
             task_schema
 
         return self.response(page, schema)


### PR DESCRIPTION
…sult'

This was in contrast to what was indicated in the docs, and it also didn't work via python client