### PR TITLE
Copying the mockClient (to pass it to child tasks) failed because mod…

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,16 @@
 Release notes
 =============
 
+3.10.2
+-----
+
+*20 June 2023*
+
+- **Bugfix**
+
+ - Fixed bug in copying the MockClient itself to pass it on to a child task (
+   `PR#723 <https://github.com/vantage6/vantage6/pull/723>`_).
+
 3.10.1
 -----
 

--- a/vantage6-client/vantage6/tools/mock_client.py
+++ b/vantage6-client/vantage6/tools/mock_client.py
@@ -204,7 +204,7 @@ class MockAlgorithmClient:
                     )
                 )
 
-        self.lib = import_module(module)
+        self.module_name = module
         self.tasks = []
 
         self.image = 'mock_image'
@@ -272,11 +272,13 @@ class MockAlgorithmClient:
             # TODO in v4+, there is no master and this should be removed
             master = input_.get("master")
 
+            module = import_module(self.parent.module_name)
+
             method_name = input_.get("method")
             if master:
-                method = getattr(self.parent.lib, method_name)
+                method = getattr(module, method_name)
             else:
-                method = getattr(self.parent.lib, f"RPC_{method_name}")
+                method = getattr(module, f"RPC_{method_name}")
 
             # get input
             args = input_.get("args", [])


### PR DESCRIPTION
…ule attribute could not be copied. Now not setting algorithm module as attribute

This change resolves the error below, which occurred because the MockClient had the `self.lib` attribute which is a module and could not be `copy.deepcopy`'d
```
Traceback (most recent call last):
    average_task = client.task.create(
  File "c:\users\bbe2101.54580\projects\vantage6\vantage6-master\vantage6-client\vantage6\tools\mock_client.py", line 294, in create
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\t3100rc1\lib\copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\t3100rc1\lib\copy.py", line 271, in _reconstruct
    state = deepcopy(state, memo)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\t3100rc1\lib\copy.py", line 146, in deepcopy
    y = copier(x, memo)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\t3100rc1\lib\copy.py", line 231, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\t3100rc1\lib\copy.py", line 161, in deepcopy
TypeError: cannot pickle 'module' object
```

