### PR TITLE
Use ubuntu 22 as base for VPN config file because otherwise configuri…

### DIFF
--- a/docker/vpn-configurator.Dockerfile
+++ b/docker/vpn-configurator.Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION=3
-FROM alpine:${ALPINE_VERSION}
+FROM ubuntu:22.04
 
-RUN apk add iproute2
+RUN apt update
+RUN apt install iproute2 iptables -y


### PR DESCRIPTION
…ng host iptables rules doesnt work on ubuntu

Fix #724 