### PR TITLE
Removed unused vserver-local commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
   vantage6-server:
     # build: .
-    image: harbor2.vantage6.ai/infrastructure/server:2.0.0a1
+    image: harbor2.vantage6.ai/infrastructure/server:latest
     dockerfile: server.Dockerfile
     ports:
       - "5000:5000"
@@ -12,7 +12,12 @@ services:
     volumes:
       # - ./configs/sqlite.yaml:/mnt/config.yaml
       - ./configs/postgress.yaml:/mnt/config.yaml
-    command: ["vserver-local start --config /mnt/config.yaml"]
+    command: [
+      "uwsgi --http :5000 --gevent 1000 --http-websockets
+        --master --callable app --disable-logging
+        --wsgi-file /vantage6/vantage6-server/vantage6/server/wsgi.py
+        --pyargv /mnt/config.yaml"
+    ]
 
   database:
     image: postgres:10

--- a/docs/devops/contribute.rst
+++ b/docs/devops/contribute.rst
@@ -213,20 +213,17 @@ code.
 Local test setup
 ^^^^^^^^^^^^^^^^
 To test your code changes, it may be useful to create a local test setup.
-There are several ways of doing this.
+This can be done by using the commands ``vserver`` and ``vnode`` in combination
+with the options ``--mount-src`` and optionally ``--image``.
 
-1. Use the command ``vserver-local`` and ``vnode-local``. This runs the
-   application in your current activated Python environment.
-2. Use the command ``vserver`` and ``vnode`` in combination with the options
-   ``--mount-src`` and optionally ``--image``.
-  * The ``--mount-src`` option will run your current code in the docker image.
-    The provided path should point towards the root folder of the `vantage6
-    repository <https://github.com/vantage6/vantage6>`_.
-  * The ``--image`` can be used to point towards a custom build infrastructure
-    image. Note that when your code update includes dependency upgrades you
-    need to build a custom infrastructure image as the 'old' image does not
-    contain these and the ``--mount-src`` option will only overwrite the
-    source and not re-install dependencies.
+* The ``--mount-src`` option will run your current code in the docker image.
+  The provided path should point towards the root folder of the `vantage6
+  repository <https://github.com/vantage6/vantage6>`_.
+* The ``--image`` can be used to point towards a custom build infrastructure
+  image. Note that when your code update includes dependency upgrades you
+  need to build a custom infrastructure image as the 'old' image does not
+  contain these and the ``--mount-src`` option will only overwrite the
+  source and not re-install dependencies.
 
 .. note::
 

--- a/docs/function-docs/server.rst
+++ b/docs/function-docs/server.rst
@@ -272,14 +272,5 @@ vantage6.server.exceptions
     :members:
 
 
-vantage6.server.cli
--------------------
-
-This section contains the documentation of the `vserver-local` CLI commands.
-
-.. click:: vantage6.server.cli.server:cli_server
-    :prog: vserver-local
-    :nested: full
-
 .. todo add files in vantage6.server.controller?
 .. todo add files in vantage6.server.configuration?

--- a/vantage6-server/vantage6/server/cli/server.py
+++ b/vantage6-server/vantage6/server/cli/server.py
@@ -1,5 +1,4 @@
 import click
-import questionary as q
 import IPython
 import yaml
 
@@ -9,16 +8,12 @@ from colorama import Fore, Style
 
 from vantage6.common import (
     info,
-    warning,
     error,
-    check_config_writeable
 )
 from vantage6.server.model.base import Database
-from vantage6.server import ServerApp, run_dev_server
 from vantage6.cli.globals import DEFAULT_SERVER_SYSTEM_FOLDERS as S_FOL
 from vantage6.server.controller import fixture
 from vantage6.cli.configuration_wizard import (
-    configuration_wizard,
     select_configuration_questionaire
 )
 from vantage6.cli.context import ServerContext
@@ -101,145 +96,8 @@ def click_insert_context(func: callable) -> callable:
 
 @click.group(name='server')
 def cli_server() -> None:
-    """Subcommand `vserver`."""
+    """Subcommand `vserver-local`."""
     pass
-
-
-#
-#   start
-#
-@cli_server.command(name='start')
-@click.option('--ip', default=None, help='ip address to listen on')
-@click.option('-p', '--port', type=int, help='port to listen on')
-@click.option('--debug', is_flag=True,
-              help='run server in debug mode (auto-restart)')
-@click_insert_context
-def cli_server_start(ctx: ServerContext, ip: str, port: str,
-                     debug: bool) -> None:
-    """
-    Start the server.
-
-    Parameters
-    ----------
-    ctx : ServerContext
-        The server context.
-    ip : str
-        The ip address to listen on.
-    port : str
-        The port to listen on.
-    debug : bool
-        Run server in debug mode (auto-restart).
-    """
-    info("Starting server.")
-
-    # Run the server
-    ip = ip or ctx.config['ip'] or '127.0.0.1'
-    port = port or int(ctx.config['port']) or 5000
-    info(f"ip: {ip}, port: {port}")
-    app = ServerApp(ctx).start()
-    run_dev_server(app, ip, port, debug=debug)
-
-
-#
-#   list
-#
-@cli_server.command(name='list')
-def cli_server_configuration_list() -> None:
-    """Print the available servers."""
-
-    click.echo("\nName"+(21*" ")+"System/User")
-    click.echo("-"*70)
-
-    sys_configs, f1 = ServerContext.available_configurations(
-        system_folders=True)
-    for config in sys_configs:
-        click.echo(
-            f"{config.name:25} System "
-        )
-
-    usr_configs, f2 = ServerContext.available_configurations(
-        system_folders=False
-    )
-    for config in usr_configs:
-        click.echo(
-            f"{config.name:25} User   "
-        )
-    click.echo("-"*70)
-
-    if len(f1)+len(f2):
-        warning(
-            f"{Fore.YELLOW}Number of failed imports: "
-            f"{len(f1)+len(f2)}{Style.RESET_ALL}"
-        )
-
-
-#
-#   files
-#
-@cli_server.command(name='files')
-@click_insert_context
-def cli_server_files(ctx: ServerContext) -> None:
-    """
-    List files locations of a server instance.
-
-    Parameters
-    ----------
-    ctx : ServerContext
-        The context of the server instance.
-    """
-    info(f"Configuration file = {ctx.config_file}")
-    info(f"Log file           = {ctx.log_file}")
-    info(f"Database           = {ctx.get_database_uri()}")
-
-
-#
-#   new
-#
-@cli_server.command(name='new')
-@click.option('-n', '--name', default=None,
-              help="name of the configutation you want to use.")
-@click.option('--system', 'system_folders', flag_value=True)
-@click.option('--user', 'system_folders', flag_value=False, default=S_FOL)
-def cli_server_new(name: str, system_folders: bool) -> None:
-    """
-    Create new server configuration.
-
-    Parameters
-    ----------
-    name : str
-        The name of the configuration.
-    system_folders : bool
-        Whether to use system folders or not.
-    """
-    if not name:
-        name = q.text("Please enter a configuration-name:").ask()
-        name_new = name.replace(" ", "-")
-        if name != name_new:
-            info(f"Replaced spaces from configuration name: {name}")
-            name = name_new
-
-    # Check that we can write in this folder
-    if not check_config_writeable(system_folders):
-        error("Your user does not have write access to all folders. Exiting")
-        exit(1)
-
-    # check that this config does not exist
-    try:
-        if ServerContext.config_exists(name, system_folders):
-            error(
-                f"Configuration {Fore.RED}{name}{Style.RESET_ALL} already "
-                "exists!"
-            )
-            exit(1)
-    except Exception as e:
-        print(e)
-        exit(1)
-
-    # create config in ctx location
-    cfg_file = configuration_wizard("server", name, system_folders)
-    info(f"New configuration created: {Fore.GREEN}{cfg_file}{Style.RESET_ALL}")
-    info(f"You can start the server with {Fore.GREEN}vserver start"
-         f"{Style.RESET_ALL}.")
 
 
 #


### PR DESCRIPTION
Removed `vserver-local` commands `start`, `files`, `new` and `list` which were not used

Left the commands `import`, `version` and `shell`, which are still useful commands that are being run from the regular CLI in a Docker container.

Fix #663 