### PR TITLE
Fix bug where a ServerConfiguration object instead of a dict was save…

### DIFF
--- a/vantage6-common/vantage6/common/configuration_manager.py
+++ b/vantage6-common/vantage6/common/configuration_manager.py
@@ -111,7 +111,7 @@ class ConfigurationManager(object):
         """
         configuration = self.conf_class(config)
         if configuration.is_valid:
-            self.config = configuration
+            self.config = config
 
     def get(self) -> Configuration:
         """


### PR DESCRIPTION
There was the following issue with new config files:

![image](https://github.com/vantage6/vantage6/assets/10533678/a45bf69c-f121-4903-9606-0c2dcef9e7a5)

This was because the data saved to the yaml was not a dict but a Configuration Python object.
Probably this went wrong in deleting the environments.