### PR TITLE
Removed no-longer-existing include_metadata option from python client…

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -408,8 +408,7 @@ class UserClient(ClientBase):
         def list(self, scope: str = 'organization',
                  name: str = None, encrypted: bool = None,
                  organization: int = None, page: int = 1,
-                 per_page: int = 20, include_metadata: bool = True,
-                 ) -> dict:
+                 per_page: int = 20) -> dict:
             """View your collaborations
 
             Parameters
@@ -429,10 +428,6 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
@@ -445,11 +440,9 @@ class UserClient(ClientBase):
               `organization` as pagination is missing at endpoint
               /organization/<id>/collaboration
             """
-            includes = ['metadata'] if include_metadata else []
             params = {
-                'page': page, 'per_page': per_page, 'include': includes,
-                'name': name, 'encrypted': encrypted,
-                'organization_id': organization,
+                'page': page, 'per_page': per_page, 'name': name,
+                'encrypted': encrypted, 'organization_id': organization,
             }
             if scope == 'organization':
                 self.parent.log.info('pagination for scope `organization` '
@@ -531,7 +524,6 @@ class UserClient(ClientBase):
                  collaboration: int = None, is_online: bool = None,
                  ip: str = None, last_seen_from: str = None,
                  last_seen_till: str = None, page: int = 1, per_page: int = 20,
-                 include_metadata: bool = True,
                  ) -> list[dict]:
             """List nodes
 
@@ -555,10 +547,6 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
@@ -566,9 +554,8 @@ class UserClient(ClientBase):
             list of dicts
                 Containing meta-data of the nodes
             """
-            includes = ['metadata'] if include_metadata else []
             params = {
-                'page': page, 'per_page': per_page, 'include': includes,
+                'page': page, 'per_page': per_page,
                 'name': name, 'organization_id': organization,
                 'collaboration_id': collaboration, 'ip': ip,
                 'last_seen_from': last_seen_from,
@@ -677,7 +664,6 @@ class UserClient(ClientBase):
         def list(
             self, name: str = None, country: int = None,
             collaboration: int = None, page: int = None, per_page: int = None,
-            include_metadata: bool = True
         ) -> list[dict]:
             """List organizations
 
@@ -693,21 +679,15 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
             list[dict]
                 Containing meta-data information of the organizations
             """
-            includes = ['metadata'] if include_metadata else []
             params = {
-                'page': page, 'per_page': per_page, 'include': includes,
-                'name': name, 'country': country,
-                'collaboration_id': collaboration
+                'page': page, 'per_page': per_page, 'name': name,
+                'country': country, 'collaboration_id': collaboration
             }
             return self.parent.request('organization', params=params)
 
@@ -832,8 +812,7 @@ class UserClient(ClientBase):
                  firstname: str = None, lastname: str = None,
                  email: str = None, role: int = None, rule: int = None,
                  last_seen_from: str = None, last_seen_till: str = None,
-                 page: int = 1, per_page: int = 20,
-                 include_metadata: bool = True) -> list:
+                 page: int = 1, per_page: int = 20) -> list:
             """List users
 
             Parameters
@@ -860,19 +839,14 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
             list of dicts
                 Containing the meta-data of the users
             """
-            includes = ['metadata'] if include_metadata else []
             params = {
-                'page': page, 'per_page': per_page, 'include': includes,
+                'page': page, 'per_page': per_page,
                 'username': username, 'organization_id': organization,
                 'firstname': firstname, 'lastname': lastname, 'email': email,
                 'role_id': role, 'rule_id': rule,
@@ -1004,7 +978,7 @@ class UserClient(ClientBase):
         def list(self, name: str = None, description: str = None,
                  organization: int = None, rule: int = None, user: int = None,
                  include_root: bool = None, page: int = 1, per_page: int = 20,
-                 include_metadata: bool = True) -> list[dict]:
+                 ) -> list[dict]:
             """List of roles
 
             Parameters
@@ -1026,19 +1000,14 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
             list[dict]
                 Containing roles meta-data
             """
-            includes = ['metadata'] if include_metadata else []
             params = {
-                'page': page, 'per_page': per_page, 'include': includes,
+                'page': page, 'per_page': per_page,
                 'name': name, 'description': description,
                 'organization_id': organization, 'rule_id': rule,
                 'include_root': include_root, 'user_id': user,
@@ -1168,7 +1137,7 @@ class UserClient(ClientBase):
             job: int = None, name: str = None, include_results: bool = False,
             description: str = None, database: str = None, run: int = None,
             status: str = None, user_created: bool = None, page: int = 1,
-            per_page: int = 20, include_metadata: bool = True
+            per_page: int = 20
         ) -> dict:
             """List tasks
 
@@ -1209,10 +1178,6 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
@@ -1220,13 +1185,6 @@ class UserClient(ClientBase):
                 dictonairy containing the key 'data' which contains the
                 tasks and a key 'links' containing the pagination
                 metadata
-
-            OR
-
-            list
-                when 'include_metadata' is set to false, it removes the
-                metadata wrapper. I.e. directly returning the 'data'
-                key.
             """
             # if the param is None, it will not be passed on to the
             # request
@@ -1241,8 +1199,6 @@ class UserClient(ClientBase):
             includes = []
             if include_results:
                 includes.append('results')
-            if include_metadata:
-                includes.append('metadata')
             params['include'] = includes
             if user_created is not None:
                 params['is_user_created'] = 1 if user_created else 0
@@ -1389,7 +1345,7 @@ class UserClient(ClientBase):
                  assigned: tuple[str, str] = None,
                  finished: tuple[str, str] = None, port: int = None,
                  page: int = None, per_page: int = None,
-                 include_metadata: bool = True) -> dict | list[dict]:
+                 ) -> dict | list[dict]:
             """List runs
 
             Parameters
@@ -1416,23 +1372,14 @@ class UserClient(ClientBase):
                 Pagination page number, defaults to 1
             per_page: int, optional
                 Number of items per page, defaults to 20
-            include_metedata: bool, optional
-                Whenevet to include pagination metadata, defaults to
-                True
 
             Returns
             -------
             dict | list[dict]
-                If include_metadata is True, a dictionary is returned
-                containing the key 'data' which contains a list of
-                runs, and a key 'links' which contains the pagination
-                metadata.
-                When include_metadata is False, the metadata wrapper
-                is stripped and only a list of runs is returned
+                A dictionary containing the key 'data' which contains a list of
+                runs, and a key 'links' which contains the pagination metadata.
             """
             includes = []
-            if include_metadata:
-                includes.append('metadata')
             if include_task:
                 includes.append('task')
 
@@ -1590,7 +1537,7 @@ class UserClient(ClientBase):
         @post_filtering()
         def list(self, name: str = None, operation: str = None,
                  scope: str = None, role: int = None, page: int = 1,
-                 per_page: int = 20, include_metadata: bool = True) -> list:
+                 per_page: int = 20) -> list:
             """List of all available rules
 
             Parameters
@@ -1607,20 +1554,14 @@ class UserClient(ClientBase):
                 Pagination page, by default 1
             per_page: int, optional
                 Number of items on a single page, by default 20
-            include_metadata: bool, optional
-                Whenever to include the pagination metadata. If this is
-                set to False the output is no longer wrapped in a
-                dictonairy, by default True
 
             Returns
             -------
             list of dicts
                 Containing all the rules from the vantage6 server
             """
-            includes = ['metadata'] if include_metadata else []
             params = {
-                'page': page, 'per_page': per_page, 'include': includes,
-                'name': name, 'operation': operation, 'scope': scope,
-                'role_id': role
+                'page': page, 'per_page': per_page, 'name': name,
+                'operation': operation, 'scope': scope, 'role_id': role
             }
             return self.parent.request('rule', params=params)

--- a/vantage6-client/vantage6/client/filter.py
+++ b/vantage6-client/vantage6/client/filter.py
@@ -134,10 +134,10 @@ def filter_keys_from_results(func: callable) -> callable:
         list[dict]
             The filtered list of dicts.
         """
-        dicts = func(*args, **kwargs)
+        dict_ = func(*args, **kwargs)
         if field:
-            return filter_dicts_keys(dicts, [field])
-        return filter_dicts_keys(dicts, fields)
+            return filter_dicts_keys(dict_, [field])
+        return filter_dicts_keys(dict_, fields)
     return wrapper_filter
 
 
@@ -231,7 +231,7 @@ def filter_dicts_by_values(
     return dicts
 
 
-def filter_dicts_keys(dicts: list[dict], keys: list[str]) -> list[dict]:
+def filter_dicts_keys(dict_: dict, keys: list[str]) -> list[dict]:
     """
     Filter a list of dicts on the specified keys. If no keys are given, the
     original list of dicts is returned.
@@ -239,7 +239,8 @@ def filter_dicts_keys(dicts: list[dict], keys: list[str]) -> list[dict]:
     Parameters
     ----------
     dicts : list[dict]
-        The list of dicts to filter.
+        The dict to filter. This is a dict with a 'data' key that contains the
+        list of data dictionaries that will be filtered.
     keys : list[str]
         A list of keys to keep in the dictionaries
 
@@ -248,9 +249,11 @@ def filter_dicts_keys(dicts: list[dict], keys: list[str]) -> list[dict]:
     list[dict]
         The filtered list of dicts.
     """
+    # note: we look only in the 'data' key of the dict, which contains the list
+    # of data. The only other key is 'links' which contains pagination links
     if keys:
-        return [filter_dict_keys(adict, keys) for adict in dicts]
-    return dicts
+        return [filter_dict_keys(adict, keys) for adict in dict_['data']]
+    return dict_
 
 
 def filter_dict_keys(dict_: dict, keys: list[str]) -> dict:

--- a/vantage6-server/vantage6/server/resource/run.py
+++ b/vantage6-server/vantage6/server/resource/run.py
@@ -289,9 +289,7 @@ class Runs(MultiRunBase):
               name: include
               schema:
                 type: string (can be multiple)
-              description: Include 'task' to include task data. Include
-                'metadata' to get pagination metadata. Note that this will put
-                the actual data in an envelope.
+              description: Include 'task' to include task data.
             - in: query
               name: page
               schema:


### PR DESCRIPTION
Fix #773  - and apart from fixing `client.x.list(fields=[...])`, I also removed all the `include_metadata` arguments that were still in the Python client but were already removed for the server in v4