### PR TITLE
Updated check when user A tries to change permissions of user B.

### DIFF
--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -1487,7 +1487,7 @@ class TestResources(unittest.TestCase):
                     organization=org)
         role.save()
         result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
-            'rules': [role.id]
+            'roles': [role.id]
         })
         self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
 

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -1068,8 +1068,14 @@ class TestResources(unittest.TestCase):
                                headers=headers)
         self.assertEqual(result.status_code, HTTPStatus.CREATED)
 
-        # however you can only assign rules that you own
+        # you can only rules that are lower in hierarchy than the ones you own
         rule = Rule.get_by_("role", Scope.ORGANIZATION, Operation.EDIT)
+        result = self.app.post(f'/api/role/{role.id}/rule/{rule.id}',
+                               headers=headers)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+
+        # you can't assign rules you don't own
+        rule = Rule.get_by_("node", Scope.ORGANIZATION, Operation.EDIT)
         result = self.app.post(f'/api/role/{role.id}/rule/{rule.id}',
                                headers=headers)
         self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
@@ -1485,8 +1491,22 @@ class TestResources(unittest.TestCase):
         })
         self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
 
-        # test that you cannot assign rules if you don't have all the rules
-        # that the other user has
+        # test that you CAN assign rules if you have higher permissions than
+        # the user you are assigning rules to. In this case, the user being
+        # changed only has permission to edit their own user, while the actor
+        # has global permission for that
+        headers = self.create_user_and_login(rules=[rule, not_owning_rule])
+        result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
+            'rules': [not_owning_rule.id, rule.id]
+        })
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+
+        # test that you cannot assign rules to users if they have permissions
+        # that you don't have yourself
+        second_not_owning_rule = Rule.get_by_("node", Scope.ORGANIZATION,
+                                              Operation.EDIT)
+        user.rules.append(second_not_owning_rule)
+        user.save()
         headers = self.create_user_and_login(rules=[rule, not_owning_rule])
         result = self.app.patch(f'/api/user/{user.id}', headers=headers, json={
             'rules': [not_owning_rule.id, rule.id]

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -1072,7 +1072,7 @@ class TestResources(unittest.TestCase):
         rule = Rule.get_by_("role", Scope.ORGANIZATION, Operation.EDIT)
         result = self.app.post(f'/api/role/{role.id}/rule/{rule.id}',
                                headers=headers)
-        self.assertEqual(result.status_code, HTTPStatus.OK)
+        self.assertEqual(result.status_code, HTTPStatus.CREATED)
 
         # you can't assign rules you don't own
         rule = Rule.get_by_("node", Scope.ORGANIZATION, Operation.EDIT)

--- a/vantage6-server/vantage6/server/permission.py
+++ b/vantage6-server/vantage6/server/permission.py
@@ -37,6 +37,11 @@ def print_operation(operation: Operation) -> str:
     -------
     str
         String representation of the operation
+
+    Raises
+    ------
+    ValueError
+        If the operation is not known
     """
     if operation.VIEW:
         return "view"
@@ -48,8 +53,10 @@ def print_operation(operation: Operation) -> str:
         return "delete"
     elif operation.SEND:
         return "send"
-    else:
+    elif operation.RECEIVE:
         return "receive"
+    else:
+        raise ValueError(f"Unknown operation {operation}")
 
 
 def print_scope(scope: Scope) -> str:
@@ -65,6 +72,11 @@ def print_scope(scope: Scope) -> str:
     -------
     str
         String representation of the scope
+
+    Raises
+    ------
+    ValueError
+        If the scope is not known
     """
     if scope.ORGANIZATION:
         return "organization"
@@ -72,8 +84,10 @@ def print_scope(scope: Scope) -> str:
         return "collaboration"
     elif scope.GLOBAL:
         return "global"
-    else:
+    elif scope.OWN:
         return "own"
+    else:
+        raise ValueError(f"Unknown scope {scope}")
 
 
 class RuleCollection(dict):

--- a/vantage6-server/vantage6/server/permission.py
+++ b/vantage6-server/vantage6/server/permission.py
@@ -21,6 +21,61 @@ log = logging.getLogger(module_name)
 RuleNeed = namedtuple("RuleNeed", ["name", "scope", "operation"])
 
 
+# TODO BvB 2023-07-27 this utility is a bit superfluous with the definition
+# of the operation and scope enums. We should remove it but then add longer
+# values to the enums, which leads to many other changes
+def print_operation(operation: Operation) -> str:
+    """
+    String representation of the operation, that is readable by humans.
+
+    Parameters
+    ----------
+    operation : Operation
+        Operation to be printed
+
+    Returns
+    -------
+    str
+        String representation of the operation
+    """
+    if operation.VIEW:
+        return "view"
+    elif operation.EDIT:
+        return "edit"
+    elif operation.CREATE:
+        return "create"
+    elif operation.DELETE:
+        return "delete"
+    elif operation.SEND:
+        return "send"
+    else:
+        return "receive"
+
+
+def print_scope(scope: Scope) -> str:
+    """
+    String representation of the scope, that is readable by humans.
+
+    Parameters
+    ----------
+    scope : Scope
+        Scope to be printed
+
+    Returns
+    -------
+    str
+        String representation of the scope
+    """
+    if scope.ORGANIZATION:
+        return "organization"
+    elif scope.COLLABORATION:
+        return "collaboration"
+    elif scope.GLOBAL:
+        return "global"
+    else:
+        return "own"
+
+
 class RuleCollection(dict):
     """
     Class that tracks a set of all rules for a certain resource name
@@ -225,7 +280,7 @@ class PermissionManager:
     """
 
     def __init__(self) -> None:
-        self.collections = {}
+        self.collections: dict[str, RuleCollection] = {}
         log.info("Loading permission system...")
         self.load_rules_from_resources()
 
@@ -467,8 +522,7 @@ class PermissionManager:
         session.commit()
         return result
 
-    @staticmethod
-    def check_user_rules(rules: list[Rule]) -> dict | bool:
+    def check_user_rules(self, rules: list[Rule]) -> dict | None:
         """
         Check if a user, node or container has all the `rules` in a list
 
@@ -479,14 +533,14 @@ class PermissionManager:
 
         Returns
         -------
-        dict | bool
+        dict | None
             Dict with a message which rule is missing, else None
         """
         for rule in rules:
-            requires = RuleNeed(rule.name, rule.scope, rule.operation)
-            try:
-                Permission(requires).test()
-            except PermissionDenied:
+            if not self.collections[rule.name].has_at_least_scope(
+                rule.scope, rule.operation
+            ):
                 return {"msg": f"You don't have the rule ({rule.name}, "
-                        f"{rule.scope}, {rule.operation})"}
+                        f"{print_scope(rule.scope)}, "
+                        f"{print_operation(rule.operation)})"}
         return None


### PR DESCRIPTION
Previously, user A would have to have the exact same permissions as user B. Now, if user A has permission to create users with scope collaboration, they will also be able to assign that permission with lower scope (i.e. organization) to user B.

Fix #443 