### PR TITLE
Give default roles with low permissions the extra permission to view …

### DIFF
--- a/vantage6-server/vantage6/server/default_roles.py
+++ b/vantage6-server/vantage6/server/default_roles.py
@@ -58,6 +58,7 @@ def get_default_roles(db) -> list[dict]:
         db.Rule.get_by_('collaboration', Scope.ORGANIZATION, Operation.VIEW),
         db.Rule.get_by_('role', Scope.ORGANIZATION, Operation.VIEW),
         db.Rule.get_by_('node', Scope.ORGANIZATION, Operation.VIEW),
+        db.Rule.get_by_('node', Scope.COLLABORATION, Operation.VIEW),
         db.Rule.get_by_('task', Scope.COLLABORATION, Operation.VIEW),
         db.Rule.get_by_('run', Scope.COLLABORATION, Operation.VIEW),
         db.Rule.get_by_('port', Scope.ORGANIZATION, Operation.VIEW),


### PR DESCRIPTION
…all nodes from their collaboration.

Now that they don't have these permissions, they cannot know if the nodes in their collaboration are online when creating a task or so