### PR TITLE
Change/rabbitmq hostname check improved

### DIFF
--- a/docs/server/optional.rst
+++ b/docs/server/optional.rst
@@ -302,7 +302,7 @@ by adding the following to the server configuration:
 
 ::
 
-   rabbitmq_uri: amqp://<username>:<password@<hostname>:5672/<vhost>
+   rabbitmq_uri: amqp://<username>:<password>@<hostname>:5672/<vhost>
 
 Be sure to create the user and vhost that you specify exist! Otherwise,
 you can add them via the `RabbitMQ management

--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -107,23 +107,33 @@ email_token_validity_minutes: 60
 token_expires_hours: 6
 refresh_token_expires_hours: 48
 
+# If you have a server with a high workload, it is recommended to use
+# multiple server instances (horizontal scaling). If you do so, you also
+# need to set up a RabbitMQ message service to ensure that the communication
+# between the server and the nodes is handled properly. Then, fill out the
+# RabbitMQ connection URI below to connect the server to it. Also, set the
+# start_with_server flag to true to start RabbitMQ when you start the server.
+rabbitmq:
+  uri: amqp://myuser:mypassword@myhostname:5672/myvhost
+  start_with_server: false
+
 # If algorithm containers need direct communication between each other
 # the server also requires a VPN server. (!) This must be a EduVPN
 # instance as vantage6 makes use of their API (!)
 # OPTIONAL
 vpn_server:
-    # the URL of your VPN server
-    url: https://your-vpn-server.ext
+  # the URL of your VPN server
+  url: https://your-vpn-server.ext
 
-    # OATH2 settings, make sure these are the same as in the
-    # configuration file of your EduVPN instance
-    redirect_url: http://localhost
-    client_id: your_VPN_client_user_name
-    client_secret: your_VPN_client_user_password
+  # OATH2 settings, make sure these are the same as in the
+  # configuration file of your EduVPN instance
+  redirect_url: http://localhost
+  client_id: your_VPN_client_user_name
+  client_secret: your_VPN_client_user_password
 
-    # Username and password to acccess the EduVPN portal
-    portal_username: your_eduvpn_portal_user_name
-    portal_userpass: your_eduvpn_portal_user_password
+  # Username and password to acccess the EduVPN portal
+  portal_username: your_eduvpn_portal_user_name
+  portal_userpass: your_eduvpn_portal_user_password
 
 # specify custom Docker images to use for starting the different
 # components.

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -141,8 +141,7 @@ class ServerApp:
             SocketIO object
         """
 
-        msg_queue = self.ctx.config.get('rabbitmq').get('uri') \
-            if self.ctx.config.get('rabbitmq') else None
+        msg_queue = self.ctx.config.get('rabbitmq', {}).get('uri')
         if msg_queue:
             log.debug(f'Connecting to msg queue: {msg_queue}')
 

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -141,7 +141,8 @@ class ServerApp:
             SocketIO object
         """
 
-        msg_queue = self.ctx.config.get('rabbitmq_uri')
+        msg_queue = self.ctx.config.get('rabbitmq').get('uri') \
+            if self.ctx.config.get('rabbitmq') else None
         if msg_queue:
             log.debug(f'Connecting to msg queue: {msg_queue}')
 

--- a/vantage6/tests_cli/test_wizard.py
+++ b/vantage6/tests_cli/test_wizard.py
@@ -60,7 +60,7 @@ class WizardTest(unittest.TestCase):
 
             keys = ["description", "ip", "port", "api_path", "uri",
                     "allow_drop_all", "jwt_secret_key", "logging",
-                    "vpn_server", "rabbitmq_uri", "two_factor_auth"]
+                    "vpn_server", "rabbitmq", "two_factor_auth"]
 
             for key in keys:
                 self.assertIn(key, config)

--- a/vantage6/tests_cli/test_wizard.py
+++ b/vantage6/tests_cli/test_wizard.py
@@ -54,7 +54,9 @@ class WizardTest(unittest.TestCase):
 
         with patch(f"{module_path}.q") as q:
             q.prompt.side_effect = self.prompts
-            q.confirm.return_value.ask.side_effect = [True, True, True, True]
+            q.confirm.return_value.ask.side_effect = [
+                True, True, True, True, True
+            ]
 
             config = server_configuration_questionaire("vantage6")
 

--- a/vantage6/vantage6/cli/configuration_wizard.py
+++ b/vantage6/vantage6/cli/configuration_wizard.py
@@ -261,7 +261,13 @@ def server_configuration_questionaire(instance_name: str) -> dict:
         rabbit_uri = q.text(
             message='Enter the URI for your RabbitMQ:'
         ).ask()
-        config['rabbitmq_uri'] = rabbit_uri
+        run_rabbit_locally = q.confirm(
+            "Do you want to run RabbitMQ locally? (Use only for testing)"
+        ).ask()
+        config['rabbitmq'] = {
+            'uri': rabbit_uri,
+            'start_with_server': run_rabbit_locally
+        }
 
     config["logging"] = {
         "level": res,

--- a/vantage6/vantage6/cli/rabbitmq/__init__.py
+++ b/vantage6/vantage6/cli/rabbitmq/__init__.py
@@ -1,7 +1,5 @@
 """RabbitMQ utilities."""
 
-from vantage6.common import is_ip_address
-
 
 def split_rabbitmq_uri(rabbit_uri: str) -> dict:
     """
@@ -28,21 +26,3 @@ def split_rabbitmq_uri(rabbit_uri: str) -> dict:
         'port': port,
         'vhost': vhost,
     }
-
-
-def is_local_address(rabbit_uri: str) -> bool:
-    """
-    Test if the host of a RabbitMQ uri is an external IP address or not
-
-    Parameters
-    ----------
-    rabbit_uri: str
-        The connection URI to the RabbitMQ service from the configuration
-
-    Returns
-    -------
-    bool:
-        Whether or not the rabbit_uri points to a service to be set up locally
-    """
-    uri_info = split_rabbitmq_uri(rabbit_uri=rabbit_uri)
-    return not is_ip_address(uri_info['host'])

--- a/vantage6/vantage6/cli/rabbitmq/queue_manager.py
+++ b/vantage6/vantage6/cli/rabbitmq/queue_manager.py
@@ -39,7 +39,7 @@ class RabbitMQManager:
     def __init__(self, ctx: ServerContext, network_mgr: NetworkManager,
                  image: str = None) -> None:
         self.ctx = ctx
-        self.queue_uri = self.ctx.config.get('rabbitmq_uri')
+        self.queue_uri = self.ctx.config.get('rabbitmq').get('uri')
         rabbit_splitted = split_rabbitmq_uri(self.queue_uri)
         self.rabbit_user = rabbit_splitted['user']
         self.rabbit_pass = rabbit_splitted['password']
@@ -89,7 +89,7 @@ class RabbitMQManager:
             ports=ports,
             detach=True,
             restart_policy={"Name": "always"},
-            hostname=f'{APPNAME}-{self.ctx.name}-rabbitmq',
+            hostname=self.host,
             labels={
                 f"{APPNAME}-type": "rabbitmq",
             },

--- a/vantage6/vantage6/cli/rabbitmq/queue_manager.py
+++ b/vantage6/vantage6/cli/rabbitmq/queue_manager.py
@@ -39,7 +39,7 @@ class RabbitMQManager:
     def __init__(self, ctx: ServerContext, network_mgr: NetworkManager,
                  image: str = None) -> None:
         self.ctx = ctx
-        self.queue_uri = self.ctx.config.get('rabbitmq').get('uri')
+        self.queue_uri = self.ctx.config['rabbitmq'].get('uri')
         rabbit_splitted = split_rabbitmq_uri(self.queue_uri)
         self.rabbit_user = rabbit_splitted['user']
         self.rabbit_pass = rabbit_splitted['password']

--- a/vantage6/vantage6/cli/server.py
+++ b/vantage6/vantage6/cli/server.py
@@ -44,7 +44,7 @@ from vantage6.cli.utils import (
     remove_file
 )
 from vantage6.cli.rabbitmq.queue_manager import RabbitMQManager
-from vantage6.cli import __version__, rabbitmq
+from vantage6.cli import __version__
 
 
 def click_insert_context(func: callable) -> callable:

--- a/vantage6/vantage6/cli/server.py
+++ b/vantage6/vantage6/cli/server.py
@@ -172,7 +172,8 @@ def vserver_start(ctx: ServerContext, ip: str, port: int, image: str,
     ui_port : int
         Port to listen on for the User Interface
     start_rabbitmq : bool
-        Start RabbitMQ message broker as local container - use in development
+        Start RabbitMQ message broker as local container - use only in
+        development
     rabbitmq_image : str
         RabbitMQ docker image to use
     keep : bool
@@ -831,7 +832,7 @@ def _start_rabbitmq(ctx: ServerContext, rabbitmq_image: str,
     network_mgr : NetworkManager
         Network manager object
     """
-    rabbit_uri = ctx.config.get('rabbitmq').get('uri')
+    rabbit_uri = ctx.config['rabbitmq'].get('uri')
     if not rabbit_uri:
         error("No RabbitMQ URI found in the configuration file! Please add"
               "a 'uri' key to the 'rabbitmq' section of the configuration.")
@@ -878,8 +879,7 @@ def _stop_server_containers(client: DockerClient, container_name: str,
 
     # kill RabbitMQ if it exists and no other servers are using to it (i.e. it
     # is not in other docker networks with other containers)
-    rabbit_uri = ctx.config.get('rabbitmq').get('uri') \
-        if ctx.config.get('rabbitmq') else None
+    rabbit_uri = ctx.config.get('rabbitmq', {}).get('uri')
     if rabbit_uri:
         rabbit_container_name = split_rabbitmq_uri(
             rabbit_uri=rabbit_uri)['host']

--- a/vantage6/vantage6/cli/server.py
+++ b/vantage6/vantage6/cli/server.py
@@ -126,6 +126,9 @@ def cli_server() -> None:
               help="Start the graphical User Interface as well")
 @click.option('--ui-port', default=None, type=int,
               help="Port to listen on for the User Interface")
+@click.option('--with-rabbitmq', 'start_rabbitmq', flag_value=True,
+              default=False, help="Start RabbitMQ message broker as local "
+              "container - use in development only")
 @click.option('--rabbitmq-image', default=None,
               help="RabbitMQ docker image to use")
 @click.option('--keep/--auto-remove', default=False,
@@ -137,18 +140,20 @@ def cli_server() -> None:
               help="Print server logs to the console after start")
 @click_insert_context
 def cli_server_start(ctx: ServerContext, ip: str, port: int, image: str,
-                     start_ui: bool, ui_port: int, rabbitmq_image: str,
-                     keep: bool, mount_src: str, attach: bool) -> None:
+                     start_ui: bool, ui_port: int, start_rabbitmq: bool,
+                     rabbitmq_image: str, keep: bool, mount_src: str,
+                     attach: bool) -> None:
     """
     Start the server.
     """
-    vserver_start(ctx, ip, port, image, start_ui, ui_port, rabbitmq_image,
-                  keep, mount_src, attach)
+    vserver_start(ctx, ip, port, image, start_ui, ui_port, start_rabbitmq,
+                  rabbitmq_image, keep, mount_src, attach)
 
 
 def vserver_start(ctx: ServerContext, ip: str, port: int, image: str,
-                  start_ui: bool, ui_port: int, rabbitmq_image: str,
-                  keep: bool, mount_src: str, attach: bool) -> None:
+                  start_ui: bool, ui_port: int, start_rabbitmq: bool,
+                  rabbitmq_image: str, keep: bool, mount_src: str,
+                  attach: bool) -> None:
     """
     Start the server in a Docker container.
 
@@ -162,6 +167,12 @@ def vserver_start(ctx: ServerContext, ip: str, port: int, image: str,
         port to listen on
     image : str
         Server Docker image to use
+    start_ui : bool
+        Start the graphical User Interface as well
+    ui_port : int
+        Port to listen on for the User Interface
+    start_rabbitmq : bool
+        Start RabbitMQ message broker as local container - use in development
     rabbitmq_image : str
         RabbitMQ docker image to use
     keep : bool
@@ -273,10 +284,18 @@ def vserver_start(ctx: ServerContext, ip: str, port: int, image: str,
     )
     server_network_mgr.create_network(is_internal=False)
 
-    # Note that ctx.data_dir has been created at this point, which is required
-    # for putting some RabbitMQ configuration files inside
-    info('Starting RabbitMQ container')
-    _start_rabbitmq(ctx, rabbitmq_image, server_network_mgr)
+    if start_rabbitmq or ctx.config.get('rabbitmq') and \
+            ctx.config['rabbitmq'].get('start_with_server', False):
+        # Note that ctx.data_dir has been created at this point, which is
+        # required for putting some RabbitMQ configuration files inside
+        info('Starting RabbitMQ container')
+        _start_rabbitmq(ctx, rabbitmq_image, server_network_mgr)
+    elif ctx.config.get('rabbitmq'):
+        info("RabbitMQ is provided in the config file as external service. "
+             "Assuming this service is up and running.")
+    else:
+        warning('Message queue disabled! This means that the vantage6 server '
+                'cannot be scaled horizontally!')
 
     # start the UI if requested
     if start_ui or ctx.config.get('ui') and ctx.config['ui'].get('enabled'):
@@ -812,18 +831,15 @@ def _start_rabbitmq(ctx: ServerContext, rabbitmq_image: str,
     network_mgr : NetworkManager
         Network manager object
     """
-    rabbit_uri = ctx.config.get('rabbitmq_uri')
+    rabbit_uri = ctx.config.get('rabbitmq').get('uri')
     if not rabbit_uri:
-        warning('Message queue disabled! This means that the server '
-                'application cannot scale horizontally!')
-    elif rabbitmq.is_local_address(rabbit_uri):
-        # kick off RabbitMQ container
-        rabbit_mgr = RabbitMQManager(
-            ctx=ctx, network_mgr=network_mgr, image=rabbitmq_image)
-        rabbit_mgr.start()
-    else:
-        info("Detected that the RabbitMQ service is a external service. "
-             "Assuming this service is up and running.")
+        error("No RabbitMQ URI found in the configuration file! Please add"
+              "a 'uri' key to the 'rabbitmq' section of the configuration.")
+        exit(1)
+    # kick off RabbitMQ container
+    rabbit_mgr = RabbitMQManager(
+        ctx=ctx, network_mgr=network_mgr, image=rabbitmq_image)
+    rabbit_mgr.start()
 
 
 def _stop_server_containers(client: DockerClient, container_name: str,
@@ -862,7 +878,8 @@ def _stop_server_containers(client: DockerClient, container_name: str,
 
     # kill RabbitMQ if it exists and no other servers are using to it (i.e. it
     # is not in other docker networks with other containers)
-    rabbit_uri = ctx.config.get('rabbitmq_uri')
+    rabbit_uri = ctx.config.get('rabbitmq').get('uri') \
+        if ctx.config.get('rabbitmq') else None
     if rabbit_uri:
         rabbit_container_name = split_rabbitmq_uri(
             rabbit_uri=rabbit_uri)['host']


### PR DESCRIPTION
Fix #282 

- Changed configuration structure RabbitMQ so that users can indicate to run it locally
- no longer requiring specific hostname for running locally but any valid docker container name will do
- updated the docs
- updated `vserver new`