### PR TITLE
Include the jinja2 templates for the vdev commands in the CLI packages.

### DIFF
--- a/vantage6/setup.py
+++ b/vantage6/setup.py
@@ -55,6 +55,9 @@ setup(
         'vantage6.cli': [
             '__build__',
             'rabbitmq/rabbitmq.config',
+            'template/node_config.j2',
+            'template/server_config.j2',
+            'template/server_import_config.j2',
         ],
     },
     entry_points={


### PR DESCRIPTION
Not doing so will cause them not to be loadable when running the commands from a non-development installation