### PR TITLE
The field init_user_id was not filled out for tasks created via vserv…

### DIFF
--- a/vantage6-server/vantage6/server/controller/fixture.py
+++ b/vantage6-server/vantage6/server/controller/fixture.py
@@ -127,7 +127,8 @@ def load(fixtures: dict, drop_all: bool = False) -> None:
                 image=image,
                 collaboration=collaboration,
                 job_id=db.Task.next_job_id(),
-                init_org=init_org
+                init_org=init_org,
+                init_user=db.User.get()[0]
             )
 
             for organization in collaboration.organizations:


### PR DESCRIPTION
…er import

This may lead to issues further downstream because this field is normally filled