### PR TITLE
Error out in client if using invalid characters for database labels

### DIFF
--- a/vantage6-client/tests/test_client.py
+++ b/vantage6-client/tests/test_client.py
@@ -38,6 +38,43 @@ class TestClient(TestCase):
 
         assert results == [{'result': {'some_key': 'some_value'}}]
 
+    def test_parse_arg_databases(self):
+        dbs_in = [{"label": "dblabel"}]
+        dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+        self.assertEqual(dbs_in, dbs_out)
+
+        dbs_in = [
+            {"label": "dblabel"},
+            {"label": "dblabel2"},
+            {"label": "dblabel3"}
+        ]
+        dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+        self.assertEqual(dbs_in, dbs_out)
+
+        dbs_in = "labelstr"
+        dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+        self.assertEqual(dbs_out, [{"label": "labelstr"}])
+
+        dbs_in = [
+            {"label": "dblabel"},
+            {"label": "dblabel2"},
+            "single_label"
+        ]
+        with self.assertRaisesRegex(ValueError, "list of dict"):
+            dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+
+        dbs_in = [{"nolabel": "dblabel"}]
+        with self.assertRaisesRegex(ValueError, "label"):
+            dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+
+        dbs_in = [{"label": "bad-label"}]
+        with self.assertRaisesRegex(ValueError, "(?i)Invalid label"):
+            dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+
+        dbs_in = "1badlabel"
+        with self.assertRaisesRegex(ValueError, "(?i)Invalid label"):
+            dbs_out = UserClient.Task._parse_arg_databases(dbs_in)
+
     @staticmethod
     def post_task_on_mock_client(input_) -> dict[str, any]:
         mock_requests = MagicMock()

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -1236,10 +1236,7 @@ class UserClient(ClientBase):
                     'assigning it to at least one organization.'
                 )
 
-            if isinstance(databases, str):
-                # it is not unlikely that users specify a single database as a
-                # str, in that case we convert it to a list
-                databases = [{'label': databases}]
+            databases = self._parse_arg_databases(databases)
 
             # Data will be serialized in JSON.
             serialized_input = serialize(input_)
@@ -1264,6 +1261,61 @@ class UserClient(ClientBase):
                 "organizations": organization_json_list,
                 'databases': databases
             })
+
+        @staticmethod
+        def _parse_arg_databases(databases: list[dict] | str) -> list[dict]:
+            """Parse the databases argument
+
+            Parameters
+            ----------
+            databases: list[dict] | str
+                Each dict should contain at least a 'label' key. A single str
+                can be passed and will be interpreted as a single database with
+                that label.
+
+            Returns
+            -------
+            list[dict]
+                The parsed databases argument
+
+            Raises
+            ------
+            ValueError: if 'label' is missing from the database dict or an
+                        invalid label is provided.
+
+            Note
+            ----
+            We are looking before we leap (LBYL) rather than attempting to
+            catch an exception later on (EAFP) because the task will be created
+            on the server before nodes might even get a chance to complain.
+            """
+            if isinstance(databases, str):
+                # it is not unlikely that users specify a single database as a
+                # str, in that case we convert it to a list
+                databases = [{"label": databases}]
+
+            for db in databases:
+                try:
+                    label_input = db.get("label")
+                except AttributeError:
+                    raise ValueError(
+                        "Databases specified should be a list of dicts with"
+                        "label keys or a single str"
+                    )
+                if not label_input or not isinstance(label_input, str):
+                    raise ValueError(
+                        "Each database should have a 'label' key with a string"
+                        "value."
+                    )
+                # Labels will become part of env var names in algo container,
+                # some chars are not allowed in some shells.
+                if not label_input.isidentifier():
+                    raise ValueError(
+                        "Database labels should be made up of letters, digits"
+                        " (except first character) and underscores only. "
+                        f"Invalid label: {db.get('label')}"
+                    )
+            return databases
 
         def delete(self, id_: int) -> dict:
             """Delete a task


### PR DESCRIPTION
Algorithm images are usually built on top of the algorithm wrapper [0]. This is using python:3.10-slim-bullseye as base image at the moment, which as a Debian based image has dash as its `/bin/sh`. Docker will use that shell when using the CMD instruction in "shell form" [1] in the Dockerfile, like in the average algorithm example [2].

At the moment, environment variables are used to pass to the algorithm container the details of the database to use. This means that the database label will become an environment variable name.

Dash only allows valid identifiers: "a letter or underscore followed by zero or more letters, underscores, and digits" [3].

[0]: https://github.com/vantage6/vantage6/blob/version/4.0.3/vantage6-algorithm-tools/vantage6/algorithm/tools/wrap.py
[1]: https://docs.docker.com/engine/reference/builder/
[2]: https://github.com/IKNL/v6-average-py/blob/bb34f43/Dockerfile#L20
[3]: https://git.kernel.org/pub/scm/utils/dash/dash.git/tree/src/parser.c?h=v0.5.12#n1483