### PR TITLE
Server logging didn't work anymore as server log file was created in …

### DIFF
--- a/vantage6-common/vantage6/common/context.py
+++ b/vantage6-common/vantage6/common/context.py
@@ -3,6 +3,7 @@ import sys
 import appdirs
 import logging
 import logging.handlers
+import pyfiglet
 
 from pathlib import Path
 from typing import Tuple
@@ -11,6 +12,7 @@ from vantage6.common import (
     Singleton, error, Fore, Style, get_config_path, logger_name
 )
 from vantage6.common.colors import ColorStreamHandler
+from vantage6.common.docker.addons import running_in_docker
 from vantage6.common.globals import APPNAME
 from vantage6.common.configuration_manager import (
     ConfigurationManager
@@ -49,10 +51,31 @@ class AppContext(metaclass=Singleton):
             will be used to find the configuration file specified by
             `instance_name`.
         """
+        self.initialize(instance_type, instance_name, system_folders,
+                        config_file)
+
+    def initialize(self, instance_type: str, instance_name: str,
+                   system_folders: bool = False,
+                   config_file: str | None = None) -> None:
+        """
+        Initialize the AppContext instance.
+
+        Parameters
+        ----------
+        instance_type: str
+            'server' or 'node'
+        instance_name: str
+            Name of the configuration
+        system_folders: bool
+            Use system folders rather than user folders
+        config_file: str
+            Path to a specific config file. If left as None, OS specific folder
+            will be used to find the configuration file specified by
+            `instance_name`.
+        """
         self.scope: str = "system" if system_folders else "user"
         self.name: str = instance_name
         self.instance_type = instance_type
-
         # if config_file is None:
         #     config_file = f"{instance_name}.yaml"
         self.config_file = self.find_config_file(
@@ -76,7 +99,6 @@ class AppContext(metaclass=Singleton):
         self.log = logging.getLogger(module_name)
         self.log.info("-" * 45)
         # self.log.info(f'#{APPNAME:^78}#')
-        import pyfiglet
         self.log.info(" Welcome to")
         for line in pyfiglet.figlet_format(APPNAME, font='big').split('\n'):
             self.log.info(line)
@@ -120,16 +142,7 @@ class AppContext(metaclass=Singleton):
         instance_name = Path(path).stem
 
         self_ = cls.__new__(cls)
-        self_.name = instance_name
-        self_.scope = "system" if system_folders else "user"
-        self_.config_dir = Path(path).parent
-        self_.config_file = path
-        self_.instance_type = instance_type
-        self_.set_folders(instance_type, instance_name, system_folders)
-        module_name = logger_name(__name__)
-        self_.log = logging.getLogger(module_name)
-        if self_.LOGGING_ENABLED:
-            self_.setup_logging()
+        self_.initialize(instance_type, instance_name, system_folders, path)
 
         return self_
 
@@ -218,16 +231,22 @@ class AppContext(metaclass=Singleton):
         """
         d = appdirs.AppDirs(APPNAME, "")
 
-        if system_folders:
+        if running_in_docker():
             return {
-                "log": Path(d.site_data_dir) / instance_type,
+                "log": Path("/mnt/log"),
+                "data": Path("/mnt/data"),
+                "config": Path("/mnt/config")
+            }
+        elif system_folders:
+            return {
+                "log": Path(d.site_data_dir) / instance_type / instance_name,
                 "data": Path(d.site_data_dir) / instance_type / instance_name,
-                "config": Path(get_config_path(d, system_folders)) \
-                    / instance_type
+                "config": (Path(get_config_path(d, system_folders)) /
+                           instance_type)
             }
         else:
             return {
-                "log": Path(d.user_log_dir) / instance_type,
+                "log": Path(d.user_log_dir) / instance_type / instance_name,
                 "data": Path(d.user_data_dir) / instance_type / instance_name,
                 "config": Path(d.user_config_dir) / instance_type,
                 "dev": Path(d.user_config_dir) / "dev"
@@ -305,8 +324,7 @@ class AppContext(metaclass=Singleton):
         """
         assert self.config_manager, \
             "Log file unkown as configuration manager not initialized"
-        file_ = (Path(self.config_manager.name) /
-                 f"{type_}_{self.scope}.log")
+        file_ = f"{type_}_{self.scope}.log"
         return self.log_dir / file_
 
     @property

--- a/vantage6/vantage6/cli/context.py
+++ b/vantage6/vantage6/cli/context.py
@@ -194,10 +194,6 @@ class NodeContext(AppContext):
     # configuration file and makes sure only valid configuration can be loaded.
     INST_CONFIG_MANAGER = NodeConfigurationManager
 
-    # Flag to indicate if the node is running in a docker container or directly
-    # on the host machine.
-    running_in_docker = False
-
     def __init__(self, instance_name: str, system_folders: bool = N_FOL,
                  config_file: str = None):
         super().__init__("node", instance_name, system_folders, config_file)

--- a/vantage6/vantage6/cli/node/start.py
+++ b/vantage6/vantage6/cli/node/start.py
@@ -174,7 +174,7 @@ def cli_node_start(name: str, config: str, system_folders: bool, image: str,
     # FIXME: should obtain mount points from DockerNodeContext
     mounts = [
         # (target, source)
-        ("/mnt/log", str(ctx.log_dir)),
+        (f"/mnt/log/{name}", str(ctx.log_dir)),
         ("/mnt/data", data_volume.name),
         ("/mnt/vpn", vpn_volume.name),
         ("/mnt/ssh", ssh_volume.name),

--- a/vantage6/vantage6/cli/server/start.py
+++ b/vantage6/vantage6/cli/server/start.py
@@ -76,6 +76,9 @@ def cli_server_start(ctx: ServerContext, ip: str, port: int, image: str,
                   "is already running")
             exit(1)
 
+    # check that log directory exists - or create it
+    ctx.log_dir.mkdir(parents=True, exist_ok=True)
+
     # Determine image-name. First we check if the option --image has been used.
     # Then we check if the image has been specified in the config file, and
     # finally we use the default settings from the package.
@@ -101,6 +104,8 @@ def cli_server_start(ctx: ServerContext, ip: str, port: int, image: str,
     mounts = [
         docker.types.Mount(
             config_file, str(ctx.config_file), type="bind"
+        ), docker.types.Mount(
+            "/mnt/log/", str(ctx.log_dir), type="bind"
         )
     ]
 


### PR DESCRIPTION
…different place in the container

Also 2 other improvements:
- ensure the appContext init is run when starting the server
- No longer mount all node logs into container for a single node

This supersedes #952 and instead of #946 it merges the changes into main - branch was created by cherrypicking the commit from the latter PR