### PR TITLE
Prevent error if no databases are defined

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -1238,6 +1238,8 @@ class UserClient(ClientBase):
                     'assigning it to at least one organization.'
                 )
 
+            if databases is None:
+                databases = []
             databases = self._parse_arg_databases(databases)
 
             # Data will be serialized in JSON.


### PR DESCRIPTION
Without this I got the following when calling `client.task.create()` without a `databases` argument:
```
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\420rc1\lib\site-packages\vantage6\cli\test\common\diagnostic_runner.py", line 122, in vpn_features
    task = self.client.task.create(
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\420rc1\lib\site-packages\vantage6\client\filter.py", line 93, in wrapper_filter
    dict_ = func(*args, **kwargs)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\420rc1\lib\site-packages\vantage6\client\filter.py", line 178, in wrapper_filter
    return func(*args, **kwargs)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\420rc1\lib\site-packages\vantage6\client\__init__.py", line 1241, in create
    databases = self._parse_arg_databases(databases)
  File "C:\Users\bbe2101.54580\AppData\Local\miniconda3\envs\420rc1\lib\site-packages\vantage6\client\__init__.py", line 1299, in _parse_arg_databases
    for db in databases:
TypeError: 'NoneType' object is not iterable
```

