### PR TITLE
Bugfix/permission error user create

### DIFF
--- a/vantage6-server/vantage6/server/permission.py
+++ b/vantage6-server/vantage6/server/permission.py
@@ -241,7 +241,7 @@ class RuleCollection(dict):
         """
         scopes: list[Scope] = self._get_scopes_from(scope)
         for s in scopes:
-            perm = getattr(self, f"{operation}_{s}")
+            perm = getattr(self, f"{operation}_{s}", None)
             if perm and perm.can():
                 return True
         return False


### PR DESCRIPTION
This resolves the following error which I got when creating a user. It only occurs when creating users with certain permissions (it happened when creating root user but not organization admin user)

```
2024-01-23 12:19:20 - server         - ERROR    - Exception occured during request
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/usr/local/lib/python3.10/site-packages/flask_restful/__init__.py", line 489, in wrapper
    resp = resource(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flask/views.py", line 107, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)
  File "/usr/local/lib/python3.10/site-packages/flask_restful/__init__.py", line 604, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flask_jwt_extended/view_decorators.py", line 154, in decorator
    return current_app.ensure_sync(fn)(*args, **kwargs)
  File "/vantage6/vantage6-server/vantage6/server/resource/__init__.py", line 241, in decorator
    return fn(*args, **kwargs)
  File "/vantage6/vantage6-server/vantage6/server/resource/user.py", line 428, in post
    denied = self.permissions.check_user_rules(role_.rules)
  File "/vantage6/vantage6-server/vantage6/server/permission.py", line 564, in check_user_rules
    if not self.collections[rule.name].has_at_least_scope(
  File "/vantage6/vantage6-server/vantage6/server/permission.py", line 245, in has_at_least_scope
    perm = getattr(self, f'{operation}_{s}')
AttributeError: 'RuleCollection' object has no attribute 'v_col'
```