### PR TITLE
Node logs were not persisted due to error in mount location

### DIFF
--- a/vantage6/vantage6/cli/node/start.py
+++ b/vantage6/vantage6/cli/node/start.py
@@ -197,7 +197,7 @@ def cli_node_start(
     # FIXME: should obtain mount points from DockerNodeContext
     mounts = [
         # (target, source)
-        (f"/mnt/log/{name}", str(ctx.log_dir)),
+        ("/mnt/log", str(ctx.log_dir)),
         ("/mnt/data", data_volume.name),
         ("/mnt/vpn", vpn_volume.name),
         ("/mnt/ssh", ssh_volume.name),


### PR DESCRIPTION
Fix #993 (at least I see the debug logs now again, but before this fix I actually saw nothing at all instead of just INFO and higher)