### PR TITLE
Prevent that message on stop node says 'None' for node name by using …

### DIFF
--- a/vantage6/tests_cli/test_node_cli.py
+++ b/vantage6/tests_cli/test_node_cli.py
@@ -260,7 +260,9 @@ class NodeCLITest(unittest.TestCase):
 
         result = runner.invoke(cli_node_stop, ["--name", "iknl"])
 
-        self.assertEqual(result.output, "[info ] - Stopped the iknl Node.\n")
+        self.assertEqual(
+            result.output, "[info ] - Stopped the vantage6-iknl-user Node.\n"
+        )
 
         self.assertEqual(result.exit_code, 0)
 

--- a/vantage6/vantage6/cli/node/stop.py
+++ b/vantage6/vantage6/cli/node/stop.py
@@ -77,7 +77,7 @@ def cli_node_stop(
 
         if container_name in running_node_names:
             _stop_node(client, container_name, force, system_folders)
-            info(f"Stopped the {Fore.GREEN}{name}{Style.RESET_ALL} Node.")
+            info(f"Stopped the {Fore.GREEN}{container_name}{Style.RESET_ALL} Node.")
         else:
             error(f"{Fore.RED}{name}{Style.RESET_ALL} is not running?!")
 


### PR DESCRIPTION
…name of container which is always set