### PR TITLE
Prevent error on deleting docker volumes

### DIFF
--- a/vantage6-common/vantage6/common/docker/addons.py
+++ b/vantage6-common/vantage6/common/docker/addons.py
@@ -523,5 +523,5 @@ def delete_volume_if_exists(client: docker.DockerClient, volume_name: Volume) ->
     if volume:
         try:
             volume.remove()
-        except docker.errors.NotFound:
+        except (docker.errors.NotFound, docker.errors.APIError):
             log.warning("Could not delete volume %s", volume.name)


### PR DESCRIPTION
Prevent error on deleting docker volumes

 - catch error if docker volume is still in use
 - prevent that the error is generated at all by sleeping 1 second between removing the container and deleting its volumes