### PR TITLE
Fix pulling from private registries

### DIFF
--- a/vantage6-node/vantage6/node/docker/docker_base.py
+++ b/vantage6-node/vantage6/node/docker/docker_base.py
@@ -1,5 +1,7 @@
 import docker
 
+from docker import DockerClient
+
 from vantage6.common.docker.network_manager import NetworkManager
 
 
@@ -9,11 +11,25 @@ class DockerBaseManager(object):
     by multiple derived classes
     """
 
-    def __init__(self, isolated_network_mgr: NetworkManager) -> None:
+    def __init__(
+        self,
+        isolated_network_mgr: NetworkManager,
+        docker_client: DockerClient = None,
+    ) -> None:
+        """
+        Constructor for DockerBaseManager
+
+        Parameters
+        ----------
+        isolated_network_mgr: NetworkManager
+            Manager of an isolated network
+        docker_client: DockerClient
+            Docker client to use. If None is provided, a new client will be created
+        """
         self.isolated_network_mgr = isolated_network_mgr
 
         # Connect to docker daemon
-        self.docker = docker.from_env()
+        self.docker = docker_client if docker_client else docker.from_env()
 
     def get_isolated_netw_ip(self, container) -> str:
         """

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -511,8 +511,10 @@ class DockerManager(DockerBaseManager):
             self.log.debug(f"run_id={run_id} is discarded")
             return TaskStatus.ACTIVE, None
 
+        # we pass self.docker instance, in which we may have logged in to registries
         task = DockerTaskManager(
             image=image,
+            docker_client=self.docker,
             run_id=run_id,
             task_info=task_info,
             vpn_manager=self.vpn_manager,

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -7,6 +7,7 @@ import json
 import base64
 
 from pathlib import Path
+from docker import DockerClient
 
 from vantage6.common.globals import APPNAME, ENV_VAR_EQUALS_REPLACEMENT, STRING_ENCODING
 from vantage6.common.docker.addons import (
@@ -42,6 +43,7 @@ class DockerTaskManager(DockerBaseManager):
     def __init__(
         self,
         image: str,
+        docker_client: DockerClient,
         vpn_manager: VPNManager,
         node_name: str,
         run_id: int,
@@ -61,6 +63,8 @@ class DockerTaskManager(DockerBaseManager):
         ----------
         image: str
             Name of docker image to be run
+        docker_client: DockerClient
+            Docker client instance to use
         vpn_manager: VPNManager
             VPN manager required to set up traffic forwarding via VPN
         node_name: str
@@ -86,7 +90,7 @@ class DockerTaskManager(DockerBaseManager):
         self.task_id = task_info["id"]
         self.log = logging.getLogger(f"task ({self.task_id})")
 
-        super().__init__(isolated_network_mgr)
+        super().__init__(isolated_network_mgr, docker_client=docker_client)
         self.image = image
         self.__vpn_manager = vpn_manager
         self.run_id = run_id


### PR DESCRIPTION
DockerTaskManager was using a new instance of DockerClient, but we had logged into the potential different registries in DockerManager's instance of DockerClient.

This addresses https://github.com/vantage6/vantage6/issues/1168