### PR TITLE
Revert pinning of uWSGI version as 2.0.25.1 has been published which …

### DIFF
--- a/docker/algorithm-store.Dockerfile
+++ b/docker/algorithm-store.Dockerfile
@@ -36,6 +36,6 @@ RUN apt-get install --no-install-recommends --no-install-suggests -y \
 RUN CFLAGS="-I/usr/local/opt/openssl/include" \
   LDFLAGS="-L/usr/local/opt/openssl/lib" \
   UWSGI_PROFILE_OVERRIDE=ssl=true \
-  pip install uwsgi==2.0.24 -Iv
+  pip install uwsgi -Iv
 
 RUN chmod +x /vantage6/vantage6-algorithm-store/server.sh

--- a/docker/node-and-server.Dockerfile
+++ b/docker/node-and-server.Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get install --no-install-recommends --no-install-suggests -y \
 RUN CFLAGS="-I/usr/local/opt/openssl/include" \
   LDFLAGS="-L/usr/local/opt/openssl/lib" \
   UWSGI_PROFILE_OVERRIDE=ssl=true \
-  pip install uwsgi==2.0.24 -Iv
+  pip install uwsgi -Iv
 
 RUN chmod +x /vantage6/vantage6-server/server.sh
 


### PR DESCRIPTION
…mitigates an issue we had with 2.0.25

Fix #1208 