### PR TITLE
Don't show button to register nodes if all nodes are already registered

### DIFF
--- a/vantage6-ui/src/app/pages/collaboration/read/collaboration-read.component.html
+++ b/vantage6-ui/src/app/pages/collaboration/read/collaboration-read.component.html
@@ -51,14 +51,14 @@
         mat-flat-button
         class="right-aligned-button"
         color="primary"
-        *ngIf="canEdit"
+        *ngIf="canEdit && isMissingNodes()"
         (click)="onRegisterMissingNodes()"
-        >
+      >
         <mat-icon>add</mat-icon>{{ "collaboration-read.card-nodes.add" | translate }}
       </button>
     </mat-card-header>
     <mat-card-content>
-      <app-alert *ngIf="isMissingNodes()" class="node-alert" label="{{'collaboration-read.alert-missing-nodes' | translate}}"></app-alert>
+      <app-alert *ngIf="isMissingNodes()" class="node-alert" label="{{ 'collaboration-read.alert-missing-nodes' | translate }}"></app-alert>
       <div class="chip-container">
         <app-chip
           *ngFor="let node of collaboration.nodes"


### PR DESCRIPTION
The button should not be shown if there is nothing to be done