### PR TITLE
Added sticky sessions requirement to the docs for horizontal scaling

### DIFF
--- a/docs/server/deploy.rst
+++ b/docs/server/deploy.rst
@@ -16,6 +16,7 @@ There are many deployment options. We simply provide a few examples.
 -  …
 
 .. note::
+
     Because the server uses socketIO to exchange messages with the nodes and
     users, it is not trivial to horizontally scale the server. To prevent that
     socket messages get lost:
@@ -28,12 +29,50 @@ There are many deployment options. We simply provide a few examples.
 
 NGINX
 """""
+Two examples are provided below. The first example shows how to configure NGINX with
+a basic setup, which is suitable if you do not require the horizontal scaling feature.
+The second example shows how to configure NGINX with sticky sessions.
 
-A basic setup is shown below. This example shows how to configure NGINX where there
-are 3 backend servers that are load balanced. The load balancer is configured to use
-sticky sessions.
+.. note::
 
-Note that SSL is not configured in this example.
+    SSL is not configured in these examples.
+
+The most basic setup is to have a single backend server.
+
+.. code:: nginx
+
+    server {
+
+        # Public port
+        listen 80;
+        server_name _;
+
+        # vantage6-server. In the case you use a sub-path here, make sure
+        # to forward also it to the proxy_pass
+        location /subpath {
+            include proxy_params;
+
+            # internal ip and port
+            proxy_pass http://127.0.0.1:5000/subpath;
+        }
+
+        # Allow the websocket traffic
+        location /socket.io {
+            include proxy_params;
+            proxy_http_version 1.1;
+            proxy_buffering off;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "Upgrade";
+            proxy_pass http://127.0.0.1:5000/socket.io;
+        }
+    }
+
+
+
+The following example shows how to configure NGINX where there are 3 backend servers
+that are behind a load balancer. The load balancer is configured to use sticky sessions.
+
+
 
 .. code:: nginx
 
@@ -72,10 +111,9 @@ Note that SSL is not configured in this example.
    }
 
 .. note::
-    When you :ref:`server-configure` the server, make
-    sure to include the ``/subpath`` that has been set in the NGINX
-    configuration into the ``api_path`` setting
-    (e.g. ``api_path: /subpath/api``)
+    When you :ref:`server-configure` the server, make sure to include the ``/subpath``
+    that has been set in the NGINX configuration into the ``api_path`` setting (e.g.
+    ``api_path: /subpath/api``)
 
 .. _deploy-docker-compose:
 

--- a/docs/server/deploy.rst
+++ b/docs/server/deploy.rst
@@ -18,18 +18,32 @@ There are many deployment options. We simply provide a few examples.
 .. note::
     Because the server uses socketIO to exchange messages with the nodes and
     users, it is not trivial to horizontally scale the server. To prevent that
-    socket messages get lost, you should deploy a RabbitMQ service and configure
-    the server to use it. :ref:`This section <rabbitmq-install>` explains how to
-    do so.
+    socket messages get lost:
+
+        * you should deploy a RabbitMQ service and configure the server to use it.
+          :ref:`This section <rabbitmq-install>` explains how to do so.
+        * you should ensure sticky sessions are enabled in your load balancer.
 
 .. _deploy-nginx:
 
 NGINX
 """""
 
-A basic setup is shown below. Note that SSL is not configured in this example.
+A basic setup is shown below. This example shows how to configure NGINX where there
+are 3 backend servers that are load balanced. The load balancer is configured to use
+sticky sessions.
+
+Note that SSL is not configured in this example.
 
 .. code:: nginx
+
+   upstream backend {
+       server backend1.example.com;
+       server backend2.example.com;
+       server backend3.example.com;
+
+       sticky name=sessionid path=/;
+   }
 
    server {
 
@@ -37,13 +51,13 @@ A basic setup is shown below. Note that SSL is not configured in this example.
        listen 80;
        server_name _;
 
-       # vantage6-server. In the case you use a sub-path here, make sure
-       # to foward also it to the proxy_pass
+       # vantage6-server. In the case you use a sub-path here, make sure to forward also
+       # it to the proxy_pass
        location /subpath {
            include proxy_params;
 
            # internal ip and port
-           proxy_pass http://127.0.0.1:5000/subpath;
+           proxy_pass http://backend/subpath;
        }
 
        # Allow the websocket traffic
@@ -53,7 +67,7 @@ A basic setup is shown below. Note that SSL is not configured in this example.
            proxy_buffering off;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection "Upgrade";
-           proxy_pass http://127.0.0.1:5000/socket.io;
+           proxy_pass http://backend/socket.io;
        }
    }
 
@@ -70,7 +84,7 @@ Docker compose
 
 An alternative to ``v6 server start`` is to use docker-compose. Below is an
 example of a ``docker-compose.yml`` file that may be used to start the server.
-Obviously, you may want to change this to your own situtation. For example, you
+Obviously, you may want to change this to your own situation. For example, you
 may want to use a different image tag, or you may want to use a different port.
 
 .. code:: yaml


### PR DESCRIPTION
Fixes #1224 

I did not document the ARR affinity option for Azure as there was no section for this yet. I opened a separate issue for this: https://github.com/vantage6/vantage6/issues/1269