### PR TITLE
Copied all dataframes before supplying them to the partial functions in the `MockClient`

### DIFF
--- a/vantage6-algorithm-tools/vantage6/algorithm/tools/mock_client.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/tools/mock_client.py
@@ -239,7 +239,9 @@ class MockAlgorithmClient:
                 if getattr(method, "wrapped_in_algorithm_client_decorator", False):
                     mocked_kwargs["mock_client"] = client_copy
                 if getattr(method, "wrapped_in_data_decorator", False):
-                    mocked_kwargs["mock_data"] = data
+                    # make a copy of the data to avoid modifying the original data of
+                    # subsequent tasks
+                    mocked_kwargs["mock_data"] = [d.copy() for d in data]
 
                 result = method(*args, **kwargs, **mocked_kwargs)
 


### PR DESCRIPTION
When this was not done subsequent calls of partial functions could end up with a modified dataframe. Something that is not consistent with how this works in the infrastructure.