### PR TITLE
Hide the option to change the organizations in a collaboration if the…

### DIFF
--- a/vantage6-ui/src/app/components/forms/collaboration-form/collaboration-form.component.html
+++ b/vantage6-ui/src/app/components/forms/collaboration-form/collaboration-form.component.html
@@ -7,7 +7,7 @@
     <mat-checkbox formControlName="encrypted" color="primary" labelPosition="before">
       {{ "collaboration.encrypted" | translate }}
     </mat-checkbox>
-    <mat-form-field subscriptSizing="dynamic">
+    <mat-form-field subscriptSizing="dynamic" *ngIf="canEditOrganizations">
       <mat-label>{{ "collaboration.organizations" | translate }}</mat-label>
       <mat-select
         multiple


### PR DESCRIPTION
… user doesn't have permission to do so

This change is required due to the changed permissions of collaboration admins in extending a collaboration