### PR TITLE
Algorithm stores not linked to a collaboration should be returned to …

### DIFF
--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -3556,7 +3556,7 @@ class TestResources(unittest.TestCase):
         results = self.app.get("/api/algorithmstore", headers=headers)
         all_stores = AlgorithmStore.get()
         num_stores_to_find = (
-            len([store for store in all_stores if store.collaboration_id == None]) + 1
+            len([store for store in all_stores if store.collaboration_id is None]) + 1
         )
         self.assertEqual(results.status_code, HTTPStatus.OK)
         self.assertEqual(len(results.json["data"]), num_stores_to_find)

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -3572,7 +3572,7 @@ class TestResources(unittest.TestCase):
             query_string={"collaboration_id": col.id},
         )
         self.assertEqual(results.status_code, HTTPStatus.OK)
-        self.assertEqual(len(results.json["data"]), 1)
+        self.assertEqual(len(results.json["data"]), num_stores_to_find)
         results = self.app.get(f"/api/algorithmstore/{algo_store.id}", headers=headers)
         self.assertEqual(results.status_code, HTTPStatus.OK)
 

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -3551,10 +3551,15 @@ class TestResources(unittest.TestCase):
         algo_store.save()
         rule = Rule.get_by_("collaboration", Scope.ORGANIZATION, Operation.VIEW)
         headers = self.create_user_and_login(organization=org, rules=[rule])
-        # list
+
+        # list. We expect to find all stores without specified collaboration and this one
         results = self.app.get("/api/algorithmstore", headers=headers)
+        all_stores = AlgorithmStore.get()
+        num_stores_to_find = (
+            len([store for store in all_stores if store.collaboration_id == None]) + 1
+        )
         self.assertEqual(results.status_code, HTTPStatus.OK)
-        self.assertEqual(len(results.json["data"]), 1)
+        self.assertEqual(len(results.json["data"]), num_stores_to_find)
         # single record
         results = self.app.get(f"/api/algorithmstore/{algo_store.id}", headers=headers)
         self.assertEqual(results.status_code, HTTPStatus.OK)

--- a/vantage6-server/vantage6/server/resource/algorithm_store.py
+++ b/vantage6-server/vantage6/server/resource/algorithm_store.py
@@ -199,7 +199,12 @@ class AlgorithmStores(AlgorithmStoreBase):
         if not self.r_col.v_glo.can():
             collab_ids = [c.id for c in auth_org.collaborations]
             if self.r_col.v_org.can():
-                q = q.filter(db.AlgorithmStore.collaboration_id.in_(collab_ids))
+                q = q.filter(
+                    or_(
+                        db.AlgorithmStore.collaboration_id.in_(collab_ids),
+                        db.AlgorithmStore.collaboration_id.is_(None),
+                    )
+                )
             else:
                 return {
                     "msg": "You lack the permission to do that!"


### PR DESCRIPTION
…users with permission to see algorithm stores as these are generally available - this was not the case