### PR TITLE
Prevent proxy requests from hanging by not returning headers

### DIFF
--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -296,7 +296,7 @@ def proxy_task():
             "msg": "Request failed, see node logs"
         }, HTTPStatus.INTERNAL_SERVER_ERROR
 
-    return response.content, response.status_code, response.headers.items()
+    return response.content, response.status_code
 
 
 @app.route("/result", methods=["GET"])
@@ -345,7 +345,7 @@ def proxy_result() -> Response:
     for result in results["data"]:
         result = decrypt_result(result)
 
-    return results, response.status_code, response.headers.items()
+    return results, response.status_code
 
 
 @app.route("/result/<int:id>", methods=["GET"])
@@ -384,7 +384,7 @@ def proxy_results(id_: int) -> Response:
     result = get_response_json_and_handle_exceptions(response)
     result = decrypt_result(result)
 
-    return result, response.status_code, response.headers.items()
+    return result, response.status_code
 
 
 @app.route(


### PR DESCRIPTION
Partially undoing changes from #1268 - tasks where hanging whenever they tried `client.result.get()`. 

I did not really look into why `response.headers.items()` is causing this but after deleting it, everything worked fine. To be sure that we're not introducing new bugs I removed them everywhere where they were not yet present.