### PR TITLE
Fix that algorithm store authorization headers are forwarded to store…

### DIFF
--- a/vantage6-server/vantage6/server/algo_store_communication.py
+++ b/vantage6-server/vantage6/server/algo_store_communication.py
@@ -251,7 +251,7 @@ def _execute_algo_store_request(
     # set headers
     if not headers:
         headers = {}
-    headers = {"server_url": server_url}
+    headers["server_url"] = server_url
 
     params = None
     json = None


### PR DESCRIPTION
… instead of overwritten

This is good to merge soon, because it gives trouble in almost all of the communication between v6 server and algorithm store.