### PR TITLE
Added missing algorithm argument types in the documentation

### DIFF
--- a/vantage6-algorithm-store/vantage6/algorithm/store/resource/algorithm.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/resource/algorithm.py
@@ -243,8 +243,9 @@ class Algorithms(AlgorithmStoreResources):
                               type:
                                 type: string
                                 description: Type of argument. Can be 'string',
-                                  'integer', 'float', 'boolean', 'json',
-                                  'column', 'organizations' or 'organization'
+                                  'string_list', 'integer', 'integer_list', 'float',
+                                  'float_list', 'boolean', 'json', 'column',
+                                  'column_list', 'organization' or 'organization_list'
                         ui_visualizations:
                           type: array
                           description: List of visualizations that are available in


### PR DESCRIPTION
This branched of main. The additional commits shown here should disappear when `main` is merged back into this release branch. Alternatively we could merge it into main.. its just docs