### PR TITLE
Addressing random BadNameSpace error by including the 'always_connect' option to Socket.io

### DIFF
--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -219,6 +219,7 @@ class ServerApp:
                 cors_allowed_origins=cors_settings,
                 logger=debug_mode,
                 engineio_logger=debug_mode,
+                always_connect=True
             )
         except Exception as e:
             log.warning(
@@ -235,6 +236,7 @@ class ServerApp:
                 cors_allowed_origins=cors_settings,
                 logger=debug_mode,
                 engineio_logger=debug_mode,
+                always_connect=True
             )
 
         # FIXME: temporary fix to get socket object into the namespace class

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -219,7 +219,7 @@ class ServerApp:
                 cors_allowed_origins=cors_settings,
                 logger=debug_mode,
                 engineio_logger=debug_mode,
-                always_connect=True
+                always_connect=True,
             )
         except Exception as e:
             log.warning(
@@ -236,7 +236,7 @@ class ServerApp:
                 cors_allowed_origins=cors_settings,
                 logger=debug_mode,
                 engineio_logger=debug_mode,
-                always_connect=True
+                always_connect=True,
             )
 
         # FIXME: temporary fix to get socket object into the namespace class


### PR DESCRIPTION
This is a minor fix that seems to address issue #1333: random socket.io error (socketio.exceptions.BadNamespaceError: /tasks is not a connected namespace) on the v6 nodes while trying to share its parameters with the server during its initialization. It is based on this discussion thread ([Client is getting socketio.exceptions.BadNamespaceError after reconnecting · Issue #920 · miguelgrinberg/python-socketio (github.com)](https://github.com/miguelgrinberg/python-socketio/issues/920)). I tested this with a server running with the 'patched' code within a SURF-RC workspace, and a node running on a separate one (also on SURF). When I removed the 'always_connect' option and restarted the server and the node, the problem occurred again.

The [official documentation](https://python-socketio.readthedocs.io/en/latest/api.html) states:

___**always_connect**... Set to True if you need to emit events from the connect handler and your client is confused when it receives events before the connection acceptance. In any other case use the default of False.___

For me, issue #1333 fits the 'confusion' part.
