### PR TITLE
Fix/alternative sql sqlalchemy issue fix

### DIFF
--- a/vantage6-algorithm-tools/vantage6/algorithm/tools/wrappers.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/tools/wrappers.py
@@ -20,6 +20,8 @@ import io
 import os
 import pandas as pd
 
+from sqlalchemy import create_engine
+
 from enum import Enum
 
 from SPARQLWrapper import SPARQLWrapper, CSV
@@ -302,7 +304,15 @@ def load_sql_data(database_uri: str, query: str) -> pd.DataFrame:
     pd.DataFrame
         The data from the database
     """
+    engine = create_engine(_sqldb_uri_preprocess(database_uri))
 
-    db_connection = _sqldb_uri_preprocess(database_uri)
-    df = pd.read_sql(query, db_connection)
+    dbapi_conn = engine.raw_connection()
+
+    try:
+        # Execute the query and store the results in a DataFrame
+        df = pd.read_sql_query(query, con=dbapi_conn)
+
+    finally:
+        dbapi_conn.close()  # Ensure the connection is closed
+
     return df


### PR DESCRIPTION
Alternative fix to issue #1237 using version 1.4 of the SQLalchemy library V6 depends on (connectorx is no longer used).  Tested with a file-based SQLite database, and an online PostgresSQL one.