### PR TITLE
Pass on print_log_header argument properly in v6 node stop

### DIFF
--- a/vantage6/vantage6/cli/context/node.py
+++ b/vantage6/vantage6/cli/context/node.py
@@ -40,11 +40,15 @@ class NodeContext(AppContext):
         config_file: str = None,
         print_log_header: bool = True,
     ):
-        super().__init__(InstanceType.NODE, instance_name, system_folders, config_file)
-        self.log.info("vantage6 version '%s'", __version__)
-
+        super().__init__(
+            InstanceType.NODE,
+            instance_name,
+            system_folders,
+            config_file,
+            print_log_header,
+        )
         if print_log_header:
-            self.log.info(f"vantage6 version '{__version__}'")
+            self.log.info("vantage6 version '%s'", __version__)
 
     @classmethod
     def from_external_config_file(


### PR DESCRIPTION
Fix #1398 