### PR TITLE
Don't require user to run client.setup_encryption(), unless they have…

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -14,7 +14,7 @@ import traceback
 from pathlib import Path
 
 from vantage6.common.globals import APPNAME
-from vantage6.common.encryption import RSACryptor
+from vantage6.common.encryption import DummyCryptor, RSACryptor
 from vantage6.common import WhoAmI
 from vantage6.common.serialization import serialize
 from vantage6.client.filter import post_filtering
@@ -170,6 +170,10 @@ class UserClient(ClientBase):
             self.log.info(
                 f" --> Organization: {organization_name} " f"(id={organization_id})"
             )
+
+            # setup default encryption so user doesn't have to do this unless encryption
+            # is enabled
+            self.cryptor = DummyCryptor()
         except Exception:
             self.log.info("--> Retrieving additional user info failed!")
             self.log.error(traceback.format_exc())
@@ -1534,15 +1538,15 @@ class UserClient(ClientBase):
         @post_filtering(iterable=False)
         def create(
             self,
-            organizations: list,
+            organizations: list | None,
             name: str,
             image: str,
             description: str,
             input_: dict,
-            collaboration: int = None,
-            study: int = None,
-            store: int = None,
-            databases: list[dict] = None,
+            collaboration: int | None = None,
+            study: int | None = None,
+            store: int | None = None,
+            databases: list[dict] | None = None,
         ) -> dict:
             """Create a new task
 

--- a/vantage6-common/vantage6/common/client/client_base.py
+++ b/vantage6-common/vantage6/common/client/client_base.py
@@ -285,7 +285,7 @@ class ClientBase(object):
 
         return response.json()
 
-    def setup_encryption(self, private_key_file: str) -> None:
+    def setup_encryption(self, private_key_file: str | None) -> None:
         """Enable the encryption module fot the communication
 
         This will attach a Crypter object to the client. It will also
@@ -295,8 +295,8 @@ class ClientBase(object):
 
         Parameters
         ----------
-        private_key_file : str
-            File path of the private key file
+        private_key_file : str | None
+            File path of the private key file, or None if encryption is not enabled
 
         Raises
         ------


### PR DESCRIPTION
… an encrypted collaboration

I also checked if we needed to change error messages in the client in case encryption was not setup when using an encrypted collaboration. This was not the case: encryption setup is only required when creating a task or reading the results. When creating a task, the server will return a clear message that input is not encrypted. When reading results, it gives a clear message that encryption is not setup.

Fix #1302 