### PR TITLE
When creating a task, multiple dropdown selection property was not ch…

### DIFF
--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.html
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.html
@@ -79,15 +79,26 @@
               </div>
               <mat-form-field subscriptSizing="dynamic">
                 <mat-label>{{ "task-create.step-function.organization" | translate }}</mat-label>
-                <mat-select
-                  formControlName="organizationIDs"
-                  [compareWith]="compareIDsForSelection"
-                  [multiple]="function.type !== functionType.Central"
-                >
-                  <mat-option *ngFor="let organization of organizations" [value]="organization.id">
-                    {{ organization.name }}
-                  </mat-option>
-                </mat-select>
+                <!--
+                This ugly if-else is required because the 'multiple' property of mat-select
+                cannot be changed after initialization (see e.g.
+                https://stackoverflow.com/questions/51204450/error-cannot-change-multiple-mode-of-select-after-initialization)
+                -->
+                <div *ngIf="function.type === functionType.Central; else partialOrgDropdown">
+                  <mat-select formControlName="organizationIDs" [compareWith]="compareIDsForSelection" [multiple]="false">
+                    <mat-option *ngFor="let organization of organizations" [value]="organization.id">
+                      {{ organization.name }}
+                    </mat-option>
+                  </mat-select>
+                </div>
+                <ng-template #partialOrgDropdown>
+                  <mat-select formControlName="organizationIDs" [compareWith]="compareIDsForSelection" [multiple]="true">
+                    <mat-option *ngFor="let organization of organizations" [value]="organization.id">
+                      {{ organization.name }}
+                    </mat-option>
+                  </mat-select>
+                </ng-template>
+                <!-- End ugly if-else -->
               </mat-form-field>
             </div>
             <app-alert


### PR DESCRIPTION
…anged if function type changed

E.g. when first selection a partial function, you would get a multi-select dropdown for the organizations to create the task for. However, when you then changed your mind and selected a central function, the dropdown did not change to only allow you to select a single organization

This turned out to be so because the multiple property of mat-select cannot be changed after initialization