### PR TITLE
Added setuptools dependency.

### DIFF
--- a/vantage6-common/requirements.txt
+++ b/vantage6-common/requirements.txt
@@ -10,3 +10,4 @@ python-dateutil==2.8.2
 qrcode==7.3.1
 requests==2.32.3
 schema==0.7.5
+setuptools>=67.8.0

--- a/vantage6-common/setup.py
+++ b/vantage6-common/setup.py
@@ -43,6 +43,7 @@ setup(
         "qrcode==7.3.1",
         "requests==2.32.3",
         "schema==0.7.5",
+        "setuptools>=67.8.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
It was not explicitly defined anywhere but this was not encountered because conda (which we recommend) installs it in each env by default

I added the dependency to the `common` package as it will then be included everywhere.