### PR TITLE
Patch eduvpn3 4.7

### DIFF
--- a/vantage6-server/vantage6/server/resource/vpn.py
+++ b/vantage6-server/vantage6/server/resource/vpn.py
@@ -289,6 +289,7 @@ class EduVPNConnector:
             "userName": self.config["portal_username"],
             "userPass": self.config["portal_userpass"],
             "_user_pass_auth_redirect_to": authorize_url,
+            "authRedirectTo": authorize_url
         }
 
         # Referer doesn't matter so much but is a required header

--- a/vantage6-server/vantage6/server/resource/vpn.py
+++ b/vantage6-server/vantage6/server/resource/vpn.py
@@ -289,7 +289,7 @@ class EduVPNConnector:
             "userName": self.config["portal_username"],
             "userPass": self.config["portal_userpass"],
             "_user_pass_auth_redirect_to": authorize_url,
-            "authRedirectTo": authorize_url
+            "authRedirectTo": authorize_url,
         }
 
         # Referer doesn't matter so much but is a required header


### PR DESCRIPTION
Apparently the api for authenticating in eduvpn has changed, so I added another parameter.
I kept the old parameter for backward compatibility and eduvpn doesn't seem to mind.