### PR TITLE
Small changes to running tasks in the UI - and change to default roles

### DIFF
--- a/vantage6-server/vantage6/server/default_roles.py
+++ b/vantage6-server/vantage6/server/default_roles.py
@@ -65,6 +65,7 @@ def get_default_roles(db) -> list[dict]:
         db.Rule.get_by_("run", Scope.COLLABORATION, Operation.VIEW),
         db.Rule.get_by_("port", Scope.ORGANIZATION, Operation.VIEW),
         db.Rule.get_by_("event", Scope.ORGANIZATION, Operation.RECEIVE),
+        db.Rule.get_by_("event", Scope.COLLABORATION, Operation.RECEIVE),
         db.Rule.get_by_("study", Scope.ORGANIZATION, Operation.VIEW),
     ]
     VIEWER_ROLE = {
@@ -121,7 +122,6 @@ def get_default_roles(db) -> list[dict]:
         db.Rule.get_by_("node", Scope.COLLABORATION, Operation.CREATE),
         db.Rule.get_by_("node", Scope.COLLABORATION, Operation.VIEW),
         db.Rule.get_by_("node", Scope.COLLABORATION, Operation.DELETE),
-        db.Rule.get_by_("event", Scope.COLLABORATION, Operation.RECEIVE),
         db.Rule.get_by_("event", Scope.COLLABORATION, Operation.SEND),
         db.Rule.get_by_("study", Scope.COLLABORATION, Operation.VIEW),
         db.Rule.get_by_("study", Scope.COLLABORATION, Operation.CREATE),

--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
@@ -63,6 +63,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
   columns: string[] = [];
   isLoading: boolean = true;
   isLoadingColumns: boolean = false;
+  isSubmitting: boolean = false;
   isTaskRepeat: boolean = false;
   isDataInitialized: boolean = false;
   isNgInitDone: boolean = false;
@@ -267,6 +268,16 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   async handleSubmit(): Promise<void> {
+    if (this.isSubmitting) return;
+    this.isSubmitting = true;
+    try {
+      await this.submitTask();
+    } catch (error) {
+      this.isSubmitting = false;
+    }
+  }
+
+  async submitTask(): Promise<void> {
     if (
       this.studyForm.invalid ||
       this.packageForm.invalid ||

--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
@@ -227,6 +227,8 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
           controls[controls.length - 1].setValue(value);
           isFirst = false;
         }
+      } else if (argument.type === ArgumentType.Boolean) {
+        this.parameterForm.get(parameter.label)?.setValue(parameter.value ? true : false);
       } else {
         this.parameterForm.get(parameter.label)?.setValue(parameter.value);
       }

--- a/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.html
+++ b/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.html
@@ -15,11 +15,12 @@
 </app-page-header>
 <app-alert *ngIf="algorithmNotFoundInStore" label="{{ 'task-read.alert-algorithm-not-found' | translate }}"></app-alert>
 <ng-container *ngIf="!isLoading && task; else loading">
-  <mat-card *ngIf="!isTaskComplete()">
-    <mat-card-header>
-      <mat-card-title>{{ "task-read.card-status.title" | translate }}</mat-card-title>
-    </mat-card-header>
-    <mat-card-content>
+  <mat-card>
+    <mat-expansion-panel [expanded]="!isTaskComplete()">
+      <mat-expansion-panel-header>
+        <mat-panel-title>{{ "task-read.card-status.title" | translate }}</mat-panel-title>
+      </mat-expansion-panel-header>
+      <h3>{{ "task-read.card-status.main-process-title" | translate }}</h3>
       <div class="status-info-container">
         <app-status-info
           *ngFor="let run of task?.runs"
@@ -28,7 +29,7 @@
           nodeName="{{ run.node.name }}"
           [status]="getTaskStatusTranslation(run.status)"
         >
-          <button actions mat-raised-button *ngIf="run.log && isFailedRun(run.status)" (click)="openLog(run.log)">
+          <button actions mat-raised-button *ngIf="run.log" (click)="openLog(run.log)">
             {{ "task-run.show-log" | translate }}
           </button>
           <span actionText *ngIf="run.node.status !== 'online' && isActive(run.status)">{{
@@ -36,12 +37,8 @@
           }}</span>
         </app-status-info>
       </div>
-    </mat-card-content>
-    <div *ngIf="childTasks.length > 0">
-      <mat-card-header>
-        <mat-card-title>{{ "task-read.card-status.child-title" | translate }}</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
+      <div *ngIf="childTasks.length > 0">
+        <h3>{{ "task-read.card-status.child-process-title" | translate }}</h3>
         <div class="status-info-container" *ngFor="let childTask of childTasks">
           <app-status-info
             *ngFor="let run of childTask?.runs"
@@ -50,7 +47,7 @@
             nodeName="{{ run.node.name }}"
             [status]="getTaskStatusTranslation(run.status)"
           >
-            <button actions mat-raised-button *ngIf="run.log && isFailedRun(run.status)" (click)="openLog(run.log)">
+            <button actions mat-raised-button *ngIf="run.log" (click)="openLog(run.log)">
               {{ "task-run.show-log" | translate }}
             </button>
             <span actionText *ngIf="run.node.status !== 'online' && isActive(run.status)">{{
@@ -58,13 +55,13 @@
             }}</span>
           </app-status-info>
         </div>
-      </mat-card-content>
-    </div>
-    <mat-card-actions *ngIf="canKill && isActive(task.status)">
-      <button mat-flat-button color="warn" (click)="handleTaskKill()">
-        {{ "task-read.card-status.actions.kill" | translate }}
-      </button>
-    </mat-card-actions>
+      </div>
+      <mat-card-actions *ngIf="canKill && isActive(task.status)">
+        <button mat-flat-button color="warn" (click)="handleTaskKill()">
+          {{ "task-read.card-status.actions.kill" | translate }}
+        </button>
+      </mat-card-actions>
+    </mat-expansion-panel>
   </mat-card>
   <mat-card *ngIf="!isLoading && task.results && task.results.length > 0">
     <mat-card-header>

--- a/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.ts
@@ -287,7 +287,14 @@ export class TaskReadComponent implements OnInit, OnDestroy {
     }
   }
 
+  private async waitUntilInitialized(): Promise<void> {
+    while (this.isLoading) {
+      await new Promise((f) => setTimeout(f, 200));
+    }
+  }
+
   private async onAlgorithmStatusUpdate(statusUpdate: AlgorithmStatusChangeMsg): Promise<void> {
+    await this.waitUntilInitialized();
     // Update status of child tasks
     this.childTasks.forEach((task: BaseTask) => {
       if (task.id === statusUpdate.task_id) {
@@ -359,6 +366,7 @@ export class TaskReadComponent implements OnInit, OnDestroy {
   }
 
   private async onNewTask(newTaskMsg: NewTaskMsg): Promise<void> {
+    await this.waitUntilInitialized();
     if (!this.task) return;
     if (newTaskMsg.parent_id !== this.task.id) return;
 
@@ -367,6 +375,7 @@ export class TaskReadComponent implements OnInit, OnDestroy {
   }
 
   private async onNodeStatusUpdate(nodeStatus: NodeOnlineStatusMsg): Promise<void> {
+    await this.waitUntilInitialized();
     // first update the child tasks
     this.childTasks.forEach((task: BaseTask) => {
       task.runs.forEach((run: TaskRun) => {

--- a/vantage6-ui/src/assets/localizations/en.json
+++ b/vantage6-ui/src/assets/localizations/en.json
@@ -171,8 +171,9 @@
       "title": "General"
     },
     "card-status": {
-      "title": "Main process",
-      "child-title": "Child processes",
+      "title": "Status",
+      "main-process-title": "Main process",
+      "child-process-title": "Child processes",
       "task-name": "Name:",
       "node-name": "Node:",
       "actions": {

--- a/vantage6-ui/src/environments/environment.development.ts
+++ b/vantage6-ui/src/environments/environment.development.ts
@@ -4,7 +4,7 @@ const env: EnvironmentConfig = {
   production: false,
   // server_url: 'https://cotopaxi.vantage6.ai',
   // api_path: ''
-  server_url: 'http://localhost:5000',
+  server_url: 'http://localhost:7601',
   api_path: '/api'
 };
 


### PR DESCRIPTION
Server:
- add rule 'view events on collaboration scope' to all default roles. Without this, they cannot receive socket events such as algorithm updates and node statuses for other nodes in their collaboration, which is very inconvenient and leads e.g. to tasks hanging in 'pending' in the UI (fix #1478)

UI:
- extra check to prevent racing condition to prevent that task status updates get stuck on read task page (other part fix #1478)
- fix for repeating task with boolean values: set them by default to false
- Prevent that users can submit the task multiple times on create task page if it doesn't respond quick enough
- keep task status (folded) when task is finished, fix #1445
- also show log file on successfully completed algorithm runs, fix #1472