### PR TITLE
Fix add already whitelisted server to store

### DIFF
--- a/vantage6-algorithm-store/tests_store/resources/test_v6server.py
+++ b/vantage6-algorithm-store/tests_store/resources/test_v6server.py
@@ -135,7 +135,7 @@ class TestVantage6ServerResource(TestResources):
 
         # if we try this again it should fail
         response = self.app.post("/api/vantage6-server", headers=HEADERS, json=body_)
-        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        self.assertEqual(response.status_code, HTTPStatus.ALREADY_REPORTED)
 
         # check that whitelisting localhost servers cannot be done with default policy
         policy.delete()

--- a/vantage6-algorithm-store/vantage6/algorithm/store/resource/vantage6_server.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/resource/vantage6_server.py
@@ -230,7 +230,7 @@ class Vantage6Servers(AlgorithmStoreResources):
             return {
                 "msg": "This server is already whitelisted in this algorithm store "
                 "instance."
-            }, HTTPStatus.FORBIDDEN
+            }, HTTPStatus.ALREADY_REPORTED
 
         # the user that is whitelisting the server should be able to delete it
         # in the future. Assign the server manager role to the user executing this

--- a/vantage6-server/vantage6/server/algo_store_communication.py
+++ b/vantage6-server/vantage6/server/algo_store_communication.py
@@ -106,7 +106,7 @@ def post_algorithm_store(
             # whitelist it as it will not be able to do anything with the store - return
             # the error message from the algorithm store
             return response, status
-    elif status != HTTPStatus.CREATED:
+    elif status not in [HTTPStatus.CREATED, HTTPStatus.ALREADY_REPORTED]:
         # return error
         return response, status
 


### PR DESCRIPTION
Fixes #1460 

When adding a store to the server, the store tried to whitelist the server. In case the server was already whitelisted, an error was returned and the store could not be added. 
The case in which an already whitelisted server tries to be whitelisted again returns a different response. In this way, the server is not added twice to the db, but the process is not blocked.