### PR TITLE
Add additional filter for collaboration when study is used

### DIFF
--- a/vantage6-server/vantage6/server/resource/node.py
+++ b/vantage6-server/vantage6/server/resource/node.py
@@ -270,7 +270,9 @@ class Nodes(NodeBase):
                 q.join(db.Organization)
                 .join(db.StudyMember)
                 .join(db.Study)
+                .join(db.Collaboration)
                 .filter(db.Study.id == study_id)
+                .filter(db.Node.collaboration_id == study.collaboration_id)
             )
 
         for param in ["status", "ip"]:


### PR DESCRIPTION
The filter for studies selected all organizations from that study and displayed **all** nodes from these organizations. I added a filter to only select those that are also part of the collaboration.

I tested it in a local environment.