### PR TITLE
Bugfix/UI/proper display pd tojson tables

### DIFF
--- a/vantage6-ui/src/app/components/visualization/visualize-table/visualize-table.component.ts
+++ b/vantage6-ui/src/app/components/visualization/visualize-table/visualize-table.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { isNested } from 'src/app/helpers/utils.helper';
 import { parseDefaultPandasFormat } from 'src/app/helpers/visualization.helper';
 import { Visualization } from 'src/app/models/api/visualization.model';
@@ -21,7 +22,10 @@ export class VisualizeTableComponent implements OnChanges {
   name?: string;
   description?: string;
 
-  constructor(private fileService: FileService) {}
+  constructor(
+    private fileService: FileService,
+    private translateService: TranslateService
+  ) {}
 
   ngOnChanges(): void {
     // if the result is found at a key, use that key. E.g. if the result is { data: [1, 2, 3] },
@@ -54,7 +58,7 @@ export class VisualizeTableComponent implements OnChanges {
     if (this.schemaDefinesColumns()) {
       columns = this.visualization?.schema.columns as string[];
     }
-    const parsedData = parseDefaultPandasFormat(tableData, columns);
+    const parsedData = parseDefaultPandasFormat(tableData, this.translateService.instant('general.parameter'), columns);
     this.columns = parsedData.columns;
     this.rows = parsedData.rows;
   }

--- a/vantage6-ui/src/app/helpers/visualization.helper.ts
+++ b/vantage6-ui/src/app/helpers/visualization.helper.ts
@@ -1,17 +1,31 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function parseDefaultPandasFormat(df: { [key: string]: any[] }, columns: string[] | null): { columns: string[]; rows: any } {
+export function parseDefaultPandasFormat(
+  df: { [key: string]: any[] },
+  parameterTxt: string,
+  columns: string[] | null
+): { columns: string[]; rows: any[] } {
   if (!columns) {
     columns = Object.keys(df);
   }
-  const rows = [];
-  for (let i = 0; i < Object.keys(Object.values(df)[0]).length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const indices = Object.keys(Object.values(df)[0]);
+  const rows: any = [];
+  // if the indices are not simply numbers, add them as first row
+  const indices_are_numbers: boolean = indices[0] !== '0';
+  if (indices_are_numbers) {
+    // add extra column for indices
+    columns = [parameterTxt, ...columns];
+  }
+  indices.forEach((index: any) => {
     const row: any = {};
     for (const column of columns) {
-      row[column] = df[column][i] as string;
+      if (column === parameterTxt) {
+        row[parameterTxt] = index;
+      } else {
+        row[column] = df[column][index] as string;
+      }
     }
     rows.push(row);
-  }
+  });
   return { columns: columns, rows: rows };
 }
 

--- a/vantage6-ui/src/app/helpers/visualization.helper.ts
+++ b/vantage6-ui/src/app/helpers/visualization.helper.ts
@@ -9,9 +9,12 @@ export function parseDefaultPandasFormat(
   }
   const indices = Object.keys(Object.values(df)[0]);
   const rows: any = [];
-  // if the indices are not simply numbers, add them as first row
-  const indices_are_numbers: boolean = indices[0] !== '0';
-  if (indices_are_numbers) {
+  // If the indices of the Pandas data frame are simply numbers starting at zero, do not
+  // add them as first column. Indices as 0, 1, 2... are the default indices, and are
+  // not interesting to display. However, if the indices are something like 'sum',
+  // 'mean', 'std', etc., then they are interesting and should be displayed as a column.
+  const pandasIndicesAreNumbers: boolean = indices[0] !== '0';
+  if (pandasIndicesAreNumbers) {
     // add extra column for indices
     columns = [parameterTxt, ...columns];
   }

--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
@@ -426,6 +426,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
       !this.shouldShowParameterBooleanInput(argument)
     );
   }
+
   shouldIncludeFormField(argument: Argument): boolean {
     return !this.shouldShowParameterBooleanInput(argument) && !this.shouldShowMultipleInput(argument);
   }

--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
@@ -63,6 +63,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
   columns: string[] = [];
   isLoading: boolean = true;
   isLoadingColumns: boolean = false;
+  hasLoadedColumns: boolean = false;
   isSubmitting: boolean = false;
   isTaskRepeat: boolean = false;
   isDataInitialized: boolean = false;
@@ -415,6 +416,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
       this.columns = task.results?.[0].decoded_result || JSON.parse('');
     }
     this.isLoadingColumns = false;
+    this.hasLoadedColumns = true;
   }
 
   shouldShowParameterSimpleInput(argument: Argument): boolean {
@@ -433,7 +435,7 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
       argument.type === this.argumentType.IntegerList ||
       argument.type === this.argumentType.FloatList ||
       argument.type === this.argumentType.StringList ||
-      (argument.type === this.argumentType.ColumnList && this.columns.length === 0)
+      (argument.type === this.argumentType.ColumnList && this.columns.length === 0 && this.hasLoadedColumns)
     );
   }
 

--- a/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.ts
@@ -128,7 +128,11 @@ export class TaskReadComponent implements OnInit, OnDestroy {
         const store = await this.algorithmStoreService.getAlgorithmStore(this.task.algorithm_store?.id.toString());
         this.algorithm = await this.algorithmService.getAlgorithmByUrl(this.task.image, store);
         this.function = this.algorithm?.functions.find((_) => _.name === this.task?.input?.method) || null;
-        this.selectedVisualization = this.function?.ui_visualizations?.[0] || null;
+        if (!this.selectedVisualization) {
+          // by checking in if statement whether visualization was already set, we prevent
+          // the visualization from being reset to the first one when the task is reloaded
+          this.selectedVisualization = this.function?.ui_visualizations?.[0] || null;
+        }
       } else {
         this.algorithmNotFoundInStore = true;
       }

--- a/vantage6-ui/src/assets/localizations/en.json
+++ b/vantage6-ui/src/assets/localizations/en.json
@@ -19,7 +19,8 @@
     "description": "Description",
     "overview": "Overview",
     "file-select": "Select file",
-    "unknown": "Unknown"
+    "unknown": "Unknown",
+    "parameter": "Parameter"
   },
   "resources": {
     "collaboration": "Collaboration",


### PR DESCRIPTION
This makes visualization of tables in the UI more stable, as it will also visualize tables in case you have a specifically named index of your pandas data frame in the Python algorithm.

Also, there is a small fix in resetting visualizations in the last commit, which probably fixes #1511 - that was probably an issue that task was still being loaded while user switched visualization, and then when task finishes loading, it changes back but does not reset the visualization dropdown.

Finally, notice that this PR also includes the commits of #1522 - so we can drop that one and review only this one, or do that one first