### PR TITLE
Added functionality to mount folders (as databases)

### DIFF
--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -90,6 +90,13 @@ databases:
       cdm_schema: public
       results_schema: results
 
+  # For folder mounts, directory on the host will be mounted under /mnt/<label>.
+  # In the example below, the folder `/path/to/share/with/container` will be
+  # made available as `/mnt/persistent`. The folder will be mounted read/write.
+  - label: persistent
+    type: folder
+    uri: /path/to/share/with/container
+
 
 # end-to-end encryption settings
 encryption:

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -201,8 +201,12 @@ class DockerManager(DockerBaseManager):
                 uri = db_config["uri"]
 
             if running_in_docker():
-                db_is_file = Path(f"/mnt/{uri}").exists() and Path(f"/mnt/{uri}").is_file()
-                db_is_dir = Path(f"/mnt/{uri}").exists() and Path(f"/mnt/{uri}").is_dir()
+                db_is_file = (
+                    Path(f"/mnt/{uri}").exists() and Path(f"/mnt/{uri}").is_file()
+                )
+                db_is_dir = (
+                    Path(f"/mnt/{uri}").exists() and Path(f"/mnt/{uri}").is_dir()
+                )
 
                 if db_is_file:
                     uri = f"/mnt/{uri}"

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -444,10 +444,9 @@ class DockerTaskManager(DockerBaseManager):
         }
 
         for db_label, db in self.databases.items():
-
-            if db['is_dir']:
+            if db["is_dir"]:
                 self.log.debug(f"Adding folder as database '{db_label}'")
-                volumes[db['uri']] = {"bind": f"/mnt/{db_label}", "mode": "rw"}
+                volumes[db["uri"]] = {"bind": f"/mnt/{db_label}", "mode": "rw"}
 
         if running_in_docker():
             volumes[self.data_volume_name] = {"bind": self.data_folder, "mode": "rw"}

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -447,10 +447,7 @@ class DockerTaskManager(DockerBaseManager):
 
             if db['is_dir']:
                 self.log.debug(f"Adding folder as database '{db_label}'")
-                volumes[db['uri']] = {
-                    "bind": f"/mnt/{db_label}",
-                    "mode": "rw"
-                }
+                volumes[db['uri']] = {"bind": f"/mnt/{db_label}", "mode": "rw"}
 
         if running_in_docker():
             volumes[self.data_volume_name] = {"bind": self.data_folder, "mode": "rw"}

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -443,10 +443,20 @@ class DockerTaskManager(DockerBaseManager):
             tmp_vol_name: {"bind": self.tmp_folder, "mode": "rw"},
         }
 
+        for db_label, db in self.databases.items():
+
+            if db['is_dir']:
+                self.log.debug(f"Adding folder as database '{db_label}'")
+                volumes[db['uri']] = {
+                    "bind": f"/mnt/{db_label}",
+                    "mode": "rw"
+                }
+
         if running_in_docker():
             volumes[self.data_volume_name] = {"bind": self.data_folder, "mode": "rw"}
         else:
             volumes[self.__tasks_dir] = {"bind": self.data_folder, "mode": "rw"}
+
         return volumes
 
     def _setup_environment_vars(


### PR DESCRIPTION
Folders can be used for permanent storage between runs (e.g. caching). This is particularly useful when using duckdb. 

Adding functionality to support read-only mounts should be trivial.