### PR TITLE
Prevent warning about port 443 as insecure whitelisted port because c…

### DIFF
--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -64,7 +64,7 @@ class NodePolicy(str, Enum):
     REQUIRE_ALGORITHM_PULL = "require_algorithm_pull"
 
 
-class Ports(str, Enum):
+class Ports(int, Enum):
 
     HTTP = 80
     HTTPS = 443


### PR DESCRIPTION
…omparison between str and int failed - enum is now int-baseclassed which is more correct

I checked the code to see where this Enum was used but I don't think this change will lead to issues there (it will sooner solve bugs we didn't find yet) 