### PR TITLE
Updated docs dependencies. Main reason is to fix issues with sphinx a…

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,9 +5,9 @@
 -r ../vantage6/requirements.txt
 -r ../vantage6-node/requirements.txt
 -r ../vantage6-server/requirements.txt
-sphinx==5.3.0
+sphinx==8.1.3
 sphinx-autobuild
 sphinx-autodoc-typehints
-sphinx-click==4.4.0
+sphinx-click
 sphinxcontrib-plantuml
-furo==2022.12.7
+furo


### PR DESCRIPTION
…utosummary generation

One more thing I'd like to slip into 4.8. This will prevent the endless loop we sometimes got stuck in when running `make devdocs` on a different branch (and anyway we hadn't updated these in a over 2 years so we should)