### PR TITLE
Flag in Makefile to disable function docs locally by default, because…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,20 @@ BASE ?= 4.0
 # Use `make PUSH_REG=true` to push images to registry after building
 PUSH_REG ?= false
 
-
 # We use a conditional (true on any non-empty string) later. To avoid
 # accidents, we don't use user-controlled PUSH_REG directly.
 # See: https://www.gnu.org/software/make/manual/html_node/Conditional-Functions.html
 _condition_push :=
 ifeq ($(PUSH_REG), true)
 	_condition_push := not_empty_so_true
+endif
+
+# Use `make devdocs FUNCTIONDOCS=true` to build the function documentation
+FUNCTIONDOCS ?= false
+
+_autosummary_flags := --define autosummary_generate=0
+ifeq ($(FUNCTIONDOCS), true)
+	_autosummary_flags :=
 endif
 
 help:
@@ -264,4 +271,4 @@ test:
 # Note that the value of the envvar does not matter, just that it is set.
 devdocs: export READTHEDOCS = Yes
 devdocs:
-	sphinx-autobuild docs docs/_build/html --watch .
+	sphinx-autobuild docs docs/_build/html --watch . ${_autosummary_flags}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@ sys.path.insert(0, os.path.abspath("../vantage6-algorithm-tools"))
 sys.path.insert(0, os.path.abspath("../vantage6-common"))
 sys.path.insert(0, os.path.abspath("../vantage6-backend-common"))
 
-
 # -- Project information -----------------------------------------------------
 
 project = "vantage6"

--- a/docs/devops/documentation.rst
+++ b/docs/devops/documentation.rst
@@ -24,11 +24,24 @@ commands:
 
 ::
 
+    # install requirements to run documentation (only required once)
     pip install -r docs/requirements.txt
+
+    # run documentation interactively
+    make devdocs
+    # or alternatively, if you don't have make
     sphinx-autobuild docs docs/_build/html --watch .
 
-Of course, you only have to install the requirements if you had not done so
-before.
+Then, you can access the documentation on ``http://127.0.0.1:8000``. The ``--watch``
+option makes sure that if you make changes to either the documentation text or the
+docstrings, the documentation pages will also be reloaded.
+
+.. note::
+
+    The command ``make devdocs`` does *not* build the function documentation by default,
+    because building that interactively is slow. If you need to build the function
+    documentation locally, you can do so by either running ``make html`` or
+    ``make devdocs FUNCTIONDOCS=true``.
 
 .. note::
 
@@ -37,11 +50,6 @@ before.
     `install Java <https://www.java.com/en/download/help/download_options.html>`_.
     PlantUML itself is included in the Python requirements, so you do not have to
     install it separately.
-
-Then you can access the documentation on ``http://127.0.0.1:8000``. The
-``--watch`` option makes sure that if you make changes to either the
-documentation text or the docstrings, the documentation pages will also be
-reloaded.
 
 This documentation is automatically built and published on a commit (on
 certain branches, including ``main``). Both Frank and Bart have access to the


### PR DESCRIPTION
… they are too slow to build

I *think* these changes should not impact the builds by readthedocs because those don't use the `make` commands (right?!)