### PR TITLE
Handle error when user is not registered in algorithm store

### DIFF
--- a/vantage6-ui/src/app/services/api.service.ts
+++ b/vantage6-ui/src/app/services/api.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse, HttpResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpResponse, HttpStatusCode } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, first } from 'rxjs';
 import { ACCESS_TOKEN_KEY } from 'src/app/models/constants/sessionStorage';
@@ -190,7 +190,7 @@ export class ApiService {
           resolve(response as T);
         },
         (error) => {
-          if (error.status !== 401) {
+          if (error.status !== HttpStatusCode.Unauthorized && error.status !== HttpStatusCode.Forbidden) {
             const errorMsg = this.getErrorMsg(error);
             this.snackBarService.showMessage(errorMsg);
           }


### PR DESCRIPTION
When going to algorithm store management pages, and user is not registered in a store, checking their permission gives a 403. This was not caught properly leading to an error message in the UI - while everything was functional as they are not allowed to change anything but maybe see algorithms. Now the error is caught