### PR TITLE
For arguments that are a list of str/int/float, one form control was …

### DIFF
--- a/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/create/task-create.component.ts
@@ -515,7 +515,8 @@ export class TaskCreateComponent implements OnInit, OnDestroy, AfterViewInit {
 
   getFormArrayControls(argument: Argument) {
     if ((this.parameterForm.get(argument.name) as FormArray).controls === undefined) {
-      this.parameterForm.setControl(argument.name, this.fb.array([this.getNewControlForInputList(argument)]));
+      const initialControl = argument.has_default_value ? [] : [this.getNewControlForInputList(argument)];
+      this.parameterForm.setControl(argument.name, this.fb.array(initialControl));
     }
     return (this.parameterForm.get(argument.name) as FormArray).controls;
   }


### PR DESCRIPTION
…always generated even if they had a default value available. This obligated the user to still fill in something. Now, this control is removed