### PR TITLE
Add results_cleanup_days option to server

### DIFF
--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -124,6 +124,9 @@ refresh_token_expires_hours: 48
 # Careful! Make sure you have regular backups of your database before enabling
 # this feature, as a wrong configuration could lead to data loss.
 results_cleanup_days: 30
+# the cleanup worker will also delete the input of the runs if this is set to
+# true. False by default.
+results_cleanup_include_input: false
 
 # If you have a server with a high workload, it is recommended to use
 # multiple server instances (horizontal scaling). If you do so, you also

--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -123,10 +123,10 @@ refresh_token_expires_hours: 48
 # older than the number of days specified here. Disabled by default.
 # Careful! Make sure you have regular backups of your database before enabling
 # this feature, as a wrong configuration could lead to data loss.
-results_cleanup_days: 30
+runs_data_cleanup_days: 30
 # the cleanup worker will also delete the input of the runs if this is set to
 # true. False by default.
-results_cleanup_include_input: false
+runs_data_cleanup_include_input: false
 
 # If you have a server with a high workload, it is recommended to use
 # multiple server instances (horizontal scaling). If you do so, you also

--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -119,6 +119,12 @@ email_token_validity_minutes: 60
 token_expires_hours: 6
 refresh_token_expires_hours: 48
 
+# a worker will run every hour and delete results from completed runs that are
+# older than the number of days specified here. Disabled by default.
+# Careful! Make sure you have regular backups of your database before enabling
+# this feature, as a wrong configuration could lead to data loss.
+results_cleanup_days: 30
+
 # If you have a server with a high workload, it is recommended to use
 # multiple server instances (horizontal scaling). If you do so, you also
 # need to set up a RabbitMQ message service to ensure that the communication

--- a/vantage6-server/tests_server/test_cleanup.py
+++ b/vantage6-server/tests_server/test_cleanup.py
@@ -1,0 +1,173 @@
+import unittest
+
+from datetime import datetime, timedelta, timezone
+
+from vantage6.server.model.run import Run
+from vantage6.server.model.base import Database, DatabaseSessionManager
+from vantage6.server.controller import cleanup
+from vantage6.common.task_status import TaskStatus
+
+
+class TestCleanupRunsIsolated(unittest.TestCase):
+    def setUp(self):
+        Database().connect("sqlite://", allow_drop_all=True)
+        self.session = DatabaseSessionManager.get_session()
+
+    def tearDown(self):
+        # clear_data() will clear session too
+        Database().clear_data()
+
+    def test_cleanup_completed_old_run(self):
+        # Eligible: completed > 30 days ago
+        run = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=31),
+            result="result",
+            input="input",
+            log="log should be preserved",
+            status=TaskStatus.COMPLETED,
+        )
+        self.session.add(run)
+        self.session.commit()
+
+        cleanup.cleanup_runs_data(30, include_input=True)
+        self.session.refresh(run)
+        self.assertEqual(run.result, "")
+        self.assertEqual(run.input, "")
+        self.assertEqual(run.log, "log should be preserved")
+        self.assertIsNotNone(run.cleanup_at)
+
+    def test_no_cleanup_recent_completed_run(self):
+        # Ineligible: completed, but not old enough
+        run = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=10),
+            result="result",
+            input="input",
+            status=TaskStatus.COMPLETED,
+        )
+        self.session.add(run)
+        self.session.commit()
+
+        cleanup.cleanup_runs_data(30, include_input=True)
+        self.session.refresh(run)
+        self.assertEqual(run.result, "result")
+        self.assertEqual(run.input, "input")
+        self.assertIsNone(run.cleanup_at)
+
+    def test_no_cleanup_non_completed_run(self):
+        # Ineligible: not COMPLETED, albeit old enough
+        run = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=31),
+            result="result",
+            input="input",
+            status=TaskStatus.FAILED,  # Not COMPLETED, so ineligible
+        )
+        self.session.add(run)
+        self.session.commit()
+
+        cleanup.cleanup_runs_data(30, include_input=True)
+        self.session.refresh(run)
+        self.assertEqual(run.result, "result")
+        self.assertEqual(run.input, "input")
+        self.assertIsNone(run.cleanup_at)
+
+    def test_cleanup_without_clearing_input(self):
+        # Eligible: completed > 30 days ago
+        run = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=40),
+            result="result",
+            input="input",
+            status=TaskStatus.COMPLETED,
+        )
+        self.session.add(run)
+        self.session.commit()
+
+        cleanup.cleanup_runs_data(30, include_input=False)
+        self.session.refresh(run)
+        self.assertEqual(run.result, "")
+        self.assertEqual(run.input, "input")
+        self.assertIsNotNone(run.cleanup_at)
+
+
+# Test cleanup_results()' handling of multiple runs
+class TestCleanupRunsCount(unittest.TestCase):
+    def setUp(self):
+        Database().connect("sqlite://", allow_drop_all=True)
+        self.session = DatabaseSessionManager.get_session()
+
+    def tearDown(self):
+        # clear_data() will clear session too
+        Database().clear_data()
+
+    def create_runs(self):
+        run0 = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=31),
+            result="result0",
+            input="input0",
+            status=TaskStatus.COMPLETED,
+        )
+        run1 = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=200),
+            result="result1",
+            input="input1",
+            status=TaskStatus.COMPLETED,
+        )
+        run2 = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=10),
+            result="result2",
+            input="input2",
+            status=TaskStatus.COMPLETED,
+        )
+        run3 = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=10),
+            result="result3",
+            input="input3",
+            status=TaskStatus.PENDING,
+        )
+        run4 = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=31),
+            result="result4",
+            input="input4",
+            status=TaskStatus.FAILED,
+        )
+        run5 = Run(
+            finished_at=datetime.now(timezone.utc) - timedelta(days=10),
+            result="result5",
+            input="input5",
+            status=TaskStatus.ACTIVE,
+        )
+        self.session.add_all([run0, run1, run2, run3, run4, run5])
+        self.session.commit()
+
+        return run0, run1, run2, run3, run4, run5
+
+    def test_cleanup_runs_count(self):
+        # Insert runs into db
+        runs = self.create_runs()
+
+        # clean up result and input from runs older than 30 days
+        cleanup.cleanup_runs_data(30, include_input=True)
+
+        # db has been changed, refresh objects
+        for run in runs:
+            self.session.refresh(run)
+
+        # Query the DB to get cleaned up and non-cleaned up runs
+        cleaned_runs = self.session.query(Run).filter(Run.cleanup_at != None).all()
+        remaining_runs = self.session.query(Run).filter(Run.cleanup_at == None).all()
+
+        # We expect only run0 and run1 to have been cleaned up
+        self.assertEqual(len(cleaned_runs), 2)
+        self.assertEqual(len(remaining_runs), 4)
+
+        # Verify that cleaned runs have their result and input cleared, and
+        # cleanup_at set
+        for run in cleaned_runs:
+            self.assertEqual(run.result, "")
+            self.assertEqual(run.input, "")
+            self.assertIsNotNone(run.cleanup_at)
+
+        # Verify that runs that should not have been cleaned up keep their
+        # result and input
+        for i in range(2, 6):
+            self.assertEqual(runs[i].result, f"result{i}")
+            self.assertEqual(runs[i].input, f"input{i}")

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -820,6 +820,9 @@ class ServerApp:
 
     def __runs_data_cleanup_worker(self):
         """Start a background thread to clean up data from old Runs."""
+        # NOTE/TODO: this is a very simple implementation, horizonal scaling is
+        # not being taken into account. We'd probably only need one worker per
+        # database, not per server instance (for example).
         include_input = self.ctx.config.get("runs_data_cleanup_include_input", False)
         while True:
             try:

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -821,7 +821,10 @@ class ServerApp:
     def __results_cleanup_worker(self):
         """Start a background thread to clean up old tasks."""
         while True:
-            cleanup.cleanup_results(self.ctx.config.get("results_cleanup_days"))
+            try:
+                cleanup.cleanup_results(self.ctx.config.get("results_cleanup_days"))
+            except:
+                log.error("Results cleanup failed. Will try again in one hour.")
             # simple for now: check every hour
             time.sleep(3600)
 

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -171,12 +171,12 @@ class ServerApp:
         # set the server version
         self.__version__ = __version__
 
-        if self.ctx.config.get("results_cleanup_days"):
+        if self.ctx.config.get("runs_data_cleanup_days"):
             log.info(
                 "Results older than %s days will be removed",
-                self.ctx.config.get("results_cleanup_days"),
+                self.ctx.config.get("runs_data_cleanup_days"),
             )
-            t_cleanup = Thread(target=self.__results_cleanup_worker, daemon=True)
+            t_cleanup = Thread(target=self.__runs_data_cleanup_worker, daemon=True)
             t_cleanup.start()
 
         # set up socket ping/pong
@@ -818,13 +818,13 @@ class ServerApp:
                 log.exception("Node-status thread had an exception")
                 time.sleep(PING_INTERVAL_SECONDS)
 
-    def __results_cleanup_worker(self):
-        """Start a background thread to clean up old tasks."""
-        include_input = self.ctx.config.get("results_cleanup_include_input", False)
+    def __runs_data_cleanup_worker(self):
+        """Start a background thread to clean up data from old Runs."""
+        include_input = self.ctx.config.get("runs_data_cleanup_include_input", False)
         while True:
             try:
-                cleanup.cleanup_results(
-                    self.ctx.config.get("results_cleanup_days"),
+                cleanup.cleanup_runs_data(
+                    self.ctx.config.get("runs_data_cleanup_days"),
                     include_input=include_input,
                 )
             except:

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -830,8 +830,9 @@ class ServerApp:
                     self.ctx.config.get("runs_data_cleanup_days"),
                     include_input=include_input,
                 )
-            except:
+            except Exception as e:
                 log.error("Results cleanup failed. Will try again in one hour.")
+                log.exception(e)
             # simple for now: check every hour
             time.sleep(3600)
 

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -820,9 +820,13 @@ class ServerApp:
 
     def __results_cleanup_worker(self):
         """Start a background thread to clean up old tasks."""
+        include_input = self.ctx.config.get("results_cleanup_include_input", False)
         while True:
             try:
-                cleanup.cleanup_results(self.ctx.config.get("results_cleanup_days"))
+                cleanup.cleanup_results(
+                    self.ctx.config.get("results_cleanup_days"),
+                    include_input=include_input,
+                )
             except:
                 log.error("Results cleanup failed. Will try again in one hour.")
             # simple for now: check every hour

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -24,7 +24,7 @@ def cleanup_runs_data(days: int, include_input: bool = False):
     session = DatabaseSessionManager.get_session()
 
     if not days or days < 1:
-        log.warning("Invalid number of days specified. No cleanup will be performed.")
+        log.warning("Invalid number of days '%s' specified. No cleanup will be performed.", days)
         return
 
     try:

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -10,7 +10,7 @@ module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 
 
-def cleanup_results(days: int, include_input: bool = False):
+def cleanup_runs_data(days: int, include_input: bool = False):
     """
     Clear the `result` and (optionally) `input` field for `Run` instances older
     than the specified number of days.

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -1,7 +1,10 @@
+import logging
+
+from datetime import datetime, timedelta, timezone
+
+from vantage6.common.task_status import TaskStatus
 from vantage6.server.model import Run
 from vantage6.server.model.base import DatabaseSessionManager
-from datetime import datetime, timedelta, timezone
-import logging
 
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
@@ -28,7 +31,11 @@ def cleanup_results(days: int, include_input: bool = False):
         with session.begin():
             runs = (
                 session.query(Run)
-                .filter(Run.finished_at < threshold_date, Run.cleanup_at == None)
+                .filter(
+                    Run.finished_at < threshold_date,
+                    Run.cleanup_at == None,
+                    Run.status == TaskStatus.COMPLETED,
+                )
                 .all()
             )
             for run in runs:

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -7,9 +7,10 @@ module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 
 
-def cleanup_results(days: int):
+def cleanup_results(days: int, include_input: bool = False):
     """
-    Clear the `result` field for `Run` instances older than the specified number of days.
+    Clear the `result` and (optionally) `input` field for `Run` instances older
+    than the specified number of days.
 
     Parameters
     ----------
@@ -32,6 +33,8 @@ def cleanup_results(days: int):
             )
             for run in runs:
                 run.result = ""
+                if include_input:
+                    run.input = ""
                 run.cleanup_at = datetime.now(timezone.utc)
                 log.info(f"Cleared result for Run ID {run.id}.")
 

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -25,9 +25,14 @@ def cleanup_results(days: int):
 
     try:
         with session.begin():
-            runs = session.query(Run).filter(Run.finished_at < threshold_date).all()
+            runs = (
+                session.query(Run)
+                .filter(Run.finished_at < threshold_date, Run.cleanup_at == None)
+                .all()
+            )
             for run in runs:
                 run.result = ""
+                run.cleanup_at = datetime.now(timezone.utc)
                 log.info(f"Cleared result for Run ID {run.id}.")
 
         log.info(

--- a/vantage6-server/vantage6/server/controller/cleanup.py
+++ b/vantage6-server/vantage6/server/controller/cleanup.py
@@ -1,0 +1,38 @@
+from vantage6.server.model import Run
+from vantage6.server.model.base import DatabaseSessionManager
+from datetime import datetime, timedelta, timezone
+import logging
+
+module_name = __name__.split(".")[-1]
+log = logging.getLogger(module_name)
+
+
+def cleanup_results(days: int):
+    """
+    Clear the `result` field for `Run` instances older than the specified number of days.
+
+    Parameters
+    ----------
+    days : int
+        The number of days after which results should be cleared.
+    """
+    threshold_date = datetime.now(timezone.utc) - timedelta(days=days)
+    session = DatabaseSessionManager.get_session()
+
+    if not days or days < 1:
+        log.warning("Invalid number of days specified. No cleanup will be performed.")
+        return
+
+    try:
+        with session.begin():
+            runs = session.query(Run).filter(Run.finished_at < threshold_date).all()
+            for run in runs:
+                run.result = ""
+                log.info(f"Cleared result for Run ID {run.id}.")
+
+        log.info(
+            "Cleanup job completed successfully, deleted %d old run results.", len(runs)
+        )
+    except Exception as e:
+        log.error(f"Failed to cleanup old run results: {e}")
+        raise

--- a/vantage6-server/vantage6/server/model/run.py
+++ b/vantage6-server/vantage6/server/model/run.py
@@ -37,6 +37,8 @@ class Run(Base):
         Time when the task was started
     finished_at : datetime
         Time when the task was finished
+    cleanup_at : datetime
+        Time when the results where deleted as part of a cleanup
     status : str
         Status of the task
     log : str
@@ -59,6 +61,7 @@ class Run(Base):
     finished_at = Column(DateTime)
     status = Column(Text)
     log = Column(Text)
+    cleanup_at = Column(DateTime, nullable=True)
 
     # relationships
     task = relationship("Task", back_populates="runs")

--- a/vantage6-server/vantage6/server/model/run.py
+++ b/vantage6-server/vantage6/server/model/run.py
@@ -38,7 +38,7 @@ class Run(Base):
     finished_at : datetime
         Time when the task was finished
     cleanup_at : datetime
-        Time when the results where deleted as part of a cleanup
+        Time when the results were deleted as part of a cleanup
     status : str
         Status of the task
     log : str

--- a/vantage6-server/vantage6/server/model/task.py
+++ b/vantage6-server/vantage6/server/model/task.py
@@ -105,7 +105,7 @@ class Task(Base):
         """
         return (
             max([r.finished_at for r in self.results])
-            if self.complete and self.results
+            if self.status == TaskStatus.COMPLETED.value and self.results
             else None
         )
 

--- a/vantage6/vantage6/cli/configuration_manager.py
+++ b/vantage6/vantage6/cli/configuration_manager.py
@@ -29,6 +29,7 @@ class ServerConfiguration(Configuration):
         "allow_drop_all": Use(bool),
         "logging": {**LOGGING_VALIDATORS, "file": Use(str)},
         Optional("server_name"): str,
+        Optional("results_cleanup_days"): Use(int),
     }
 
 

--- a/vantage6/vantage6/cli/configuration_manager.py
+++ b/vantage6/vantage6/cli/configuration_manager.py
@@ -29,7 +29,7 @@ class ServerConfiguration(Configuration):
         "allow_drop_all": Use(bool),
         "logging": {**LOGGING_VALIDATORS, "file": Use(str)},
         Optional("server_name"): str,
-        Optional("results_cleanup_days"): Use(int),
+        Optional("runs_data_cleanup_days"): Use(int),
     }
 
 


### PR DESCRIPTION
Server-enforced policy to delete results older than a certain number of days.

I opted for "clearing" results field instead of deleting tasks. For audibility purposes we might want to keep task logs and other metadata. I'm assuming here 'results' is where the potentially sensitive data might exist that a server admin might not want to keep indefinitely.
 
I considered celery, schedule, apscheduler, etc. but I don't think this feature is worth adding more dependencies and complexity — feature is disabled by default, and kept very simple for now.

A `lifetime` parameter (as mentioned https://github.com/vantage6/vantage6/issues/1560) can still fit with these changes in the future. However, this PR is coming from the perspective of the server administrator / collaboration policy, not a researcher's request for deletion. A collaboration of nodes might agree on "we don't want our results to be kept for more than X days", even if a researcher asks for a higher number of days. But perhaps this can be made configurable in the future.
