### PR TITLE
Catch errors when refreshing node client's token so that the thread t…

### DIFF
--- a/vantage6-common/vantage6/common/client/node_client.py
+++ b/vantage6-common/vantage6/common/client/node_client.py
@@ -80,7 +80,12 @@ class NodeClient(ClientBase):
                 "exp"
             ]
             time_until_expiry = expiry_time - time.time()
-            if time_until_expiry < NODE_CLIENT_REFRESH_BEFORE_EXPIRES_SECONDS:
+            if time_until_expiry < 0:
+                self.log.error(
+                    "Token and refresh token have expired. Please restart the node!"
+                )
+                return
+            elif time_until_expiry < NODE_CLIENT_REFRESH_BEFORE_EXPIRES_SECONDS:
                 try:
                     self.refresh_token()
                 except Exception as e:

--- a/vantage6-common/vantage6/common/client/node_client.py
+++ b/vantage6-common/vantage6/common/client/node_client.py
@@ -81,7 +81,14 @@ class NodeClient(ClientBase):
             ]
             time_until_expiry = expiry_time - time.time()
             if time_until_expiry < NODE_CLIENT_REFRESH_BEFORE_EXPIRES_SECONDS:
-                self.refresh_token()
+                try:
+                    self.refresh_token()
+                except Exception as e:
+                    self.log.error("Refreshing token failed: %s", e)
+                    # sleep for a bit and then try again. The server might be
+                    # unreachable or internet connection down. We sleep so long that
+                    # we should have about 20 attempts before the token expires.
+                    time.sleep(NODE_CLIENT_REFRESH_BEFORE_EXPIRES_SECONDS / 20)
             else:
                 time.sleep(
                     int(


### PR DESCRIPTION
…o refresh the token doesn't crash

Note that this was introduced in v3.8 when refresh tokens got a limited validity (https://github.com/vantage6/vantage6/commit/bd0edc010ed54df8e9ed68bf42c39deb2fd2a0b0)

I want to release this in 4.9.1 together with a few other fixes.