### PR TITLE
Add path to sphinx configuration file explicitly to the read the docs…

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,10 +8,14 @@ build:
   apt_packages:
     - default-jdk
     - graphviz
-  
+
 python:
   install:
     - requirements: docs/requirements.txt
+
+sphinx:
+  # Path to Sphinx configuration file.
+  configuration: docs/conf.py
 
 # Build the docs in all formats (html, pdf, epub, etc.)
 formats: all


### PR DESCRIPTION
… yaml configuration file

Not doing so was deprecated, causing our readthedocs build to fail. See https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/ for details