### PR TITLE
Change/hide subtasks task list

### DIFF
--- a/vantage6-ui/src/app/pages/analyze/task/list/task-list.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/list/task-list.component.ts
@@ -79,7 +79,6 @@ export class TaskListComponent implements OnInit, OnDestroy {
     this.currentPage = e.pageIndex + 1;
     const parameters: GetTaskParameters = { sort: TaskSortProperties.ID, is_user_created: 1 };
     if (this.currentSearchInput?.length) {
-      delete parameters.is_user_created;
       parameters.name = this.currentSearchInput;
     }
     await this.getTasks(this.currentPage, parameters);
@@ -89,8 +88,8 @@ export class TaskListComponent implements OnInit, OnDestroy {
     this.isLoading = true;
     const parameters: GetTaskParameters = getApiSearchParameters<GetTaskParameters>(searchRequests);
     this.currentSearchInput = parameters?.name ?? '';
-    if (!parameters?.name?.length) parameters.is_user_created = 1;
     this.paginator?.firstPage();
+    parameters.is_user_created = 1;
     this.initData(1, parameters);
   }
 


### PR DESCRIPTION
Fix #1547 - instead of a prefix, we decided just to leave subtasks entirely out of the task list in the UI as users are unlikely interested in them