### PR TITLE
Remove client.node.get() from algorithm client and mock algorithm client

### DIFF
--- a/vantage6-algorithm-tools/vantage6/algorithm/client/__init__.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/client/__init__.py
@@ -627,23 +627,6 @@ class AlgorithmClient(ClientBase):
             """
             return self.parent.request(f"collaboration/{self.parent.collaboration_id}")
 
-    class Node(ClientBase.SubClient):
-        """
-        Get information about the node.
-        """
-
-        def get(self) -> dict:
-            """
-            Get the node data.
-
-            Returns
-            -------
-            dict
-                Dictionary containing data on the node this algorithm is
-                running on.
-            """
-            return self.parent.request(f"node/{self.parent.node_id}")
-
     class Study(ClientBase.SubClient):
         """
         Get information about the study or studies.

--- a/vantage6-algorithm-tools/vantage6/algorithm/tools/mock_client.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/tools/mock_client.py
@@ -542,51 +542,6 @@ class MockAlgorithmClient:
                 "organizations": f"/api/organization?collaboration_id={collab_id}",
             }
 
-    class Node(SubClient):
-        """
-        Node subclient for the MockAlgorithmClient
-        """
-
-        def get(self, is_online: bool = True) -> dict:
-            """
-            Get mocked node
-
-            Parameters
-            ----------
-            is_online : bool
-                Whether the node is online or not. Default True.
-
-            Returns
-            -------
-            dict
-                A mocked node.
-            """
-            node_id = self.parent.node_id
-            collab_id = self.parent.collaboration_id
-            return {
-                "id": node_id,
-                "name": "mock-node",
-                "status": (
-                    AuthStatus.ONLINE.value if is_online else AuthStatus.OFFLINE.value
-                ),
-                "ip": "1.2.3.4",
-                "config": {
-                    "key": "value",
-                },
-                "collaboration": {
-                    "id": collab_id,
-                    "link": f"/api/collaboration/{collab_id}",
-                    "methods": ["DELETE", "PATCH", "GET"],
-                },
-                "last_seen": "2021-01-01T00:00:00.000000",
-                "type": "node",
-                "organization": {
-                    "id": node_id,
-                    "link": f"/api/organization/{node_id}",
-                    "methods": ["GET", "PATCH"],
-                },
-            }
-
     # TODO implement the get_addresses method before using this part
     # class VPN(SubClient):
     #     """


### PR DESCRIPTION
Containers do not have permission to get node details so the algorithm client function always yielded an error. Users should use the client.organization.get() as those IDs have to be provided for new tasks. Functions have now been removed to avoid confusion and more of these errors