### PR TITLE
fix: accessing the log before creating it on container_manager

### DIFF
--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -59,7 +59,7 @@ class ContainerManager:
         ----------
         ctx: NodeContext
             Context object from which some settings are obtained
-        """        
+        """
         self.log = logging.getLogger(logger_name(__name__))
         self.log.debug("Initializing ContainerManager")
         self.ctx = ctx

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -59,10 +59,9 @@ class ContainerManager:
         ----------
         ctx: NodeContext
             Context object from which some settings are obtained
-        """
-        self.log.debug("Initializing ContainerManager")
-
+        """        
         self.log = logging.getLogger(logger_name(__name__))
+        self.log.debug("Initializing ContainerManager")
         self.ctx = ctx
         self.client = client
 


### PR DESCRIPTION
Just a simple fix to an error that was making the node crash.