### PR TITLE
[k8s] Fixing dev environment issues

### DIFF
--- a/charts/node/templates/node-deployment.yml
+++ b/charts/node/templates/node-deployment.yml
@@ -17,6 +17,12 @@ spec:
 {{ include "node.labels" . | indent 8 }}
         component: node
     spec:
+
+      hostAliases:      
+      - ip: "172.17.0.1" # Default bridge network gateway for docker/k8s
+        hostnames:
+        - "host.docker.internal" # Defining it explicitly for environments where Docker is not installed
+
       containers:
       - name: vantage6-node
         image: {{ .Values.node.image }}

--- a/charts/server/templates/ui/ui-deployment.yml
+++ b/charts/server/templates/ui/ui-deployment.yml
@@ -27,4 +27,4 @@ spec:
         - name: SERVER_URL
           value: {{ .Values.server.baseUrl | quote }}
         - name: API_PATH
-          value: /api
+          value: /server

--- a/dev/load-basic-fixtures.py
+++ b/dev/load-basic-fixtures.py
@@ -97,6 +97,7 @@ else:
             "port": 7601,
             "server_url": "http://host.docker.internal",
             "task_dir": "/tasks",
+            "api_path": "/server",
             # TODO user defined config
         }
     )
@@ -119,6 +120,7 @@ else:
             "port": 7601,
             "server_url": "http://host.docker.internal",
             "task_dir": "/tasks",
+            "api_path": "/server",
             # TODO user defined config
         }
     )

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -13,6 +13,8 @@ vars:
   KUBE_CONFIG:
     question: "Where is your kube config from k8s located?"
     default: ~/.kube/config
+  #set to 0.0.0.0 to make the dev environment (ui, api) accessible from outside
+  PORTS_BIND_ADDRESS: "127.0.0.1" 
 
 pipelines:
 
@@ -124,7 +126,7 @@ deployments:
           logging:
             level: DEBUG
           vantage6Server:
-            uri: http://host.docker.internal:7601/api
+            uri: http://host.docker.internal:7601/server
           policies:
             allowLocalhost: 'True'
 
@@ -179,6 +181,7 @@ dev:
     imageSelector: ${SERVER_IMAGE}
     ports:
       - port: 7601:7601
+        bindAddress: ${PORTS_BIND_ADDRESS}
 
   # We use this to enable the server and the store to be coupled. We need a port to talk
   # to as the ingress is not deployed yet.
@@ -186,11 +189,13 @@ dev:
     imageSelector: ${STORE_IMAGE}
     ports:
       - port: 7602:7602
+        bindAddress: ${PORTS_BIND_ADDRESS}
 
   vantage6-store:
     imageSelector: ${STORE_IMAGE}
     ports:
       - port: 7602:7602
+        bindAddress: ${PORTS_BIND_ADDRESS}
 
     sync:
     - path: ./vantage6/:/vantage6/vantage6/
@@ -224,6 +229,7 @@ dev:
       - command: kubectl
     ports:
       - port: 7601:7601
+        bindAddress: ${PORTS_BIND_ADDRESS}
     logs:
       enabled: true
 
@@ -233,6 +239,7 @@ dev:
     imageSelector: ${UI_IMAGE}
     ports:
       - port: 7600:80
+        bindAddress: ${PORTS_BIND_ADDRESS}
 
   # Where as we could hot-reload the server code using wsgi, we cannot do this with the
   # node code. We leverage the `restartHelper` and `onUpload.restartContainer` to

--- a/vantage6/vantage6/cli/template/node_config.j2
+++ b/vantage6/vantage6/cli/template/node_config.j2
@@ -1,5 +1,5 @@
 api_key: {{ api_key }}
-api_path: /api
+api_path: {{ api_path }}
 databases:
   {% for label, path in databases.items() %}
   - label: {{ label }}


### PR DESCRIPTION
Hi @frankcorneliusmartin and @bartvanb 

Today I've been working on the last version of the integrated codebase and have fixed a couple of details that were making my dev environment fail. In particular, for your consideration:

- In some parts, the server API Path was set as /server, and in others as /api. I made changes to make these names consistent. This also required changing the node's jinja template, as it had the api_path hard coded as '/api'. @bartvanb I guess this may cause a conflict with the config-generation tools, so please let me know what you think.

- In some host configurations (like mine) the name `host.docker.internal` is not properly resolved. This name is now used across many points within the devspace environment so changing (e.g. to `172.17.0.1`) it is difficult and error-prone. I included a workaround to no longer need to change it: The node POD will now always be able to resolve it to 172.17.0.1 regardless of the docker configuration in the host, as it is now configured on the POD's hostAliases.

- I'm running devspace on my home Linux server, and was expecting to use the UI/API from my Laptop (my dev environment is VS code connected to this server). However, devspace launches services bind only to 127.0.0.1 by default. I included a variable in the devspace config file to change this easily.

Now everything works for me except the algorithm store (I'm still looking into it), but at least I can now work on the other networking stuff. I leave the PR open so you can check this out. Please let me know what you think.


