### PR TITLE
Fixing race condition when initializing server and store postgresSQL instances

### DIFF
--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -53,7 +53,7 @@ database:
   name: vantage6
 
   #hostpath of the database mount
-  volumePath: /mnt/data
+  volumePath: /mnt/data_server
 
 ui:
 

--- a/charts/store/values.yaml
+++ b/charts/store/values.yaml
@@ -33,4 +33,4 @@ database:
   name: store
 
   #hostpath of the database mount
-  volumePath: /mnt/data
+  volumePath: /mnt/data_store

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -113,7 +113,7 @@ deployments:
             secret: development-constant-secret!
 
         database:
-          volumePath: /mnt/data
+          volumePath: /mnt/data_server
 
   # The store deployment contains the store and the database.
   vantage6-store:
@@ -142,7 +142,7 @@ deployments:
         #  users can probably use the same path as in the example below. Or any other
         #  path that is accessible by the Docker daemon.
         database:
-          volumePath: /mnt/data
+          volumePath: /mnt/data_store
 
   # The node deployment should not be 'deployed' only, it should only be deployed in
   # combination with the `dev` container (The node container that is started by the


### PR DESCRIPTION
I observed that sometimes either the V6-Server database or the Store database is not initialized. According to the logs, this initialization is skipped due to an existing datafile. After that, there were errors of the type 'vantage6' / 'store' database doesn't exist.

I think this is because both PSQL services were using the same data file. I created separate ones for each one and haven't seen these errors back.
