### PR TITLE
Use enum value instead of enum object in places where strings are int…

### DIFF
--- a/vantage6-common/vantage6/common/client/node_client.py
+++ b/vantage6-common/vantage6/common/client/node_client.py
@@ -59,7 +59,7 @@ class NodeClient(ClientBase):
         organization_name = organization.get("name")
 
         self.whoami = WhoAmI(
-            type_=InstanceType.NODE,
+            type_=InstanceType.NODE.value,
             id_=id_,
             name=name,
             organization_id=organization_id,

--- a/vantage6/tests_cli/test_server_cli.py
+++ b/vantage6/tests_cli/test_server_cli.py
@@ -132,7 +132,7 @@ class ServerCLITest(unittest.TestCase):
         """Stop server without errors."""
 
         container1 = MagicMock()
-        container1.name = f"{APPNAME}-iknl-system-{InstanceType.SERVER}"
+        container1.name = f"{APPNAME}-iknl-system-{InstanceType.SERVER.value}"
         containers.containers.list.return_value = [container1]
 
         runner = CliRunner()
@@ -146,7 +146,7 @@ class ServerCLITest(unittest.TestCase):
     def test_attach(self, containers, sleep):
         """Attach log to the console without errors."""
         container1 = MagicMock()
-        container1.name = f"{APPNAME}-iknl-system-{InstanceType.SERVER}"
+        container1.name = f"{APPNAME}-iknl-system-{InstanceType.SERVER.value}"
         containers.list.return_value = [container1]
 
         sleep.side_effect = KeyboardInterrupt("Boom!")

--- a/vantage6/vantage6/cli/algostore/attach.py
+++ b/vantage6/vantage6/cli/algostore/attach.py
@@ -25,7 +25,7 @@ def cli_algo_store_attach(name: str, system_folders: bool) -> None:
     client = docker.from_env()
 
     running_servers = client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.ALGORITHM_STORE}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.ALGORITHM_STORE.value}"}
     )
     running_server_names = [container.name for container in running_servers]
 
@@ -40,7 +40,7 @@ def cli_algo_store_attach(name: str, system_folders: bool) -> None:
             return
     else:
         post_fix = "system" if system_folders else "user"
-        name = f"{APPNAME}-{name}-{post_fix}-{InstanceType.ALGORITHM_STORE}"
+        name = f"{APPNAME}-{name}-{post_fix}-{InstanceType.ALGORITHM_STORE.value}"
 
     if name in running_server_names:
         container = client.containers.get(name)

--- a/vantage6/vantage6/cli/algostore/list.py
+++ b/vantage6/vantage6/cli/algostore/list.py
@@ -12,4 +12,4 @@ def cli_algo_store_configuration_list() -> None:
     """
     check_docker_running()
 
-    get_server_configuration_list(InstanceType.ALGORITHM_STORE)
+    get_server_configuration_list(InstanceType.ALGORITHM_STORE.value)

--- a/vantage6/vantage6/cli/algostore/start.py
+++ b/vantage6/vantage6/cli/algostore/start.py
@@ -54,7 +54,7 @@ def cli_algo_store_start(
     Start the algorithm store server.
     """
     info("Starting algorithm store...")
-    docker_client = check_for_start(ctx, InstanceType.ALGORITHM_STORE)
+    docker_client = check_for_start(ctx, InstanceType.ALGORITHM_STORE.value)
 
     image = get_image(image, ctx, "algorithm-store", DEFAULT_ALGO_STORE_IMAGE)
 
@@ -91,7 +91,7 @@ def cli_algo_store_start(
         mounts=mounts,
         detach=True,
         labels={
-            f"{APPNAME}-type": InstanceType.ALGORITHM_STORE,
+            f"{APPNAME}-type": InstanceType.ALGORITHM_STORE.value,
             "name": ctx.config_file_name,
         },
         environment=environment_vars,

--- a/vantage6/vantage6/cli/algostore/stop.py
+++ b/vantage6/vantage6/cli/algostore/stop.py
@@ -23,7 +23,7 @@ def cli_algo_store_stop(ctx: AlgorithmStoreContext, all_stores: bool):
     client = docker.from_env()
 
     running_stores = client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.ALGORITHM_STORE}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.ALGORITHM_STORE.value}"}
     )
 
     if not running_stores:

--- a/vantage6/vantage6/cli/common/utils.py
+++ b/vantage6/vantage6/cli/common/utils.py
@@ -1,3 +1,4 @@
+import enum
 import questionary as q
 from colorama import Fore, Style
 import click
@@ -87,7 +88,11 @@ def get_server_configuration_list(instance_type: InstanceType.SERVER) -> None:
     client = docker.from_env()
     ctx_class = select_context_class(instance_type)
 
-    running_server_names = get_running_servers(client, instance_type)
+    instance_type_value = (
+        instance_type.value if isinstance(instance_type, enum.Enum) else instance_type
+    )
+
+    running_server_names = get_running_servers(client, instance_type_value)
     header = "\nName" + (21 * " ") + "Status" + (10 * " ") + "System/User"
 
     click.echo(header)
@@ -101,7 +106,8 @@ def get_server_configuration_list(instance_type: InstanceType.SERVER) -> None:
     for config in configs:
         status = (
             running
-            if f"{APPNAME}-{config.name}-system-{instance_type}" in running_server_names
+            if f"{APPNAME}-{config.name}-system-{instance_type_value}"
+            in running_server_names
             else stopped
         )
         click.echo(f"{config.name:25}" f"{status:25} System ")
@@ -111,7 +117,8 @@ def get_server_configuration_list(instance_type: InstanceType.SERVER) -> None:
     for config in configs:
         status = (
             running
-            if f"{APPNAME}-{config.name}-user-{instance_type}" in running_server_names
+            if f"{APPNAME}-{config.name}-user-{instance_type_value}"
+            in running_server_names
             else stopped
         )
         click.echo(f"{config.name:25}" f"{status:25} User   ")

--- a/vantage6/vantage6/cli/context/algorithm_store.py
+++ b/vantage6/vantage6/cli/context/algorithm_store.py
@@ -53,7 +53,7 @@ class AlgorithmStoreContext(BaseServerContext):
         str
             Server's docker container name
         """
-        return f"{APPNAME}-{self.name}-{self.scope}-{ServerType.ALGORITHM_STORE}"
+        return f"{APPNAME}-{self.name}-{self.scope}-{ServerType.ALGORITHM_STORE.value}"
 
     @classmethod
     def from_external_config_file(

--- a/vantage6/vantage6/cli/context/node.py
+++ b/vantage6/vantage6/cli/context/node.py
@@ -132,7 +132,7 @@ class NodeContext(AppContext):
         Path
             Path to the data folder
         """
-        return AppContext.type_data_folder(InstanceType.NODE, system_folders)
+        return AppContext.type_data_folder(InstanceType.NODE.value, system_folders)
 
     @property
     def databases(self) -> dict:

--- a/vantage6/vantage6/cli/dev/remove.py
+++ b/vantage6/vantage6/cli/dev/remove.py
@@ -40,10 +40,10 @@ def remove_demo_network(
     # check that the server is not running
     client = docker.from_env()
     running_servers = client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.SERVER}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.SERVER.value}"}
     )
     running_server_names = [server.name for server in running_servers]
-    container_name = f"{APPNAME}-{name}-user-{InstanceType.SERVER}"
+    container_name = f"{APPNAME}-{name}-user-{InstanceType.SERVER.value}"
     if container_name in running_server_names:
         error(
             f"Server {Fore.RED}{name}{Style.RESET_ALL} is still running! First stop "

--- a/vantage6/vantage6/cli/node/common/__init__.py
+++ b/vantage6/vantage6/cli/node/common/__init__.py
@@ -130,6 +130,6 @@ def find_running_node_names(client: docker.DockerClient) -> list[str]:
         List of names of running nodes
     """
     running_nodes = client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.NODE}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.NODE.value}"}
     )
     return [node.name for node in running_nodes]

--- a/vantage6/vantage6/cli/node/start.py
+++ b/vantage6/vantage6/cli/node/start.py
@@ -78,7 +78,7 @@ def cli_node_start(
 
     # check that this node is not already running
     running_nodes = docker_client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.NODE}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.NODE.value}"}
     )
 
     suffix = "system" if system_folders else "user"
@@ -306,7 +306,7 @@ def cli_node_start(
         volumes=volumes,
         detach=True,
         labels={
-            f"{APPNAME}-type": InstanceType.NODE,
+            f"{APPNAME}-type": InstanceType.NODE.value,
             "system": str(system_folders),
             "name": ctx.config_file_name,
         },

--- a/vantage6/vantage6/cli/server/attach.py
+++ b/vantage6/vantage6/cli/server/attach.py
@@ -29,7 +29,7 @@ def cli_server_attach(name: str, system_folders: bool) -> None:
     client = docker.from_env()
 
     running_servers = client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.SERVER}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.SERVER.value}"}
     )
     running_server_names = [node.name for node in running_servers]
 
@@ -43,7 +43,7 @@ def cli_server_attach(name: str, system_folders: bool) -> None:
             return
     else:
         post_fix = "system" if system_folders else "user"
-        name = f"{APPNAME}-{name}-{post_fix}-{InstanceType.SERVER}"
+        name = f"{APPNAME}-{name}-{post_fix}-{InstanceType.SERVER.value}"
 
     if name in running_server_names:
         container = client.containers.get(name)

--- a/vantage6/vantage6/cli/server/import_.py
+++ b/vantage6/vantage6/cli/server/import_.py
@@ -132,7 +132,10 @@ def cli_server_import(
         command=cmd,
         mounts=mounts,
         detach=True,
-        labels={f"{APPNAME}-type": InstanceType.SERVER, "name": ctx.config_file_name},
+        labels={
+            f"{APPNAME}-type": InstanceType.SERVER.value,
+            "name": ctx.config_file_name,
+        },
         environment=environment_vars,
         auto_remove=not keep,
         tty=True,

--- a/vantage6/vantage6/cli/server/list.py
+++ b/vantage6/vantage6/cli/server/list.py
@@ -12,4 +12,4 @@ def cli_server_configuration_list() -> None:
     """
     check_docker_running()
 
-    get_server_configuration_list(InstanceType.SERVER)
+    get_server_configuration_list(InstanceType.SERVER.value)

--- a/vantage6/vantage6/cli/server/shell.py
+++ b/vantage6/vantage6/cli/server/shell.py
@@ -28,7 +28,7 @@ def cli_server_shell(ctx: ServerContext) -> None:
     docker_client = docker.from_env()
 
     running_servers = docker_client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.SERVER}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.SERVER.value}"}
     )
 
     if ctx.docker_container_name not in [s.name for s in running_servers]:

--- a/vantage6/vantage6/cli/server/start.py
+++ b/vantage6/vantage6/cli/server/start.py
@@ -83,7 +83,7 @@ def cli_server_start(
     Start the server.
     """
     info("Starting server...")
-    docker_client = check_for_start(ctx, InstanceType.SERVER)
+    docker_client = check_for_start(ctx, InstanceType.SERVER.value)
 
     image = get_image(image, ctx, "server", DEFAULT_SERVER_IMAGE)
 
@@ -157,7 +157,10 @@ def cli_server_start(
         command=cmd,
         mounts=mounts,
         detach=True,
-        labels={f"{APPNAME}-type": InstanceType.SERVER, "name": ctx.config_file_name},
+        labels={
+            f"{APPNAME}-type": InstanceType.SERVER.value,
+            "name": ctx.config_file_name,
+        },
         environment=environment_vars,
         ports={f"{internal_port}/tcp": (ip, port_)},
         name=ctx.docker_container_name,

--- a/vantage6/vantage6/cli/server/stop.py
+++ b/vantage6/vantage6/cli/server/stop.py
@@ -37,7 +37,7 @@ def cli_server_stop(name: str, system_folders: bool, all_servers: bool):
     client = docker.from_env()
 
     running_servers = client.containers.list(
-        filters={"label": f"{APPNAME}-type={InstanceType.SERVER}"}
+        filters={"label": f"{APPNAME}-type={InstanceType.SERVER.value}"}
     )
 
     if not running_servers:
@@ -62,7 +62,7 @@ def cli_server_stop(name: str, system_folders: bool, all_servers: bool):
             return
     else:
         post_fix = "system" if system_folders else "user"
-        container_name = f"{APPNAME}-{name}-{post_fix}-{InstanceType.SERVER}"
+        container_name = f"{APPNAME}-{name}-{post_fix}-{InstanceType.SERVER.value}"
 
     if container_name not in running_server_names:
         error(f"{Fore.RED}{name}{Style.RESET_ALL} is not running!")

--- a/vantage6/vantage6/cli/server/version.py
+++ b/vantage6/vantage6/cli/server/version.py
@@ -22,10 +22,10 @@ def cli_server_version(name: str, system_folders: bool) -> None:
     check_docker_running()
     client = docker.from_env()
 
-    running_server_names = get_running_servers(client, InstanceType.SERVER)
+    running_server_names = get_running_servers(client, InstanceType.SERVER.value)
 
     name = get_server_name(
-        name, system_folders, running_server_names, InstanceType.SERVER
+        name, system_folders, running_server_names, InstanceType.SERVER.value
     )
 
     if name in running_server_names:


### PR DESCRIPTION
…erpolated

Not doing this led to errors in python 3.11 - which we would encounter anyway when updating python version in v5 so I fixed it now