### PR TITLE
Feature/#1680 settable k8s task namespace

### DIFF
--- a/charts/node/templates/node-configmap.yml
+++ b/charts/node/templates/node-configmap.yml
@@ -43,3 +43,4 @@ data:
       - level: warning
         name: docker.auth
     task_dir: {{ .Values.node.taskDirHost }}
+    task_namespace: {{ .Values.node.taskNamespace }}

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -30,5 +30,7 @@ node:
       uri: postgres://vantage6:vantage6@vantage6-vantage6-postgres:5432/vantage6
       type: other
 
+  # Kubernetes configuration
   kubeConfig: /root/.kube/config
+  taskNamespace: vantage6-tasks
 

--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -22,6 +22,8 @@ DEFAULT_UI_IMAGE = f"infrastructure/ui:{MAIN_VERSION_NAME}"
 
 DEFAULT_ALGO_STORE_IMAGE = f"infrastructure/algorithm-store:{MAIN_VERSION_NAME}"
 
+DEFAULT_ALPINE_IMAGE = f"{DEFAULT_DOCKER_REGISTRY}/infrastructure/alpine:latest"
+
 #
 #   COMMON GLOBALS
 #

--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -22,7 +22,7 @@ DEFAULT_UI_IMAGE = f"infrastructure/ui:{MAIN_VERSION_NAME}"
 
 DEFAULT_ALGO_STORE_IMAGE = f"infrastructure/algorithm-store:{MAIN_VERSION_NAME}"
 
-DEFAULT_ALPINE_IMAGE = f"{DEFAULT_DOCKER_REGISTRY}/infrastructure/alpine:latest"
+DEFAULT_ALPINE_IMAGE = "infrastructure/alpine:latest"
 
 #
 #   COMMON GLOBALS

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -222,7 +222,6 @@ class Node:
         task_results = self.client.run.list(
             state=TaskStatusQueryOptions.OPEN.value, include_task=True
         )
-        self.log.debug("task_results: %s", task_results)
 
         # add the tasks to the queue
         self.__add_tasks_to_queue(task_results)
@@ -442,7 +441,8 @@ class Node:
                     data={
                         "result": results.data,
                         # TODO (HC) check if only logs[0] are enough
-                        "log": results.logs[0],
+                        # TODO include logs
+                        # "log": results.logs[0],
                         "status": results.status,
                         "finished_at": datetime.datetime.now().isoformat(),
                     },

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -105,6 +105,14 @@ class Node:
 
         self.k8s_container_manager = ContainerManager(self.ctx, self.client)
 
+        # ensure that the namespace to create tasks in is set up correctly or try to
+        # create it
+        self.log.debug("Ensuring that the task namespace is properly configured")
+        namespace_created = self.k8s_container_manager.ensure_task_namespace()
+        if not namespace_created:
+            self.log.error("Could not create the task namespace. Exiting.")
+            exit(1)
+
         self.log.info(f"Connecting server: {self.client.base_path}")
 
         # Authenticate with the server, obtaining a JSON Web Token.

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -440,9 +440,7 @@ class Node:
                     id_=results.run_id,
                     data={
                         "result": results.data,
-                        # TODO (HC) check if only logs[0] are enough
-                        # TODO include logs
-                        # "log": results.logs[0],
+                        "log": results.logs,
                         "status": results.status,
                         "finished_at": datetime.datetime.now().isoformat(),
                     },

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -16,6 +16,7 @@ from vantage6.cli.context.node import NodeContext
 from vantage6.common import logger_name, get_database_config
 from vantage6.common.globals import (
     DEFAULT_ALPINE_IMAGE,
+    DEFAULT_DOCKER_REGISTRY,
     NodePolicy,
     ContainerEnvNames,
     STRING_ENCODING,
@@ -149,7 +150,9 @@ class ContainerManager:
                                 # TODO ensure image is an image that can always be
                                 # pulled by the node
                                 name="test-container",
-                                image=DEFAULT_ALPINE_IMAGE,
+                                image=(
+                                    f"{DEFAULT_DOCKER_REGISTRY}/{DEFAULT_ALPINE_IMAGE}"
+                                ),
                             )
                         ]
                     ),
@@ -1078,7 +1081,7 @@ class ContainerManager:
             # Get all jobs from the task namespace for this node
             jobs = self.batch_api.list_namespaced_job(self.task_namespace)
             if not jobs.items:
-                time.sleep(10)
+                time.sleep(1)
                 continue
 
             # Create a list of failed or succeeded jobs

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -377,6 +377,8 @@ class ContainerManager:
                 "action": str(action.value),
                 "session_id": str(session_id),
                 "df_name": df_details.get("name") if df_details else "",
+                "df_id": str(df_details.get("id")) if df_details else "",
+                "df_label": df_details.get("label") if df_details else "",
             },
         )
 
@@ -826,7 +828,6 @@ class ContainerManager:
             )
             ok = False
 
-        self.log.debug(self.databases.keys())
         if source_database["label"] not in self.databases.keys():
             self.log.error(
                 "The database used in the data extraction step does not exist."
@@ -1076,7 +1077,6 @@ class ContainerManager:
 
             # Get all jobs from the task namespace for this node
             jobs = self.batch_api.list_namespaced_job(self.task_namespace)
-            self.log.debug(jobs)
             if not jobs.items:
                 time.sleep(10)
                 continue

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -1113,10 +1113,13 @@ class ContainerManager:
                     )
                     logs = ["error while getting logs"]
 
+                # logs are saved as string instead of list[str]
+                logs = "\n".join(logs)
+
                 self.log.info(
-                    f"Sending results of run_id={run_io.run_id} "
-                    f"and task_id={job.metadata.annotations['task_id']} back to the "
-                    "server"
+                    "Sending results of run_id=%s and task_id=%s back to the server",
+                    run_io.run_id,
+                    job.metadata.annotations["task_id"],
                 )
 
                 result = Result(

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -1057,7 +1057,7 @@ class ContainerManager:
         """
         pods = self.core_api.list_namespaced_pod(
             namespace=self.task_namespace,
-            label_selector=label,
+            label_selector=f"app={label}",
         )
         return True if pods.items else False
 

--- a/vantage6-node/vantage6/node/k8s/run_io.py
+++ b/vantage6-node/vantage6/node/k8s/run_io.py
@@ -49,9 +49,9 @@ class RunIO:
         self.run_id = run_id
         self.session_id = session_id
         self.action = action
-        self.df_name = dataframe_details["name"] if dataframe_details else None
-        self.df_id = dataframe_details["id"] if dataframe_details else None
-        self.db_label = dataframe_details["db_label"] if dataframe_details else None
+        self.df_name = dataframe_details.get("name") if dataframe_details else None
+        self.df_id = dataframe_details.get("id") if dataframe_details else None
+        self.db_label = dataframe_details.get("db_label") if dataframe_details else None
         self.client = client
 
         # The directory where the data is stored
@@ -85,9 +85,11 @@ class RunIO:
             run_id=int(data["run_id"]),
             session_id=int(data["session_id"]),
             action=AlgorithmStepType(data["action"]),
-            dataframe_details=(
-                data["dataframe_details"] if "dataframe_details" in data else None
-            ),
+            dataframe_details={
+                "name": data.get("df_name"),
+                "id": data.get("df_id"),
+                "db_label": data.get("df_label"),
+            },
             host_data_dir=host_data_dir,
             client=client,
         )
@@ -250,7 +252,9 @@ class RunIO:
         if not self.df_name:
             self.log.error(
                 "A session task was started without a dataframe. The session ID "
-                f"is {self.session_id} and the run ID is {self.run_id}.",
+                "is %s and the run ID is %s.",
+                self.session_id,
+                self.run_id,
             )
             return RunStatus.FAILED
 
@@ -279,7 +283,7 @@ class RunIO:
             {"name": field.name, "dtype": str(field.type)} for field in table.schema
         ]
         self.client.request(
-            f"/session/{self.session_id}/dataframe/{self.df_id}",
+            f"/session/dataframe/{self.df_id}",
             method="post",
             json=columns_info,
         )

--- a/vantage6/vantage6/cli/context/node.py
+++ b/vantage6/vantage6/cli/context/node.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import os.path
 
 from pathlib import Path
 
 from vantage6.common.context import AppContext
-from vantage6.common.globals import APPNAME, InstanceType
+from vantage6.common.globals import APPNAME, STRING_ENCODING, InstanceType
 from vantage6.cli.configuration_manager import NodeConfigurationManager
 from vantage6.cli.globals import DEFAULT_NODE_SYSTEM_FOLDERS as N_FOL
 from vantage6.cli._version import __version__
@@ -51,6 +52,7 @@ class NodeContext(AppContext):
         )
         if print_log_header:
             self.log.info("vantage6 version '%s'", __version__)
+        self.identifier = self.__create_node_identifier()
 
     @classmethod
     def from_external_config_file(
@@ -247,3 +249,16 @@ class NodeContext(AppContext):
             URI to the database
         """
         return self.config["databases"][label]
+
+    def __create_node_identifier(self) -> str:
+        """
+        Create a unique identifier for the node.
+
+        Returns
+        -------
+        str
+            Unique identifier for the node
+        """
+        return hashlib.sha256(
+            self.config.get("api_key").encode(STRING_ENCODING)
+        ).hexdigest()[:16]


### PR DESCRIPTION
Main feats: 
- settable task namespace
- extraction tasks produce a parquet file

What needs to be changed, is that logs from extraction tasks are currently not saved to the server: there is still a bug in that so it's disabled