### PR TITLE
Fix duplicated node logging in v5 dev env

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -289,7 +289,7 @@ dev:
     restartHelper:
       inject: true
 
-    command: ["python", "/vantage6/vantage6-node/vantage6/dev_start.py", "/mnt/config/"]
+    command: ["bash", "/vantage6/vantage6-node/dev_start.sh", "/mnt/config/"]
 
 
 
@@ -325,12 +325,3 @@ commands:
   rebuild:
     description: "Rebuild all images for this project"
     command: devspace build
-
-
-# Define dependencies to other projects with a devspace.yaml
-# dependencies:
-#   api:
-#     git: https://...  # Git-based dependencies
-#     tag: v1.0.0
-#   ui:
-#     path: ./ui        # Path-based dependencies (for monorepos)

--- a/vantage6-node/dev_start.sh
+++ b/vantage6-node/dev_start.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# start a node for each config file the provided directory
+
+config_dir=$1
+if [ -z "$config_dir" ]; then
+    echo "Provide a configuration directory as argument"
+    exit 1
+fi
+
+# python_pids=()
+for config in $config_dir/*.yaml; do
+    echo "Starting node with config: $config"
+    python /vantage6/vantage6-node/vantage6/dev_start.py $config &
+    # python_pids+=($!)
+done
+
+# TODO we need to decide what we want to do here. Now I put sleep infinity to keep the
+# node container running. This has the advantage that once the node crashes, the
+# container will keep running and therefore, the error should be most visible in the
+# logs. There is also (commented-out) code to check if a Python process has exited
+# and if so, exit the script with the exit code of the Python process. This will lead
+# to continuous restarts of the node - good for production but also nice for development?
+sleep infinity
+
+# Note: after deciding what to do (see TODO above), we need either to remove this code
+# or to improve it (it's not really readable as it is now)
+# # Function to check if a PID is from a Python process
+# is_python_process() {
+#     local pid=$1
+#     # Check if process exists and is a Python process
+#     if ps -p $pid -o comm= 2>/dev/null | grep -q "python"; then
+#         return 0
+#     else
+#         return 1
+#     fi
+# }
+
+# # Wait for any process to exit
+# while true; do
+#     # Wait for next process to exit and get its PID
+#     wait -n
+#     exit_code=$?
+
+#     # Find which process exited
+#     for pid in "${python_pids[@]}"; do
+#         if ! kill -0 $pid 2>/dev/null; then
+#             # If it was a Python process that exited, exit the script
+#             if is_python_process $pid; then
+#                 echo "Python process $pid exited with code $exit_code"
+#                 exit $exit_code
+#             fi
+#         fi
+#     done
+# done

--- a/vantage6-node/vantage6/dev_start.py
+++ b/vantage6-node/vantage6/dev_start.py
@@ -1,5 +1,4 @@
 import sys
-import threading
 import logging
 from pathlib import Path
 from vantage6.node.context import DockerNodeContext
@@ -23,20 +22,14 @@ def run_function(config):
 
 if __name__ == "__main__":
 
-    config_folder = Path(sys.argv[1]) if len(sys.argv) > 1 else None
-    if not config_folder:
-        log.critical("No config folder provided.")
+    config_file = Path(sys.argv[1]) if len(sys.argv) > 1 else None
+    if not config_file:
+        log.critical("No config file provided.")
         sys.exit(1)
 
-    configs = config_folder.glob("*.yaml")
-    configs = [str(config_path) for config_path in list(configs)]
-    threads = []
+    if not config_file.exists():
+        log.critical("Config file does not exist: %s", config_file)
+        sys.exit(1)
 
-    for config in configs:
-        log.info(f"Starting node with config: {config}")
-        thread = threading.Thread(target=run_function, args=(config,))
-        thread.start()
-        threads.append(thread)
-
-    for thread in threads:
-        thread.join()
+    log.info("Starting node with config: %s", config_file)
+    run_function(config_file)


### PR DESCRIPTION
Logs were duplicated as logs were written in several threads and probably due to logger singletons this led to multiple copies of each log statement