### PR TITLE
Fix branch retrieval in release workflow to use `--points-at` instead o…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         id: branchname
         run: |
           # get the branch on which the tag is based
-          raw=$(git branch -r --contains ${{ github.ref }})
+          raw=$(git branch -r --points-at ${{ github.ref }})
           # delete the name of the branch up to and including 'origin/'
           branch=$(echo $raw | sed 's/.*origin\///')
           echo "branch=${branch}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
…f `--contains`

* Tested this on the `release/5.0` branch and that worked.