### PR TITLE
Fixing python client : session's dataframe creation

### DIFF
--- a/vantage6-client/vantage6/client/subclients/dataframe.py
+++ b/vantage6-client/vantage6/client/subclients/dataframe.py
@@ -72,7 +72,7 @@ class DataFrameSubClient(ClientBase.SubClient):
         method: str,
         input_: dict,
         session: int | None = None,
-        store_id: int | None = None,
+        store: int | None = None,
         name: str | None = None,
         display=False,
     ) -> dict:
@@ -87,16 +87,18 @@ class DataFrameSubClient(ClientBase.SubClient):
             The name of the image that will be used to retrieve the data from the
             source database.
         method: str
-            Method to use for creating the dataframe
+            The method from the algorithm's image to be used for creating the dataframe
         input_: dict
             The input for the dataframe creation. It should include
             the arguments of the given method (kwargs)
         name: str
             Name that can be used in within the session
-        session : int
+        session : int, optional
             The session ID in which the dataframe is located. When not provided, the
             session ID of the client is used when it is set. In case the session ID is
             not set, an error is printed.
+        store: int, optional
+            The algorithm store where the algorithm image is registered
         display : bool, optional
             Whether to print the dataframe details. By default False.
 
@@ -157,8 +159,8 @@ class DataFrameSubClient(ClientBase.SubClient):
 
         if name is not None:
             request_payload["name"] = name
-        if store_id is not None:
-            request_payload["task"]["store_id"] = store_id
+        if store is not None:
+            request_payload["task"]["store_id"] = store
 
         df = self.parent.request(
             f"session/{session_id}/dataframe", method="POST", json=request_payload

--- a/vantage6-client/vantage6/client/subclients/dataframe.py
+++ b/vantage6-client/vantage6/client/subclients/dataframe.py
@@ -70,6 +70,7 @@ class DataFrameSubClient(ClientBase.SubClient):
         label:str,
         image:str,
         method:str,
+        input_:dict,
         session:int|None=None,           
         store_id:int|None=None,        
         name:str|None=None,
@@ -86,7 +87,12 @@ class DataFrameSubClient(ClientBase.SubClient):
             The name of the image that will be used to retrieve the data from the
             source database.
         method: str
-            (*Still not sure how to describe this parameter*)
+            Method to use for creating the dataframe
+        input_: dict
+            The input for the dataframe creation. It should include
+            the arguments of the given method (kwargs)
+        name: str
+            Name that can be used in within the session
         session : int
             The session ID in which the dataframe is located. When not provided, the
             session ID of the client is used when it is set. In case the session ID is
@@ -126,7 +132,12 @@ class DataFrameSubClient(ClientBase.SubClient):
         organizations = [(o["id"], o["public_key"]) for o in orgs["data"]]
 
         # Data will be serialized in JSON.
-        # serialized_input = serialize(input_)
+        #serialized_input = serialize(input_)
+
+        #TODO HC-I don't understand where to get this value from
+        serialized_input = serialize(input_)
+
+
 
         # Encrypt the input per organization using that organization's
         # public key.
@@ -135,11 +146,9 @@ class DataFrameSubClient(ClientBase.SubClient):
             organization_json_list.append(
                 {
                     "id": org_id,
-                    # Not sure what is expected to go here. According to the
-                    # schema (common.input_schema.SessionTaskInputSchema) only the id is required
-                    #"input": self.parent.cryptor.encrypt_bytes_to_str(
-                    #    serialized_input, pub_key
-                    #),
+                    "input": self.parent.cryptor.encrypt_bytes_to_str(
+                        serialized_input, pub_key
+                    ),
                 }
             )
 

--- a/vantage6-client/vantage6/client/subclients/dataframe.py
+++ b/vantage6-client/vantage6/client/subclients/dataframe.py
@@ -66,14 +66,14 @@ class DataFrameSubClient(ClientBase.SubClient):
 
     @post_filtering(iterable=False)
     def create(
-        self,     
-        label:str,
-        image:str,
-        method:str,
-        input_:dict,
-        session:int|None=None,           
-        store_id:int|None=None,        
-        name:str|None=None,
+        self,
+        label: str,
+        image: str,
+        method: str,
+        input_: dict,
+        session: int | None = None,
+        store_id: int | None = None,
+        name: str | None = None,
         display=False,
     ) -> dict:
         """
@@ -82,7 +82,7 @@ class DataFrameSubClient(ClientBase.SubClient):
         Parameters
         ----------
         label : str
-            Database label that is specified in the node configuration file.            
+            Database label that is specified in the node configuration file.
         image : str
             The name of the image that will be used to retrieve the data from the
             source database.
@@ -147,7 +147,7 @@ class DataFrameSubClient(ClientBase.SubClient):
             )
 
         request_payload = {
-            "label":label,
+            "label": label,
             "task": {
                 "method": method,
                 "image": image,
@@ -160,11 +160,8 @@ class DataFrameSubClient(ClientBase.SubClient):
         if store_id is not None:
             request_payload["task"]["store_id"] = store_id
 
-
         df = self.parent.request(
-            f"session/{session_id}/dataframe",
-            method="POST",
-            json=request_payload
+            f"session/{session_id}/dataframe", method="POST", json=request_payload
         )
 
         if display:

--- a/vantage6-client/vantage6/client/subclients/dataframe.py
+++ b/vantage6-client/vantage6/client/subclients/dataframe.py
@@ -66,11 +66,13 @@ class DataFrameSubClient(ClientBase.SubClient):
 
     @post_filtering(iterable=False)
     def create(
-        self,
-        database: str,
-        image: str,
-        input_: dict,
-        session: int = None,
+        self,     
+        label:str,
+        image:str,
+        method:str,
+        session:int|None=None,           
+        store_id:int|None=None,        
+        name:str|None=None,
         display=False,
     ) -> dict:
         """
@@ -78,15 +80,14 @@ class DataFrameSubClient(ClientBase.SubClient):
 
         Parameters
         ----------
-        database : str
-            The name of the database. This is the label of the source database at the
-            node.
+        label : str
+            Database label that is specified in the node configuration file.            
         image : str
             The name of the image that will be used to retrieve the data from the
             source database.
-        input_: dict
-            The input for the dataframe creation.
-        session : int, optional
+        method: str
+            (*Still not sure how to describe this parameter*)
+        session : int
             The session ID in which the dataframe is located. When not provided, the
             session ID of the client is used when it is set. In case the session ID is
             not set, an error is printed.
@@ -125,7 +126,7 @@ class DataFrameSubClient(ClientBase.SubClient):
         organizations = [(o["id"], o["public_key"]) for o in orgs["data"]]
 
         # Data will be serialized in JSON.
-        serialized_input = serialize(input_)
+        # serialized_input = serialize(input_)
 
         # Encrypt the input per organization using that organization's
         # public key.
@@ -134,22 +135,33 @@ class DataFrameSubClient(ClientBase.SubClient):
             organization_json_list.append(
                 {
                     "id": org_id,
-                    "input": self.parent.cryptor.encrypt_bytes_to_str(
-                        serialized_input, pub_key
-                    ),
+                    # Not sure what is expected to go here. According to the
+                    # schema (common.input_schema.SessionTaskInputSchema) only the id is required
+                    #"input": self.parent.cryptor.encrypt_bytes_to_str(
+                    #    serialized_input, pub_key
+                    #),
                 }
             )
+
+        request_payload = {
+            "label":label,
+            "task": {
+                "method": method,
+                "image": image,
+                "organizations": organization_json_list,
+            },
+        }
+
+        if name is not None:
+            request_payload["name"] = name
+        if store_id is not None:
+            request_payload["task"]["store_id"] = store_id
+
 
         df = self.parent.request(
             f"session/{session_id}/dataframe",
             method="POST",
-            json={
-                "label": database,
-                "task": {
-                    "image": image,
-                    "organizations": organization_json_list,
-                },
-            },
+            json=request_payload
         )
 
         if display:

--- a/vantage6-client/vantage6/client/subclients/dataframe.py
+++ b/vantage6-client/vantage6/client/subclients/dataframe.py
@@ -131,13 +131,7 @@ class DataFrameSubClient(ClientBase.SubClient):
         orgs = self.parent.organization.list(**params)
         organizations = [(o["id"], o["public_key"]) for o in orgs["data"]]
 
-        # Data will be serialized in JSON.
-        #serialized_input = serialize(input_)
-
-        #TODO HC-I don't understand where to get this value from
         serialized_input = serialize(input_)
-
-
 
         # Encrypt the input per organization using that organization's
         # public key.


### PR DESCRIPTION
Redefining the client method that creates a new dataframe in a session, given the schema used by its corresponding API resource-handler (see issue #1883)