### PR TITLE
Ignore default devspace tasks folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/function-docs/_autosummary
 # Ignore DevSpace cache and log folder
 .devspace/
 dev/.data/
+.tasks/
 
 # Helm
 charts/**/*.tgz


### PR DESCRIPTION
By default the `.tasks` directory is used in the repository folder (for linux/macos), lets ignore it :)

I dont know why the unittest are failing, but I geuss that is already the case in the release branch? Anyway this change did not break it.