### PR TITLE
Enabling communication between the Jobs and their corresponding Node proxy

### DIFF
--- a/charts/node/templates/node-deployment.yml
+++ b/charts/node/templates/node-deployment.yml
@@ -27,7 +27,7 @@ spec:
         image: {{ .Values.node.image }}
         env:
         - name: PROXY_SERVER_PORT
-          value: "{{ .Values.node.proxyPort }}"
+          value: "{{ (index .Values.node.proxyPorts 0).port}}"
         command: ["vnode-local", "start", "-c", "/app/config/config.yml", "--dockerized"]
         volumeMounts:
         - name: task-files-root

--- a/charts/node/templates/node-service.yml
+++ b/charts/node/templates/node-service.yml
@@ -8,16 +8,9 @@ spec:
 {{ include "node.matchLabels" . | indent 4 }}
     component: node
   ports:
-    # These ports must match ones defined on DEV_NODES_PREDEFINED_PORTS
-    - name: node1
+{{- range .Values.node.proxyPorts }}
+    - name: {{ .name }}
       protocol: TCP
-      port:  7654
-      targetPort:  7654
-    - name: node2
-      protocol: TCP
-      port:  6171
-      targetPort:  6171
-    - name: node3
-      protocol: TCP
-      port:  3986
-      targetPort:  3986
+      port: {{ .port }}
+      targetPort: {{ .targetPort | default .port }}
+{{- end }}      

--- a/charts/node/templates/node-service.yml
+++ b/charts/node/templates/node-service.yml
@@ -8,6 +8,16 @@ spec:
 {{ include "node.matchLabels" . | indent 4 }}
     component: node
   ports:
-  - protocol: TCP
-    port:  {{ .Values.node.proxyPort }}
-    targetPort:  {{ .Values.node.proxyPort }}
+    # These ports must match ones defined on DEV_NODES_PREDEFINED_PORTS
+    - name: node1
+      protocol: TCP
+      port:  7654
+      targetPort:  7654
+    - name: node2
+      protocol: TCP
+      port:  6171
+      targetPort:  6171
+    - name: node3
+      protocol: TCP
+      port:  3986
+      targetPort:  3986

--- a/charts/node/values.yaml
+++ b/charts/node/values.yaml
@@ -18,7 +18,23 @@ node:
   # Task directory on the host machine
   taskDirHost: /tmp/vantage6/tasks
 
-  proxyPort: 7654
+  
+  # Ports exposed by the Node POD (these can can be more than one when using the dev environment).
+  # These port numbers are used to add the corresponding targetPort on the Node service
+  # so that the Jobs can reach their node using K8S' naming service. The first element
+  # of the list is the default port.
+  # The number of ports must match the number of Nodes within the POD, and the port numbers
+  # must match the ones listed on DEV_NODES_PREDEFINED_PORTS (see notes on node/__init__)
+  proxyPorts:
+    - name: node1
+      port: 7654 #Default port
+    - name: node2
+      port: 6171
+    - name: node3
+      port: 3986
+
+
+
 
   # TODO the way databases are mounted and named can lead to possible naming conflicts
   databases:

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -54,7 +54,7 @@ from vantage6.node.globals import (
     TIME_LIMIT_RETRY_CONNECT_NODE,
     PROXY_SERVER_HOST,
     DEFAULT_PROXY_SERVER_PORT,
-    DEV_NODES_PREDEFINED_PORTS
+    DEV_NODES_PREDEFINED_PORTS,
 )
 from vantage6.node.k8s.container_manager import ContainerManager
 from vantage6.node.socket import NodeTaskNamespace
@@ -182,7 +182,6 @@ class Node:
         # this is where we try to find a port for the proxyserver
 
         port_assigned = False
-                
 
         for try_number in range(5):
             self.log.info("Starting proxyserver at '%s:%s'", proxy_host, proxy_port)
@@ -209,9 +208,11 @@ class Node:
                 # central functions): instead of random numbers, a sequence of predefined ports
                 # is used.
                 #
-                # Question: could the dev-environment be fixed to three nodes? Supporting an 
-                # undefined number of Nodes would be difficult 
-                proxy_port = DEV_NODES_PREDEFINED_PORTS[try_number % len(DEV_NODES_PREDEFINED_PORTS)]                                
+                # Question: could the dev-environment be fixed to three nodes? Supporting an
+                # undefined number of Nodes would be difficult
+                proxy_port = DEV_NODES_PREDEFINED_PORTS[
+                    try_number % len(DEV_NODES_PREDEFINED_PORTS)
+                ]
 
                 self.log.warning("Retrying with a different port: %s", proxy_port)
                 os.environ["PROXY_SERVER_PORT"] = str(proxy_port)

--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -54,7 +54,7 @@ DATABASE_BASE_PATH = "/app/databases/"
 
 # Must be consistent with node pod configuration
 # http://vantage6-node-node-service.vantage6-dev.svc.cluster.local:7654
-PROXY_SERVER_HOST = "vantage6-node-node-service.vantage6-dev.svc.cluster.local"
+PROXY_SERVER_HOST = "http://vantage6-node-node-service.vantage6-dev.svc.cluster.local"
 
 # Default proxy server port. It may be changed when starting the proxy if
 # the port is already in use

--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -53,5 +53,12 @@ TASK_FILES_ROOT = "/app/tasks"
 DATABASE_BASE_PATH = "/app/databases/"
 
 # Must be consistent with node pod configuration
-PROXY_SERVER_HOST = "http://v6proxy-subdomain.vantage6-node.svc.cluster.local"
-PROXY_SERVER_PORT = 4567
+# http://vantage6-node-node-service.vantage6-dev.svc.cluster.local:7654
+PROXY_SERVER_HOST = "vantage6-node-node-service.vantage6-dev.svc.cluster.local"
+
+# Default proxy server port. It may be changed when starting the proxy if
+# the port is already in use
+DEFAULT_PROXY_SERVER_PORT = 7654
+
+# Alternative ports
+DEV_NODES_PREDEFINED_PORTS = [7654, 6171, 3986, 5623, 3425]

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -31,7 +31,7 @@ from vantage6.common.client.node_client import NodeClient
 from vantage6.node.globals import (
     ENV_VARS_NOT_SETTABLE_BY_NODE,
     PROXY_SERVER_HOST,
-    PROXY_SERVER_PORT,
+    DEFAULT_PROXY_SERVER_PORT,
     DATABASE_BASE_PATH,
     TASK_FILES_ROOT,
     JOB_POD_OUTPUT_PATH,
@@ -348,7 +348,7 @@ class ContainerManager:
             "PROXY_SERVER_HOST", PROXY_SERVER_HOST
         )
         env_vars[ContainerEnvNames.PORT.value] = os.environ.get(
-            "PROXY_SERVER_PORT", str(PROXY_SERVER_PORT)
+            "PROXY_SERVER_PORT", str(DEFAULT_PROXY_SERVER_PORT)
         )
         env_vars[ContainerEnvNames.API_PATH.value] = ""
 


### PR DESCRIPTION
These changes address issue #1913, by replacing the use of randomly generated port numbers with a fixed set of ports:


_Like in the original V6-node, in the new one you can configure the port that will be used for the proxy (PROXY_SERVER_PORT). The problem is, when the allocation of this default port fails (e.g., because it is being used by other process) a random one is chosen._ 

_The dev-environment is using this feature to spin multiple nodes within the same POD, without a ports conflict (so it always has one v6-node with the default port, and N-1 v6-nodes with random ones). However, with exception of the v6-node no.1, these nodes are not reachable by their corresponding jobs anyway, as the Node-service doesn't have such random ports enabled for forwarding. This is a -provisional- workaround to fix this by switching from random ports to pre-defined ones._



This solution implies:

- There should be a limit on the number of nodes that can be setup on the dev. environment .
- This limit correspond to the number of ports defined on `charts/node/values.yaml`, which in turn correspond to the list of fixed ports on globals.DEV_NODES_PREDEFINED_PORTS
- In general, for consistency, there should be a strong constraint on the availability of these ports. That is, the alternative ones would be used only if a previous one was used by another Node. Not having the default port during the startup should make the node to fail -so it is responsibility of the person doing the setup to either release the port or to change the value of the default one.

Another alternative may be creating a POD for each Node on the dev environment, so that the default port can always be used regardless of the number of Nodes, but I'm not sure how complex this change would be.

I used [this algorithm](https://github.com/hcadavid/v6-sessions-k8s-diagnostics/blob/9dbb7e4458c817a2553e184206eb7d0bd8d2304c/v6-session-basics/partial.py#L192) to test that each job can reach the Node-proxy API with the FQDN and proxy port given to them .

@frankcorneliusmartin @bartvanb could you give me your thoughts on this? 
