### PR TITLE
Change/1782 port forward UI k8s service

### DIFF
--- a/charts/server/templates/ui/ui-service.yml
+++ b/charts/server/templates/ui/ui-service.yml
@@ -9,7 +9,7 @@ spec:
     component: ui
   ports:
     - protocol: TCP
-      port: 80          # External port for the UI
+      port: {{ .Values.ui.port }}   # External port for the UI
       targetPort: 4200    # Container port for the UI
       name: vantage6-server-frontend
-  type: ClusterIP
+  type: LoadBalancer

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -98,7 +98,5 @@ ui:
 
   # The image of the UI
   image: harbor2.vantage6.ai/infrastructure/ui:latest
-
-
-
-
+  # External port for the UI
+  port: 7600

--- a/charts/server/values.yaml
+++ b/charts/server/values.yaml
@@ -98,5 +98,5 @@ ui:
 
   # The image of the UI
   image: harbor2.vantage6.ai/infrastructure/ui:latest
-  # External port for the UI
+  # Service port for the UI
   port: 7600

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -274,9 +274,6 @@ dev:
     # would require image rebuild but it's not transparent.
     - path: ./vantage6-ui/src/:/app/src/
       disableDownload: true
-    ports:
-      - port: 7600:4200
-        bindAddress: localhost
 
   # Where as we could hot-reload the server code using wsgi, we cannot do this with the
   # node code. We leverage the `restartHelper` and `onUpload.restartContainer` to


### PR DESCRIPTION
Solve #1782.

Note that:
1. Docker k8s supports load balancer, so the external IP would be `localhost` for dev env
2. Microk8s does does not natively have load balancer, so to use LoadBalancer service for dev env, you can use https://metallb.io/ to enable load balancer, or use `kubectl port-forward svc/vantage6-server-vantage6-frontend-service  7600:7600` to port forwarding the service. (these should be put to doc)

