### PR TITLE
Use only command `start-dev` to start dev env

### DIFF
--- a/dev/populate_server.sh
+++ b/dev/populate_server.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# This script checks if the vantage6 server has already been populated with example data.
+# If not, it prompts the user to populate the server and runs the necessary devspace pipeline.
+# It uses a marker file to track whether the server has been populated.
+
+# Arguments:
+#   $1 - Path to the populate marker file
+
+POPULATE_MARKER=$1
+
+# Validate that the POPULATE_MARKER argument is provided
+if [ -z "${POPULATE_MARKER}" ]; then
+  echo "Error: POPULATE_MARKER argument is required."
+  echo "Usage: $0 <POPULATE_MARKER>"
+  exit 1
+fi
+
+# Check if the marker file exists
+if [ ! -f "${POPULATE_MARKER}" ]; then
+  echo "Do you want to populate vantage6 server with some example data? (y/n)"
+  read -r answer
+  if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+    # Run the pipeline to populate the server
+    echo "Starting to populate vantage6 server..."
+    devspace run-pipeline init
+    echo "Populating vantage6 server done."
+  else
+    echo "Skipping populating vantage6 server."
+  fi
+  # Create the marker file to indicate the server has been populated
+  mkdir -p .devspace
+  touch "${POPULATE_MARKER}"
+else
+  # Skip population if the marker file already exists
+  echo "Skipping populating vantage6 server. The server is already populated: found marker '${POPULATE_MARKER}'."
+fi

--- a/dev/purge_data.sh
+++ b/dev/purge_data.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script is used to purge data related to the vantage6 development environment.
+# It deletes the populate marker file, task directory, server database, and store database.
+
+# Arguments:
+#   $1 - Path to the populate marker file
+#   $2 - Path to the task directory
+#   $3 - Path to the server database mount directory
+#   $4 - Path to the store database mount directory
+
+POPULATE_MARKER=$1
+TASK_DIRECTORY=$2
+SERVER_DATABASE_MOUNT_PATH=$3
+STORE_DATABASE_MOUNT_PATH=$4
+
+# Validate that all required arguments are provided
+if [ -z "${POPULATE_MARKER}" ] || [ -z "${TASK_DIRECTORY}" ] || [ -z "${SERVER_DATABASE_MOUNT_PATH}" ] || [ -z "${STORE_DATABASE_MOUNT_PATH}" ]; then
+  echo "Error: Missing arguments."
+  echo "Usage: $0 <POPULATE_MARKER> <TASK_DIRECTORY> <SERVER_DATABASE_MOUNT_PATH> <STORE_DATABASE_MOUNT_PATH>"
+  exit 1
+fi
+
+echo "Deleting ${POPULATE_MARKER}"
+rm -f "${POPULATE_MARKER}"
+
+echo "Deleting all data in ${TASK_DIRECTORY}"
+rm -rf "${TASK_DIRECTORY:?}/"*
+
+echo "Deleting all data in ${SERVER_DATABASE_MOUNT_PATH}"
+rm -rf "${SERVER_DATABASE_MOUNT_PATH:?}/"*
+
+echo "Deleting all data in ${STORE_DATABASE_MOUNT_PATH}"
+rm -rf "${STORE_DATABASE_MOUNT_PATH:?}/"*

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -98,14 +98,11 @@ pipelines:
       stop_dev --all
       purge_deployments --all
       run_dependencies --all --pipeline purge
-      echo "Deleting ${POPULATE_MARKER}"
-      sh -c 'rm -f  "${1:?}"'   -- ${POPULATE_MARKER}
-      echo "Deleting all data in ${TASK_DIRECTORY}"
-      sh -c 'rm -rf "${1:?}/"*' -- ${TASK_DIRECTORY}
-      echo "Deleting all data in ${SERVER_DATABASE_MOUNT_PATH}"
-      sh -c 'rm -rf "${1:?}/"*' -- ${SERVER_DATABASE_MOUNT_PATH}
-      echo "Deleting all data in ${STORE_DATABASE_MOUNT_PATH}"
-      sh -c 'rm -rf "${1:?}/"*' -- ${STORE_DATABASE_MOUNT_PATH}
+      dev/purge_data.sh \
+        ${POPULATE_MARKER} \
+        ${TASK_DIRECTORY} \
+        ${SERVER_DATABASE_MOUNT_PATH} \
+        ${STORE_DATABASE_MOUNT_PATH}
     
   stop-dev:
     run: |-

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -333,12 +333,6 @@ dev:
 
 # Use the `commands` section to define repeatable dev workflows for this project
 commands:
-  # This command will spin up a server and store temporary to fill it with some
-  # basic data.
-  populate-server:
-    description: "Populate the server with fixtures for a given number of nodes"
-    command: devspace run-pipeline init
-
   # This will put all components in development mode. This is the main entrypoint
   # for development.
   start-dev:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -38,22 +38,7 @@ pipelines:
   # and the nodes. Make sure that you have run `devspace run-pipeline init` before.
   dev:
     run: |-
-      if [ ! -f "${POPULATE_MARKER}" ]; then
-        echo "Do you want to populate vantage6 server with some example data? (y/n)"
-        read -r answer
-        if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
-          echo "Starting to populate vantage6 server..."
-          run_pipelines init
-          echo "Populating vantage6 server done."
-        else
-          echo "Skipping populating vantage6 server."
-        fi
-        mkdir -p .devspace
-        touch "${POPULATE_MARKER}"
-      else
-        echo "Skipping populating vantage6 server. The server is already populated: found marker '${POPULATE_MARKER}'."
-      fi
-
+      dev/populate_server.sh ${POPULATE_MARKER}
       run_dependencies --all
       run_pipelines \
         server \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -51,7 +51,7 @@ pipelines:
         mkdir -p .devspace
         touch "${POPULATE_MARKER}"
       else
-        echo "Skipping populating vantage6 server. The server is already populated: found marker '${POPULATE_MARKER}''."
+        echo "Skipping populating vantage6 server. The server is already populated: found marker '${POPULATE_MARKER}'."
       fi
 
       run_dependencies --all

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,6 +3,7 @@ name: vantage6git
 
 # TODO using tags isnt safe with the devspace build stuff
 vars:
+  POPULATE_MARKER: ".devspace/vantage6_populate_done"
   SERVER_IMAGE: harbor2.vantage6.ai/infrastructure/server
   NODE_IMAGE: harbor2.vantage6.ai/infrastructure/node
   STORE_IMAGE: harbor2.vantage6.ai/infrastructure/algorithm-store
@@ -37,6 +38,22 @@ pipelines:
   # and the nodes. Make sure that you have run `devspace run-pipeline init` before.
   dev:
     run: |-
+      if [ ! -f "${POPULATE_MARKER}" ]; then
+        echo "Do you want to populate vantage6 server with some example data? (y/n)"
+        read -r answer
+        if [ "$answer" = "y" ] || [ "$answer" = "Y" ]; then
+          echo "Starting to populate vantage6 server..."
+          run_pipelines init
+          echo "Populating vantage6 server done."
+        else
+          echo "Skipping populating vantage6 server."
+        fi
+        mkdir -p .devspace
+        touch "${POPULATE_MARKER}"
+      else
+        echo "Skipping populating vantage6 server. The server is already populated: found marker '${POPULATE_MARKER}''."
+      fi
+
       run_dependencies --all
       run_pipelines \
         server \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -115,6 +115,12 @@ pipelines:
       rm -rf "${TASK_DIRECTORY}"
       rm -rf "${SERVER_DATABASE_MOUNT_PATH}"
       rm -rf "${STORE_DATABASE_MOUNT_PATH}"
+    
+  stop-dev:
+    run: |-
+      stop_dev --all
+      purge_deployments --all
+      run_dependencies --all --pipeline purge
 
 # This is a list of `images` that DevSpace can build for this project. These can be
 # build with `devspace build` or when running `devspace dev -b`.
@@ -349,11 +355,10 @@ commands:
     description: "Start the development environment"
     command: devspace dev
 
-  # This will stop all components from the development mode. Note that the deployments
-  # are not deleted.
+  # This will remove all running k8s resources from the development mode. 
   stop-dev:
     description: "Stop the development environment"
-    command: devspace reset pods
+    command: devspace run-pipeline stop-dev
 
   # This will delete all running k8s resources and local data (e.g. tasks data, database data). 
   # This is useful when you want to start from scratch.

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -105,6 +105,16 @@ pipelines:
         vantage6-node
       start_dev \
         vantage6-node
+    
+  purge:
+    run: |-
+      stop_dev --all
+      purge_deployments --all
+      run_dependencies --all --pipeline purge
+      rm -rf "${POPULATE_MARKER}"
+      rm -rf "${TASK_DIRECTORY}"
+      rm -rf "${SERVER_DATABASE_MOUNT_PATH}"
+      rm -rf "${STORE_DATABASE_MOUNT_PATH}"
 
 # This is a list of `images` that DevSpace can build for this project. These can be
 # build with `devspace build` or when running `devspace dev -b`.
@@ -345,8 +355,8 @@ commands:
     description: "Stop the development environment"
     command: devspace reset pods
 
-  # This will delete all deployments and services. This is useful when you want to
-  # start from scratch.
+  # This will delete all running k8s resources and local data (e.g. tasks data, database data). 
+  # This is useful when you want to start from scratch.
   purge:
     description: "Purge the development environment"
     command: devspace purge

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -107,17 +107,24 @@ pipelines:
         vantage6-node
     
   purge:
+    # Careful with destructive rm commands like `rm -rf ${p}/*`!! 
     run: |-
+      echo "Purging all deployments..."
       stop_dev --all
       purge_deployments --all
       run_dependencies --all --pipeline purge
-      rm -rf "${POPULATE_MARKER}"
-      rm -rf "${TASK_DIRECTORY}"
-      rm -rf "${SERVER_DATABASE_MOUNT_PATH}"
-      rm -rf "${STORE_DATABASE_MOUNT_PATH}"
+      echo "Deleting ${POPULATE_MARKER}"
+      sh -c 'rm -f  "${1:?}"'   -- ${POPULATE_MARKER}
+      echo "Deleting all data in ${TASK_DIRECTORY}"
+      sh -c 'rm -rf "${1:?}/"*' -- ${TASK_DIRECTORY}
+      echo "Deleting all data in ${SERVER_DATABASE_MOUNT_PATH}"
+      sh -c 'rm -rf "${1:?}/"*' -- ${SERVER_DATABASE_MOUNT_PATH}
+      echo "Deleting all data in ${STORE_DATABASE_MOUNT_PATH}"
+      sh -c 'rm -rf "${1:?}/"*' -- ${STORE_DATABASE_MOUNT_PATH}
     
   stop-dev:
     run: |-
+      echo "Purging all deployments..."
       stop_dev --all
       purge_deployments --all
       run_dependencies --all --pipeline purge


### PR DESCRIPTION
Fix #1929, https://github.com/vantage6/vantage6/issues/1785#issuecomment-2866695484
Not fix but prevent the #1942 (commit [f4f086f](https://github.com/vantage6/vantage6/pull/1930/commits/f4f086f9be4deab1adcf38c6665764c5baa0935e))

Related: merge #1891 first to make sure database and task data persist after running `devspace run stop-dev`. 