### PR TITLE
Modify port numbers that server and store databases are exposed at in…

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -270,18 +270,18 @@ dev:
       bindAddress: ${PORTS_BIND_ADDRESS}
     logs:
       enabled: true
-  
+
   vantage6-server-db:
     labelSelector:
       app: vantage6-server
       component: postgres
     ports:
       # expose the server database port
-      - port: 5432:5432
+      - port: 7632:5432
         bindAddress: localhost
-      - port: 5432:5432
+      - port: 7632:5432
         bindAddress: ${PORTS_BIND_ADDRESS}
-  
+
   vantage6-store:
     imageSelector: ${STORE_IMAGE}
     ports:
@@ -308,9 +308,9 @@ dev:
       component: postgres
     ports:
       # expose the store database port
-      - port: 5433:5432
+      - port: 7633:5432
         bindAddress: localhost
-      - port: 5433:5432
+      - port: 7633:5432
         bindAddress: ${PORTS_BIND_ADDRESS}
 
   # This puts the store container in development mode.


### PR DESCRIPTION
… the dev env

Two reasons for this change:
- for some miraculous reason, 5432 didn't work on my setup (maybe a weird WSL thing) - changing it to another port number solved the issue
- we have all our dev components exposed in ports 76xy