### PR TITLE
Fix bug that users of own organization are not shown if user has coll…

### DIFF
--- a/vantage6-server/vantage6/server/resource/user.py
+++ b/vantage6-server/vantage6/server/resource/user.py
@@ -304,6 +304,10 @@ class Users(UserBase):
                             for col in g.user.organization.collaborations
                             for org in col.organizations
                         ]
+                        # include the organization of the user: in case the organization
+                        # is not part of any collaboration they would otherwise not be
+                        # visible
+                        + [g.user.organization_id]
                     )
                 )
             elif self.r.v_org.can():


### PR DESCRIPTION
…aboration scope permission but organization is not involved in any collaborations

I happened to come across this bug while working on keycloak in v5 where the populate-server doesn't work yet so I had a (rare) very empty server content.
To be sure this bug is not present for other resources, I also checked those - but for most resources with collaboration scope, you actually need collaborations in order to have any resources