### PR TITLE
Only non 404 errors are logged as error when removing run secrets

### DIFF
--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -1275,17 +1275,22 @@ class ContainerManager:
         namespace: str
             Namespace where the secret is located
         """
-        self.log.info(
-            "Cleaning up kubernetes Secret %s in namespace %s",
-            secret_name,
-            namespace,
-        )
         try:
             self.core_api.delete_namespaced_secret(
                 name=secret_name, namespace=namespace
             )
+            self.log.info(
+                "Removed kubernetes Secret %s in namespace %s",
+                secret_name,
+                namespace,
+            )
         except ApiException as exc:
-            self.log.error("Exception when deleting namespaced secret: %s", exc)
+            if exc.status == 404:
+                self.log.debug(
+                    "No secret %s to remove in namespace %s", secret_name, namespace
+                )
+            else:
+                self.log.error("Exception when deleting namespaced secret: %s", exc)
 
     def __delete_job(self, job_name: str, namespace: str) -> None:
         """


### PR DESCRIPTION
Not all job pods have secrets, therefore I accept 404 status codes to be returned when deleting run secrets.

Fixes the namespace error in #1941 