### PR TITLE
Checking if devspace init pipeline succeeds. Without checking, server…

### DIFF
--- a/dev/populate_server.sh
+++ b/dev/populate_server.sh
@@ -24,13 +24,19 @@ if [ ! -f "${POPULATE_MARKER}" ]; then
     # Run the pipeline to populate the server
     echo "Starting to populate vantage6 server..."
     devspace run-pipeline init
-    echo "Populating vantage6 server done."
+    INIT_STATUS=$?
+    if [ $INIT_STATUS -eq 0 ]; then
+      echo "Populating vantage6 server completed successfully."
+      # Create the marker file to indicate the server has been populated
+      mkdir -p .devspace
+      touch "${POPULATE_MARKER}"
+    else
+      echo "Error: Failed to populate vantage6 server. The init pipeline did not complete successfully (exit code: $INIT_STATUS)."
+      exit $INIT_STATUS
+    fi
   else
     echo "Skipping populating vantage6 server."
   fi
-  # Create the marker file to indicate the server has been populated
-  mkdir -p .devspace
-  touch "${POPULATE_MARKER}"
 else
   # Skip population if the marker file already exists
   echo "Skipping populating vantage6 server. The server is already populated: found marker '${POPULATE_MARKER}'."


### PR DESCRIPTION
… was not populated upon errors

This is just an idea - let me know what you think. We could expand on this by allowing user to 'continue anyway' or so