### PR TITLE
Updated the algorithm internal IO paths

### DIFF
--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -42,11 +42,9 @@ DEFAULT_REQUIRE_ALGO_IMAGE_PULL = True
 
 # Mount paths within the algorithm containers. Algorithms containers are run as
 # jobs in the Kubernetes cluster.
-# TODO v5+ we might consider using different paths for this to avoid conflicts with
-# the algorithm image contents. Maybe e.g. `/app/vantage6/task/input` etc?
-JOB_POD_INPUT_PATH = "/app/input"
-JOB_POD_OUTPUT_PATH = "/app/output"
-JOB_POD_SESSION_FOLDER_PATH = "/app/session"
+JOB_POD_INPUT_PATH = "/app/vantage6/task/input"
+JOB_POD_OUTPUT_PATH = "/app/vantage6/task/output"
+JOB_POD_SESSION_FOLDER_PATH = "/app/vantage6/task/session"
 
 # The mount location of the tasks files, databases and kube config in the node
 # container.


### PR DESCRIPTION
Checked it with the extraction algorithm:

```
LOGS of POD run-1-gbj2v (created by job run-1) 

 info > wrapper for v6-session-basics
info > Reading input file /app/vantage6/task/input
info > Dispatching ...
info > Module 'v6-session-basics' imported!
[[32minfo [0m] - Validating function action: data extraction
[[32minfo [0m] - Reading CSV file from /app/databases/default.csv
[[32minfo [0m] - Converting algorithm output to a Parquet Table.
info > Writing output to /app/vantage6/task/output
[0m 
```