### PR TITLE
Show menu to select dataframe if function requires a dataframe and no…

### DIFF
--- a/dev/v6-session-basic-algorithm-store.json
+++ b/dev/v6-session-basic-algorithm-store.json
@@ -1,106 +1,121 @@
 {
-    "name": "v6-session-basics",
-    "code_url": "https://github.com/vantage6/v6-session-basics",
-    "description": "This algorithm demonstrates the basics of a session.",
-    "reviews": [],
-    "vantage6_version": "4.9",
-    "partitioning": "horizontal",
-    "functions": [
-      {
-        "name": "global_sum",
-        "display_name": "Sum",
-        "standalone": true,
-        "description": "Compute the global sum of a federated dataset",
-        "ui_visualizations": [],
-        "step_type": "central compute",
-        "arguments": [
-          {
-            "has_default_value": false,
-            "name": "column",
-            "display_name": "Column to sum",
-            "description": "Computes the global sum of the given column",
-            "type": "column",
-            "default_value": "",
-            "is_frontend_only": false
-          }
-        ],
-        "databases": []
-      },
-      {
-        "name": "sleep",
-        "display_name": "Sleep",
-        "standalone": true,
-        "description": "Sleep for a given number of seconds",
-        "ui_visualizations": [],
-        "step_type": "federated compute",
-        "arguments": [],
-        "databases": []
-      },
-      {
-        "name": "read_csv",
-        "display_name": "Read CSV file",
-        "standalone": true,
-        "description": "",
-        "ui_visualizations": [],
-        "step_type": "data extraction",
-        "arguments": [],
-        "databases": [
-          {
-            "description": "",
-            "name": "Database"
-          }
-        ]
-      },
-      {
-        "name": "pre_process",
-        "display_name": "Change column dtype",
-        "standalone": true,
-        "description": "Change data type of particular column (e.g. string to int)",
-        "ui_visualizations": [],
-        "step_type": "preprocessing",
-        "arguments": [
-          {
-            "has_default_value": false,
-            "name": "column",
-            "display_name": "Column ",
-            "description": "Column to change data type of ",
-            "type": "column",
-            "default_value": "",
-            "is_frontend_only": false
-          },
-          {
-            "has_default_value": false,
-            "name": "dtype",
-            "display_name": "New data type",
-            "description": "",
-            "type": "string",
-            "default_value": "",
-            "is_frontend_only": false
-          }
-        ],
-        "databases": []
-      },
-      {
-        "name": "sum",
-        "display_name": "Sum",
-        "standalone": true,
-        "description": "",
-        "ui_visualizations": [],
-        "step_type": "federated compute",
-        "arguments": [
-          {
-            "has_default_value": false,
-            "name": "column",
-            "display_name": "Column to sum",
-            "description": "",
-            "type": "column",
-            "default_value": "",
-            "is_frontend_only": false
-          }
-        ],
-        "databases": []
-      }
-    ],
-    "documentation_url": "",
-    "image": "harbor2.vantage6.ai/algorithms/session-basics"
-  }
+  "name": "v6-session-basics",
+  "code_url": "https://github.com/vantage6/v6-session-basics",
+  "description": "This algorithm demonstrates the basics of a session.",
+  "reviews": [],
+  "vantage6_version": "4.9",
+  "partitioning": "horizontal",
+  "functions": [
+    {
+      "name": "global_sum",
+      "display_name": "Sum",
+      "standalone": true,
+      "description": "Compute the global sum of a federated dataset",
+      "ui_visualizations": [],
+      "step_type": "central compute",
+      "arguments": [
+        {
+          "has_default_value": false,
+          "name": "column",
+          "display_name": "Column to sum",
+          "description": "Computes the global sum of the given column",
+          "type": "column",
+          "default_value": "",
+          "is_frontend_only": false
+        }
+      ],
+      "databases": [
+        {
+          "name": "Data",
+          "description": "Dataframe to use for computing the sum"
+        }
+      ]
+    },
+    {
+      "name": "sleep",
+      "display_name": "Sleep",
+      "standalone": true,
+      "description": "Sleep for a given number of seconds",
+      "ui_visualizations": [],
+      "step_type": "federated compute",
+      "arguments": [],
+      "databases": []
+    },
+    {
+      "name": "read_csv",
+      "display_name": "Read CSV file",
+      "standalone": true,
+      "description": "",
+      "ui_visualizations": [],
+      "step_type": "data extraction",
+      "arguments": [],
+      "databases": [
+        {
+          "description": "",
+          "name": "Database to read from"
+        }
+      ]
+    },
+    {
+      "name": "pre_process",
+      "display_name": "Change column dtype",
+      "standalone": true,
+      "description": "Change data type of particular column (e.g. string to int)",
+      "ui_visualizations": [],
+      "step_type": "preprocessing",
+      "arguments": [
+        {
+          "has_default_value": false,
+          "name": "column",
+          "display_name": "Column ",
+          "description": "Column to change data type of ",
+          "type": "column",
+          "default_value": "",
+          "is_frontend_only": false
+        },
+        {
+          "has_default_value": false,
+          "name": "dtype",
+          "display_name": "New data type",
+          "description": "",
+          "type": "string",
+          "default_value": "",
+          "is_frontend_only": false
+        }
+      ],
+      "databases": [
+        {
+          "name": "Data",
+          "description": "Dataframe to execute preprocessing on"
+        }
+      ]
+    },
+    {
+      "name": "sum",
+      "display_name": "Sum",
+      "standalone": true,
+      "description": "",
+      "ui_visualizations": [],
+      "step_type": "federated compute",
+      "arguments": [
+        {
+          "has_default_value": false,
+          "name": "column",
+          "display_name": "Column to sum",
+          "description": "",
+          "type": "column",
+          "default_value": "",
+          "is_frontend_only": false
+        }
+      ],
+      "databases": [
+        {
+          "name": "Data",
+          "description": "Dataframe to use for computing the sum"
+        }
+      ]
+    }
+  ],
+  "documentation_url": "",
+  "image": "harbor2.vantage6.ai/algorithms/session-basics"
+}

--- a/vantage6-ui/src/app/components/forms/compute-form/create-analysis-form.component.html
+++ b/vantage6-ui/src/app/components/forms/compute-form/create-analysis-form.component.html
@@ -194,6 +194,12 @@
                 </mat-option>
               </mat-select>
             </mat-form-field>
+            <div *ngIf="dataframes.length === 0">
+              <app-alert class="node-alert" label="{{ 'task-create.alert-no-dataframes' | translate }}"></app-alert>
+              <button mat-flat-button color="primary" [routerLink]="[routes.dataframeCreate, session?.id]">
+                <mat-icon>add</mat-icon>{{ "task-create.step-dataframe.create-new-df" | translate }}
+              </button>
+            </div>
             <div>
               <button mat-button matStepperPrevious>{{ "general.back" | translate }}</button>
               <button mat-button matStepperNext *ngIf="!isLastStep(availableStepsEnum.Dataframe)">

--- a/vantage6-ui/src/app/components/forms/compute-form/create-analysis-form.component.ts
+++ b/vantage6-ui/src/app/components/forms/compute-form/create-analysis-form.component.ts
@@ -232,7 +232,7 @@ export class CreateAnalysisFormComponent implements OnInit, OnDestroy, AfterView
   }
 
   get shouldShowDataframeStep(): boolean {
-    return !this.session || (!!this.dataframes && this.dataframes.length > 0);
+    return !this.session || (!!this.function?.databases && this.function.databases.length > 0);
   }
 
   get shouldShowDatabaseStep(): boolean {

--- a/vantage6-ui/src/assets/localizations/en.json
+++ b/vantage6-ui/src/assets/localizations/en.json
@@ -220,7 +220,8 @@
       "error-db-update": "Could not retrieve node configuration. The database step will not be available. Please try again later."
     },
     "step-dataframe": {
-      "title": "Select dataframe"
+      "title": "Select dataframe",
+      "create-new-df": "Create dataframe"
     },
     "step-preprocessing": {
       "title": "Extend data",
@@ -246,7 +247,8 @@
     "alert-no-stores": "You cannot create an analysis because no algorithm stores are available to your collaboration. These are required to obtain the available algorithms from. Please contact your collaboration manager.",
     "alert-no-algorithms": "You cannot create an analysis because no algorithms can be retrieved from the algorithm stores that are linked to your collaboration. Please contact your collaboration manager.",
     "alert-no-node-config": "The node '{{name}}' does not share its configuration, nor does any other node that is online. This is required to determine the available databases. Please contact the node administrator.",
-    "alert-no-databases": "The node '{{name}}' configuration does not contain any databases, while this algorithm requires one or more. Please contact the node administrator so that they might add them."
+    "alert-no-databases": "The node '{{name}}' configuration does not contain any databases, while this algorithm function requires one or more. Please contact the node administrator so that they might add them.",
+    "alert-no-dataframes": "The selected session does not contain any dataframes, while this algorithm function requires one or more. Please initialize your session by creating a dataframe."
   },
   "task-read": {
     "title": "Analysis",


### PR DESCRIPTION
…ne are available

I've also updated the functions in populating the server so that they contain 'databases'. This nomenclature is a bit vague: the algorithm store used to have 'databases' in v4, but now in v5, a database can be both a database (for extraction functions) as a dataframe (for other functions). @frankcorneliusmartin what do you think, should we change that name? It would require an additional database field and then just one of the two would be filled in... (or some bigger refactor)