### PR TITLE
Setting specific status to runs that depend on tasks that failed

### DIFF
--- a/vantage6-common/vantage6/common/enum.py
+++ b/vantage6-common/vantage6/common/enum.py
@@ -116,6 +116,8 @@ class RunStatus(EnumBase):
     UNKNOWN_ERROR = "unknown error"
     # Datafrome was not found
     DATAFRAME_NOT_FOUND = "dataframe not found"
+    # Task was not executed because a task that it depended on failed
+    DEPENDED_ON_FAILED_TASK = "depended on failed task"
 
     # Unexpected output type from container
     UNEXPECTED_OUTPUT = "unexpected output"
@@ -168,6 +170,7 @@ class RunStatus(EnumBase):
             cls.NO_DOCKER_IMAGE.value,
             cls.UNEXPECTED_OUTPUT.value,
             cls.DATAFRAME_NOT_FOUND.value,
+            cls.DEPENDED_ON_FAILED_TASK.value,
         ]
 
     @classmethod

--- a/vantage6-ui/src/app/pipes/order-by-status.pipe.ts
+++ b/vantage6-ui/src/app/pipes/order-by-status.pipe.ts
@@ -11,7 +11,11 @@ export enum RunStatus {
   Active = 'active',
   Initializing = 'initializing',
   Pending = 'pending',
-  Completed = 'completed'
+  Completed = 'completed',
+  UnknownError = 'unknown error',
+  DataFrameNotFound = 'dataframe not found',
+  DependedOnFailedTask = 'depended on failed task',
+  UnexpectedOutput = 'unexpected output'
 }
 
 @Pipe({


### PR DESCRIPTION
Also, improved determining which tasks are dependent on a certain task by fully recursing down the tree, and also added missing runstatuses to the UI code

Triggered by this comment which was in the sessions overview issue: https://github.com/vantage6/vantage6/pull/1247#discussion_r1850409948