### PR TITLE
Add new unittest scenario to test if user with collaboration scope pe…

### DIFF
--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -1248,13 +1248,27 @@ class TestResources(unittest.TestCase):
         )
         self.assertEqual(result.status_code, HTTPStatus.UNAUTHORIZED)
 
+        # Check that collaboration permission still works if the organization is not
+        # actually in a collaboration.
+        org4 = Organization()
+        org4.save()
+        user_org_4 = User(organization=org4)
+        user_org_4.save()
+        rule = Rule.get_by_("user", Scope.COLLABORATION, Operation.VIEW)
+        headers = self.create_user_and_login(organization=org4, rules=[rule])
+        result = self.app.get("/api/user", headers=headers)
+        self.assertEqual(result.status_code, HTTPStatus.OK)
+        self.assertEqual(len(result.json["data"]), len(org4.users))
+
         # cleanup
         org.delete()
         org2.delete()
         org3.delete()
+        org4.delete()
         org_outside_col.delete()
         col.delete()
         user.delete()
+        user_org_4.delete()
 
     def test_bounce_existing_username_and_email(self):
         headers = self.create_user_and_login()


### PR DESCRIPTION
…rmission to view users can see those users if their organization is not involved in any collaborations. See #1951