### PR TITLE
Rename client_type claim to vantage6_client_type

### DIFF
--- a/charts/auth/values.yaml
+++ b/charts/auth/values.yaml
@@ -36,12 +36,12 @@ keycloak:
             webOrigins:
               - "*"
             protocolMappers:
-              - name: client_type
+              - name: vantage6_client_type
                 protocol: openid-connect
                 protocolMapper: oidc-hardcoded-claim-mapper
                 consentRequired: false
                 config:
-                  claim.name: client_type
+                  claim.name: vantage6_client_type
                   claim.value: user
                   introspection.token.claim: true
                   userinfo.token.claim: true
@@ -81,12 +81,12 @@ keycloak:
             directAccessGrantsEnabled: true
             standardFlowEnabled: false
             protocolMappers:
-              - name: client_type
+              - name: vantage6_client_type
                 protocol: openid-connect
                 protocolMapper: oidc-hardcoded-claim-mapper
                 consentRequired: false
                 config:
-                  claim.name: client_type
+                  claim.name: vantage6_client_type
                   claim.value: node
                   introspection.token.claim: true
                   userinfo.token.claim: true

--- a/vantage6-algorithm-tools/vantage6/algorithm/decorator/metadata.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/decorator/metadata.py
@@ -36,7 +36,7 @@ def _extract_token_payload(token: str) -> dict:
     Returns
     -------
     dict
-        The payload as a dictionary. It contains the keys: `client_type`,
+        The payload as a dictionary. It contains the keys: `vantage6_client_type`,
         `node_id`, `organization_id`, `collaboration_id`, `task_id`, `image`,
         and `databases`.
     """

--- a/vantage6-server/tests_server/test_resource_base.py
+++ b/vantage6-server/tests_server/test_resource_base.py
@@ -115,7 +115,7 @@ class TestResourceBase(unittest.TestCase):
         # Create a real JWT token with mock claims
         mock_claims = {
             "sub": user.keycloak_id,
-            "client_type": "user",
+            "vantage6_client_type": "user",
             "exp": 9999999999,
             "iat": 0,
         }
@@ -178,7 +178,7 @@ class TestResourceBase(unittest.TestCase):
         # Create a real JWT token with mock claims
         mock_claims = {
             "sub": node.keycloak_id,
-            "client_type": "node",
+            "vantage6_client_type": "node",
             "exp": 9999999999,
             "iat": 0,
         }
@@ -225,7 +225,7 @@ class TestResourceBase(unittest.TestCase):
         ) as mock_get_identity:
             mock_get_token.return_value = {
                 "sub": node.keycloak_id,
-                "client_type": "node",
+                "vantage6_client_type": "node",
             }
             mock_get_identity.return_value = node.keycloak_id
             token = self.app.post(

--- a/vantage6-server/vantage6/server/resource/__init__.py
+++ b/vantage6-server/vantage6/server/resource/__init__.py
@@ -204,7 +204,7 @@ def _validate_user_or_node_token(types: tuple[str]) -> None:
     claims = get_jwt()
 
     # check that identity has access to endpoint
-    g.type = claims["client_type"]
+    g.type = claims["vantage6_client_type"]
 
     if g.type not in types:
         # FIXME BvB 23-10-19: user gets a 500 error, would be better to
@@ -263,7 +263,7 @@ def _validate_container_token():
         raise Exception("Authentication failed")
 
     # Verify this is a container token
-    if claims.get("sub", {}).get("client_type") != "container":
+    if claims.get("sub", {}).get("vantage6_client_type") != "container":
         raise Exception("Not a container token")
 
     # Set the container info in the global context

--- a/vantage6-server/vantage6/server/resource/token.py
+++ b/vantage6-server/vantage6/server/resource/token.py
@@ -155,7 +155,7 @@ class ContainerToken(ServicesResources):
         # We store the task metadata in the token, so the server can verify later on
         # that the container is allowed to access certain server resources.
         container = {
-            "client_type": "container",
+            "vantage6_client_type": "container",
             "node_id": g.node.id,
             "organization_id": g.node.organization_id,
             "collaboration_id": g.node.collaboration_id,


### PR DESCRIPTION
Not a full fix for supporting external keycloak, just a rename of the custom client_type claim in this PR