### PR TITLE
Fixing error during the creation of file-based database-volumes

### DIFF
--- a/charts/node/templates/node-deployment.yml
+++ b/charts/node/templates/node-deployment.yml
@@ -57,8 +57,8 @@ spec:
       - name: config-volume
         configMap:
           name: {{ .Release.Name }}-node-configmap
-      {{- range .Values.node.databases.fileBased }}
+      {{- range default (list) .Values.node.databases.fileBased }}      
       - name: database-volume-{{ .name }}
         persistentVolumeClaim:
-          claimName: {{ .Release.Name }}-vantage6-node-database-pvc
+          claimName: {{ $.Release.Name }}-vantage6-node-database-pvc
       {{- end }}


### PR DESCRIPTION
.Release.Name variable doesn't exist within the context of a 'range' loop of a Helm Chart. The $ prefix make explicit the reference to the root context.