### PR TITLE
Add JWT decode leeway configuration option in ServerApp

### DIFF
--- a/charts/store/templates/server/store-configmap.yml
+++ b/charts/store/templates/server/store-configmap.yml
@@ -43,4 +43,5 @@ data:
     port: {{ .Values.store.internal.port }}
     root_user:
       username: {{ .Values.store.vantage6Server.rootUser }}
+      v6_server_uri: {{ .Values.store.vantage6Server.uri }}
     uri: postgresql://{{ .Values.database.username }}:{{ .Values.database.password }}@{{ .Release.Name }}-postgres-service:5432/{{ .Values.database.name }}

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -304,6 +304,11 @@ class ServerApp(Vantage6App):
         # set JWT algorithms that keycloak uses
         self.app.config["JWT_ALGORITHM"] = "RS256"
         self.app.config["JWT_DECODE_ALGORITHMS"] = ["RS256"]
+
+        # Leeway is provided for the token IAT to prevent errors that token is not yet
+        # valid, which can happen if server times are drifting slightly. Note that this
+        # may be removed after updating to pyjwt > 3.0, where the validation behaviour
+        # changes - but be sure to check that.
         self.app.config["JWT_DECODE_LEEWAY"] = self.ctx.config.get(
             "jwt_decode_leeway", 10
         )

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -306,9 +306,7 @@ class ServerApp(Vantage6App):
         self.app.config["JWT_DECODE_ALGORITHMS"] = ["RS256"]
 
         # Leeway is provided for the token IAT to prevent errors that token is not yet
-        # valid, which can happen if server times are drifting slightly. Note that this
-        # may be removed after updating to pyjwt > 3.0, where the validation behaviour
-        # changes - but be sure to check that.
+        # valid, which can happen if server times are drifting slightly.
         self.app.config["JWT_DECODE_LEEWAY"] = self.ctx.config.get(
             "jwt_decode_leeway", 10
         )

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -304,7 +304,9 @@ class ServerApp(Vantage6App):
         # set JWT algorithms that keycloak uses
         self.app.config["JWT_ALGORITHM"] = "RS256"
         self.app.config["JWT_DECODE_ALGORITHMS"] = ["RS256"]
-
+        self.app.config["JWT_DECODE_LEEWAY"] = self.ctx.config.get(
+            "jwt_decode_leeway", 10
+        )
         self.app.config["JWT_PUBLIC_KEY"] = self._get_keycloak_public_key()
 
         # set JWT secret key


### PR DESCRIPTION
* Tested it with a custom build in the IDEA4RC project
* I did not disable the IAT check as this was not easily configurable in the Flask-JWT-extended function interfaces and this seems like a proper fix.