### PR TITLE
Include READMEs for each submodule

### DIFF
--- a/vantage6-algorithm-store/Makefile
+++ b/vantage6-algorithm-store/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-algorithm-store/README.md
+++ b/vantage6-algorithm-store/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Algorithm Store
+
+This package contains the vantage6 algorithm store application.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6-algorithm-tools/Makefile
+++ b/vantage6-algorithm-tools/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-algorithm-tools/README.md
+++ b/vantage6-algorithm-tools/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Algorithm Tools
+
+This package provides Python tools to facilitate algorithm development for vantage6.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6-backend-common/Makefile
+++ b/vantage6-backend-common/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-backend-common/README.md
+++ b/vantage6-backend-common/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Backend Common
+
+This package contains code common to the central server and algorithm store.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6-client/Makefile
+++ b/vantage6-client/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-client/README.md
+++ b/vantage6-client/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Client
+
+This package provides a Python client for interacting with the vantage6 server.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6-common/Makefile
+++ b/vantage6-common/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-common/README.md
+++ b/vantage6-common/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Common
+
+This package contains common utilities for the Vantage6 platform.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6-node/Makefile
+++ b/vantage6-node/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-node/README.md
+++ b/vantage6-node/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Node
+
+This package contains the Vantage6 node application.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6-server/Makefile
+++ b/vantage6-server/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6-server/README.md
+++ b/vantage6-server/README.md
@@ -1,0 +1,25 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 Server
+
+This package contains the vantage6 server application.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6/Makefile
+++ b/vantage6/Makefile
@@ -7,9 +7,7 @@ rebuild: clean build-dist
 
 build-dist:
 	# Build the PyPI package
-	cp ../README.md .
 	uv build
-	rm README.md
 
 publish:
 	# Uploading to pypi.org

--- a/vantage6/README.md
+++ b/vantage6/README.md
@@ -1,0 +1,26 @@
+<h1 align="center">
+  <br>
+  <a href="https://vantage6.ai"><img src="https://github.com/IKNL/guidelines/blob/master/resources/logos/vantage6.png?raw=true" alt="vantage6" width="350"></a>
+</h1>
+
+<h3 align=center> A Privacy Enhancing Technology (PET) Operations platform</h3>
+
+---
+
+# Vantage6 CLI
+
+This package provides the command-line interface (CLI) for managing vantage6
+infrastructure instances, such as servers and nodes.
+
+## Documentation
+
+For complete documentation, installation instructions, and usage examples, please see
+the **[main Vantage6 README](https://github.com/vantage6/vantage6/blob/main/README.md)**
+.
+
+## About Vantage6
+
+Vantage6 is a Privacy Enhancing Technology (PET) Operations platform that enables
+federated learning and multi-party computation. For more information, visit
+[vantage6.ai](https://vantage6.ai) or join our
+[Discord community](https://discord.gg/yAyFf6Y).

--- a/vantage6/pyproject.toml
+++ b/vantage6/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "vantage6"
 version = "5.0.0a31"
 description = "vantage6 command line interface"
-readme = "../README.md"
+readme = "README.md"
 license = {text = "MIT"}
 authors = [
     {name = "Vantage6 Team"}


### PR DESCRIPTION
This done because  will not work with readme's from a parent directory, which causes the PyPi build to crash. I guess that including READMEs from upper directories is also not the nicest practice, which is why I opted for this solution after failing to make it work with a single README or symlinks (which I'm not sure is better anyway)