### PR TITLE
Make the standard algorithm functions provided via the infrastructure…

### DIFF
--- a/vantage6-algorithm-tools/vantage6/algorithm/data_extraction/__init__.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/data_extraction/__init__.py
@@ -7,6 +7,7 @@ from sqlalchemy import create_engine
 
 from vantage6.common import error, info
 
+from vantage6.algorithm.tools.error_handling import handle_pandas_errors
 from vantage6.algorithm.tools.exceptions import DataReadError
 
 from vantage6.algorithm.decorator.action import data_extraction
@@ -14,6 +15,7 @@ from vantage6.algorithm.decorator.action import data_extraction
 _SPARQL_RETURN_FORMAT = CSV
 
 
+@handle_pandas_errors
 @data_extraction
 def read_csv(connection_details: dict) -> pd.DataFrame:
     """
@@ -53,6 +55,7 @@ def _read_csv(connection_details: dict) -> pd.DataFrame:
     return df
 
 
+@handle_pandas_errors
 @data_extraction
 def read_parquet(connection_details: dict) -> pd.DataFrame:
     """
@@ -91,6 +94,7 @@ def _read_parquet(connection_details: dict) -> pd.DataFrame:
     return df
 
 
+@handle_pandas_errors
 @data_extraction
 def read_excel(connection_details: dict, sheet_name: str | None = None) -> pd.DataFrame:
     """
@@ -140,6 +144,7 @@ def _read_excel(
     return df
 
 
+@handle_pandas_errors
 @data_extraction
 def read_sparql_database(connection_details: dict, query: str) -> pd.DataFrame:
     """
@@ -225,6 +230,7 @@ def _sqldb_uri_preprocess(database_uri: str) -> str:
         return database_uri
 
 
+@handle_pandas_errors
 @data_extraction
 def read_sql_database(connection_details: dict, query: str) -> pd.DataFrame:
     """

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/aggregation.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/aggregation.py
@@ -7,12 +7,14 @@ DataFrame with statistical information based on a given grouping.
 
 import pandas as pd
 
+from vantage6.algorithm.tools.error_handling import handle_pandas_errors
 from vantage6.algorithm.tools.exceptions import UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 from vantage6.algorithm.decorator.data import dataframe
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def collapse(
@@ -160,6 +162,7 @@ def collapse(
     return agg_df.reset_index()
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def group_statistics(

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/column.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/column.py
@@ -6,12 +6,14 @@ expressions.
 
 import pandas as pd
 
+from vantage6.algorithm.tools.error_handling import handle_pandas_errors
 from vantage6.algorithm.tools.exceptions import UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 from vantage6.algorithm.decorator.data import dataframe
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def rename_columns(
@@ -55,6 +57,7 @@ def rename_columns(
     )
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def assign_column(df: pd.DataFrame, column_name: str, expression: str) -> pd.DataFrame:
@@ -96,6 +99,7 @@ def assign_column(df: pd.DataFrame, column_name: str, expression: str) -> pd.Dat
     return df
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def redefine_column(
@@ -140,6 +144,7 @@ def redefine_column(
     return df
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def change_column_type(

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/datetime.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/datetime.py
@@ -9,12 +9,14 @@ from datetime import date
 
 import pandas as pd
 
+from vantage6.algorithm.tools.error_handling import handle_pandas_errors
 from vantage6.algorithm.tools.exceptions import DataError, UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 from vantage6.algorithm.decorator.data import dataframe
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def to_datetime(
@@ -81,6 +83,7 @@ def to_datetime(
     return df
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def to_timedelta(
@@ -179,6 +182,7 @@ def to_timedelta(
     return df
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def timedelta(
@@ -268,6 +272,7 @@ def timedelta(
     return df
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def calculate_age(

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/filtering.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/filtering.py
@@ -5,10 +5,13 @@ pandas DataFrames, such as selecting and filtering rows and columns.
 
 import pandas as pd
 
+from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+
 from vantage6.algorithm.decorator.action import preprocessing
 from vantage6.algorithm.decorator.data import dataframe
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def select_rows(df: pd.DataFrame, query: str) -> pd.DataFrame:
@@ -77,6 +80,7 @@ def select_rows(df: pd.DataFrame, query: str) -> pd.DataFrame:
     return df.query(query)
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def filter_range(
@@ -161,6 +165,7 @@ def filter_range(
     return df
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def select_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
@@ -217,6 +222,7 @@ def select_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     return df[columns]
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def drop_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
@@ -266,6 +272,7 @@ def drop_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     return df.drop(columns, axis=1)
 
 
+@handle_pandas_errors
 @preprocessing
 @dataframe(1)
 def filter_by_date(

--- a/vantage6-algorithm-tools/vantage6/algorithm/tools/error_handling.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/tools/error_handling.py
@@ -1,0 +1,58 @@
+import logging
+from functools import wraps
+
+import pandas as pd
+
+from vantage6.common import logger_name
+
+from vantage6.algorithm.tools.exceptions import AlgorithmRuntimeError
+
+module_name = logger_name(__name__)
+log = logging.getLogger(module_name)
+
+
+def _collect_pandas_error_types() -> tuple[type, ...]:
+    """
+    Collect all exception classes exported from pandas.errors.
+
+    Returns a tuple of exception types to be used in an except clause.
+    """
+    exception_types = []
+    errors_module = pd.errors
+    for attr_name in errors_module.__all__:
+        attr = getattr(errors_module, attr_name, None)
+        if isinstance(attr, type) and issubclass(attr, Exception):
+            exception_types.append(attr)
+
+    return tuple(exception_types)
+
+
+PANDAS_ERROR_TYPES = _collect_pandas_error_types()
+
+
+def handle_pandas_errors(func):
+    """
+    Decorator to catch pandas-related errors from algorithm functions and
+    prevent leaking privacy-sensitive data via tracebacks.
+
+    - Catches pandas-specific exceptions and common data-manipulation errors.
+    - Logs a minimal, non-identifying message (no traceback, no exception str).
+    - Returns a safe, generic error response with 400 Bad Request.
+    - Other unexpected exceptions continue to log with traceback for debugging.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except PANDAS_ERROR_TYPES as e:
+            # Avoid logging tracebacks or exception messages that may contain data
+            msg = (
+                f"Pandas-related error of type {type(e).__name__} occurred in "
+                "algorithm function. Details have been omitted to protect privacy."
+            )
+            log.error(msg)
+            # pylint: disable=raise-missing-from
+            raise AlgorithmRuntimeError(msg)
+
+    return wrapper


### PR DESCRIPTION
… more safe by preventing error details to be printed. Also, making a new decorator available to algorithm developers to do this

This PR is a suggestion of how we could do this. If we agree upon this, we should add docs before merging the PR.

It could e.g. be improved by more subtly handling the errors so that we can still show part of the error while masking the sensitive part. That would be more helpful to the user. Another improvement could be to give node admins tools to see full errors somehow. But maybe this is good enough for now, considering other priorities.