### PR TITLE
Add try catch to uwsgi import for when it is running outside of a wsgi process

### DIFF
--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -1,5 +1,6 @@
 import logging
 import uuid
+
 # uwsgi is not available when running outside of a uwsgi process.
 # (see https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html)
 # This prevents a ModuleNotFoundError if this resource is loaded

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -1,6 +1,13 @@
 import logging
 import uuid
-import uwsgi  # type: ignore (built from source in Dockerfile)
+# uwsgi is not available when running outside of a uwsgi process.
+# (see https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html)
+# This prevents a ModuleNotFoundError if this resource is loaded
+# outside of such a server, e.g. when importing data in v6 dev create-demo-network.
+try:
+    import uwsgi  # type: ignore (built from source in Dockerfile)
+except ImportError:
+    uwsgi = None
 from flask import g, request, Response, stream_with_context
 
 from flask_restful import Api


### PR DESCRIPTION
Uwsgi is not available when running outside of a uwsgi process, (see https://uwsgi-docs.readthedocs.io/en/latest/PythonModule.html). When importing data in vs dev create-demo-network, aModuleNotFoundError is thrown if this resource is loaded. 
The proper fix will be to eventually find another way to stream without the use of uwsgi imports, until then a try catch is the best solution.