### PR TITLE
Switch to more sensible chunk size default for improved performance

### DIFF
--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -57,7 +57,7 @@ INTERVAL_MULTIPLIER = 1.5
 REQUEST_TIMEOUT = 300
 
 # Default chunk size for streaming inputs and results
-DEFAULT_CHUNK_SIZE = 8192
+DEFAULT_CHUNK_SIZE = 1024 * 1024  # 1MB
 
 
 class InstanceType(str, Enum):


### PR DESCRIPTION
Currently the default chunk size for streaming is small, since we will not usually care about latency and current performance is slow, set a more sensible default.