### PR TITLE
Make processing of new tasks more error resilient - if starting task …

### DIFF
--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -765,6 +765,7 @@ class Node:
                     )
                 except Exception as e:
                     self.log.exception("Error while patching task: %s", e)
+                time.sleep(1)
                 continue
 
     def kill_containers(self, kill_info: dict) -> list[dict]:


### PR DESCRIPTION
…crashes, ensure node doesn't die, but send message to server that node couldn't start

@frankcorneliusmartin please review with care, it's an important part of the code that I changed here. 

The consequence of this change in starting new tasks:
- **before this change**: if there was an error in the node code, the node died. The task would remain pending and could be picked up when the node was restarted with a fix for the error
- **after this change**: the node keeps running, printing errors to the logs. The task is marked as failed - it will not be restarted after node restarts.