### PR TITLE
Release new major version images for major version prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,7 +345,9 @@ jobs:
           docker pull harbor2.vantage6.ai/infrastructure/alpine:${version}
 
       - name: Tag docker images
-        if: ${{  env.stage == ''  &&  env.major_name != '' }}
+        # Tag the images with major name if it is a new release OR if it is a prerelease
+        # of a new major version (x.0.0<N>).
+        if: ${{  env.major_name != '' && (env.stage == '' || (env.minor == 0 && env.patch == 0)) }}
         run: |
           docker tag harbor2.vantage6.ai/infrastructure/server:${version} harbor2.vantage6.ai/infrastructure/server:${major_name}
           docker tag harbor2.vantage6.ai/infrastructure/server:${version} harbor2.vantage6.ai/infrastructure/server:${major_name}-live

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,8 +345,9 @@ jobs:
           docker pull harbor2.vantage6.ai/infrastructure/alpine:${version}
 
       - name: Tag docker images
-        # Tag the images with major name if it is a new release OR if it is a prerelease
-        # of a new major version (x.0.0<N>).
+        # Tag the images with major name for any new release, except prereleases. Only
+        # prereleases of a new major version (x.0.0<N>) are tagged with the major name,
+        # as no definitive releases have been made yet for that major version.
         if: ${{  env.major_name != '' && (env.stage == '' || (env.minor == 0 && env.patch == 0)) }}
         run: |
           docker tag harbor2.vantage6.ai/infrastructure/server:${version} harbor2.vantage6.ai/infrastructure/server:${major_name}


### PR DESCRIPTION
If my logic is correct, this will ensure that the `:uluru` images are updated with every prerelease after this is merged