### PR TITLE
After building new major-name images for prereleases, this commit ens…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,7 +366,7 @@ jobs:
           docker push harbor2.vantage6.ai/infrastructure/node:${major}.${minor}
 
       - name: Push docker images
-        if: ${{  env.stage == ''  &&  env.major_name != '' }}
+        if: ${{  env.major_name != '' && (env.stage == '' || (env.minor == 0 && env.patch == 0))}}
         run: |
           docker push harbor2.vantage6.ai/infrastructure/server:${major_name}
           docker push harbor2.vantage6.ai/infrastructure/server:${major_name}-live


### PR DESCRIPTION
…ures that they are also pushed

Recently in #2451 we changed the logic to build `:uluru` images for prereleases while the definitive release is not out, but I forgot to also change the logic in the image push step - this fixes that oversight.