### PR TITLE
Fail pending sibling runs immediately when one run fails

### DIFF
--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -6,6 +6,7 @@ import uuid
 import random
 import string
 import yaml
+import datetime
 
 from http import HTTPStatus
 from unittest.mock import MagicMock, patch
@@ -406,6 +407,91 @@ class TestResources(unittest.TestCase):
 
         result3 = self.app.get("/api/run?task_id=1", headers=headers)
         self.assertEqual(result3.status_code, 200)
+
+    def test_run_patch_fails_pending_siblings(self):
+        org1 = Organization(name=str(uuid.uuid1()))
+        org2 = Organization(name=str(uuid.uuid1()))
+        col = Collaboration(name=str(uuid.uuid1()), organizations=[org1, org2])
+        col.save()
+
+        node1, api_key1 = self.create_node(organization=org1, collaboration=col)
+        node2, _ = self.create_node(organization=org2, collaboration=col)
+
+        task = Task(
+            image="localhost/algorithms/test:local",
+            collaboration=col,
+            init_org=org1,
+        )
+        task.save()
+
+        failing_run = Run(
+            task=task,
+            organization=org1,
+            status=TaskStatus.PENDING.value,
+        )
+        pending_sibling = Run(
+            task=task,
+            organization=org2,
+            status=TaskStatus.PENDING.value,
+        )
+        started_sibling = Run(
+            task=task,
+            organization=org2,
+            status=TaskStatus.PENDING.value,
+            started_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+        finished_sibling = Run(
+            task=task,
+            organization=org2,
+            status=TaskStatus.COMPLETED.value,
+            finished_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+        failing_run.save()
+        pending_sibling.save()
+        started_sibling.save()
+        finished_sibling.save()
+
+        try:
+            headers = self.login_node(api_key1)
+            response = self.app.patch(
+                f"/api/run/{failing_run.id}",
+                headers=headers,
+                json={"status": TaskStatus.FAILED.value},
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+
+            pending_sibling = Run.get(pending_sibling.id)
+            started_sibling = Run.get(started_sibling.id)
+            finished_sibling = Run.get(finished_sibling.id)
+
+            # Sibling runs not yet started shouldn't be in a state that would
+            # make it be picked up later (i.e. we want finished_at set)
+            self.assertEqual(pending_sibling.status, TaskStatus.FAILED.value)
+            self.assertIsNone(pending_sibling.started_at)
+            self.assertIsNotNone(pending_sibling.finished_at)
+            self.assertIn(
+                f"sibling run id={failing_run.id} failed",
+                pending_sibling.log,
+            )
+
+            # Started/finished siblings should not be touched by fail-fast update.
+            self.assertEqual(started_sibling.status, TaskStatus.PENDING.value)
+            self.assertIsNotNone(started_sibling.started_at)
+            self.assertIsNone(started_sibling.finished_at)
+
+            self.assertEqual(finished_sibling.status, TaskStatus.COMPLETED.value)
+            self.assertIsNotNone(finished_sibling.finished_at)
+        finally:
+            failing_run.delete()
+            pending_sibling.delete()
+            started_sibling.delete()
+            finished_sibling.delete()
+            task.delete()
+            node1.delete()
+            node2.delete()
+            col.delete()
+            org1.delete()
+            org2.delete()
 
     def test_task_with_id(self):
         headers = self.login("root")

--- a/vantage6-server/vantage6/server/resource/run.py
+++ b/vantage6-server/vantage6/server/resource/run.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from typing import Union
 import sqlalchemy as sa
@@ -9,6 +10,7 @@ from http import HTTPStatus
 from sqlalchemy import desc
 
 from vantage6.common import logger_name
+from vantage6.common.task_status import TaskStatus, has_task_failed
 from vantage6.server import db
 from vantage6.server.permission import (
     RuleCollection,
@@ -687,6 +689,30 @@ class Run(SingleRunBase):
         run.log = data.get("log")
         run.status = data.get("status", run.status)
         run.save()
+
+        # Fail-fast on sibling runs that have not started yet. This prevents
+        # delayed pickup/replay after one run already failed.
+        if has_task_failed(run.status):
+            siblings = (
+                g.session.query(db_Run)
+                .filter(db_Run.task_id == run.task_id)
+                .filter(db_Run.id != run.id)
+                .filter(db_Run.started_at.is_(None))
+                .filter(db_Run.finished_at.is_(None))
+                .all()
+            )
+            if siblings:
+                now = datetime.datetime.now(datetime.timezone.utc)
+                reason = (
+                    f"Marked as failed because sibling run id={run.id} "
+                    f"failed with status '{run.status}'."
+                )
+                for sibling in siblings:
+                    sibling.status = TaskStatus.FAILED.value
+                    sibling.finished_at = now
+                    if not sibling.log:
+                        sibling.log = reason
+                    sibling.save()
 
         return run_schema.dump(run, many=False), HTTPStatus.OK
 


### PR DESCRIPTION
Partially addresses #2371 by, when a run fails, marking its unstarted sibling runs as failed and setting their finished_at. This prevents delayed replay or pickup of stale sibling runs when offline nodes reconnect.

Before this change, those sibling runs were effectively marked failed once the offline node started: it failed to obtain a container token from the server and patched the run status to failed (but without setting finished_at). The server considers a task failed as soon as one run has failed, so it does not issue new container tokens for other runs of the same failed task.

IMHO this is maybe not the best behavior (run fails -> task fails -> all unstarted runs fail), but it is consistent current way behavior/semantics and avoids the bug mentioned in #2371. Although I would find it useful to have an option for a a run to start even if one of its siblings has already failed. 

Assisted-by: gpt-5.3-codex