### PR TITLE
fix: explicit ordering for task databases

### DIFF
--- a/vantage6-server/tests_server/test_models.py
+++ b/vantage6-server/tests_server/test_models.py
@@ -15,6 +15,7 @@ from vantage6.server.model import (
     Organization,
     Collaboration,
     Task,
+    TaskDatabase,
     Run,
     Node,
     Rule,
@@ -291,6 +292,14 @@ class TestTaskModel(TestBaseModel):
                 self.assertIsInstance(run, Run)
             for user in task.collaboration.organizations[0].users:
                 self.assertIsInstance(user, User)
+
+    def test_task_databases_relationship_has_explicit_ordering(self):
+        # Read configured relationship ORDER BY clauses.
+        order_by = tuple(Task.databases.property.order_by)
+        # Keep exactly one explicit sort key.
+        self.assertEqual(len(order_by), 1)
+        # Ensure ordering is by TaskDatabase.id.
+        self.assertEqual(str(order_by[0]), str(TaskDatabase.id.expression))
 
 
 class TestRuleModel(TestBaseModel):

--- a/vantage6-server/vantage6/server/model/task.py
+++ b/vantage6-server/vantage6/server/model/task.py
@@ -87,7 +87,13 @@ class Task(Base):
     results = relationship("Run", back_populates="task", viewonly=True)
     init_org = relationship("Organization", back_populates="tasks")
     init_user = relationship("User", back_populates="created_tasks")
-    databases = relationship("TaskDatabase", back_populates="task")
+    # Keep database label order deterministic for algorithms relying on
+    # positional database selection
+    databases = relationship(
+        "TaskDatabase",
+        back_populates="task",
+        order_by="TaskDatabase.id",
+    )
     study = relationship("Study", back_populates="tasks")
     algorithm_store = relationship("AlgorithmStore", back_populates="tasks")
 


### PR DESCRIPTION
Addresses #2383

Task database order was previously read through Task.databases without an explicit `ORDER BY`, so read order was not guaranteed (for example when creating subtasks). That is unsafe for algorithms that bind databases positionally (for example `@data(2)`).

Define Task.databases ordering by TaskDatabase.id to make read order deterministic.

Note that the decorator still perseveres the natural (IMHO) order. See https://github.com/vantage6/vantage6/pull/2063#discussion_r2160533880. But I'm not changing that as it's a breaking change for existing algorithms / task-creation-scripts, and we probably don't want to do that, I guess. Although I suspect very very few people are using multiple databases, or this bug would've popped up before.

Even better would be for algorithms to not rely on the order provided by the decorator or the researcher (i.e. named dataset arguments), but that'd be for another PR I think.

Assisted-by: gpt-5.3-codex