### PR TITLE
Allow skipping input decryption in UserClient.Run.get()

### DIFF
--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -1996,7 +1996,9 @@ class UserClient(ClientBase):
 
     class Run(ClientBase.SubClient):
         @post_filtering(iterable=False)
-        def get(self, id_: int, include_task: bool = False) -> dict:
+        def get(
+            self, id_: int, include_task: bool = False, decrypt_input: bool = True
+        ) -> dict:
             """View a specific run
 
             Parameters
@@ -2005,6 +2007,8 @@ class UserClient(ClientBase):
                 id of the run you want to inspect
             include_task : bool, optional
                 Whenever to include the task or not, by default False
+            decrypt_input : bool, optional
+                Whether to attempt decryption of the run input, by default True
             field: str, optional
                 Which data field to keep in the result. For instance, "field='name'"
                 will only return the name of the run. Default is None.
@@ -2018,14 +2022,13 @@ class UserClient(ClientBase):
             dict
                 Containing the run data
             """
-            self.parent.log.info("--> Attempting to decrypt results!")
-
             # get run from the API
             params = {"include": "task"} if include_task else {}
             run = self.parent.request(endpoint=f"run/{id_}", params=params)
 
-            # decrypt input
-            run = self._decrypt_input(run_data=run, is_single_run=True)
+            if decrypt_input:
+                self.parent.log.info("--> Attempting to decrypt run input!")
+                run = self._decrypt_input(run_data=run, is_single_run=True)
 
             return run
 


### PR DESCRIPTION
Addresses #2549

So as not to potentially break clients relying on current behavior, it's left as True (do decrypt input) by default. It also makes sense if the client's org is the same as the run's org, although I wouldn't argue that to be the most common use case.

Assisted-by: gpt-5.3-codex