### PR TITLE
Add database arguments support to run context

### DIFF
--- a/docs/features/algorithms/run_context.rst
+++ b/docs/features/algorithms/run_context.rst
@@ -80,7 +80,7 @@ explanatory only and are not part of the actual JSON file.
       // Minimal runtime identity of the executing node. Provides some extra
       // context that the algorithm might need to use for its operation
       "executor": {
-        "id": "some-node-id",
+        "id": 17,
         "kind": "vantage6-node"
       },
       // Data sources the algorithm should use
@@ -88,9 +88,25 @@ explanatory only and are not part of the actual JSON file.
         {
           "id": "default",
           "uri": "/mnt/data/default.csv",
-          "type": "csv"
+          "type": "csv",
+          // Eventually it might be better to move 'arguments'.* a level up
+          "arguments": {
+            "bind": "dataset"
+          }
+        },
+        {
+          // For example, a config file for the dataset itself
+          "id": "default_config",
+          "uri": "/mnt/data/default.yaml",
+          "type": "other",
+          // Eventually it might be better to move 'arguments'.* a level up
+          "arguments": {
+            "bind": "config"
+          }
         }
       ],
+      // For example, the researcher could have selected this input with:
+      // {"label": "somelabel", "arguments": {"bind": "dataset"}}
       // Locations where results should be written
       "outputs": [
         {
@@ -118,6 +134,12 @@ explanatory only and are not part of the actual JSON file.
 
 How this relates to the current vantage6 runtime
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If the researcher supplied ``arguments`` for a selected database when
+creating the task, those values are included in the corresponding
+``inputs[*].arguments`` object. Other top-level selector fields such as ``query``,
+``sheet_name`` and ``preprocessing`` are not currently copied into run
+context.
 
 As mentioned, vantage6 algorithms already receive runtime context through the
 existing vantage6-specific mechanism of written files and environment

--- a/vantage6-client/vantage6/client/__init__.py
+++ b/vantage6-client/vantage6/client/__init__.py
@@ -1802,10 +1802,13 @@ class UserClient(ClientBase):
                 not contain its own URL in the configuration (you will be alerted of
                 this in an error message).
             databases: list[dict], optional
-                Databases to be used at the node. Each dict should contain
-                at least a 'label' key. Additional keys are 'query' (if using
-                SQL/SPARQL databases), 'sheet_name' (if using Excel databases),
-                and 'preprocessing' information.
+                Databases to be used at the node. Each dict should contain at
+                least a 'label' key. Additional optional keys are 'query' (if
+                using SQL/SPARQL databases), 'sheet_name' (if using Excel
+                databases), 'preprocessing' information, and 'arguments'. When
+                a node enables the experimental `run_context_file` feature,
+                these arguments are exposed to the algorithm via the run
+                context input entry under `inputs[*].arguments`.
             field: str, optional
                 Which data field to keep in the returned dict. For instance,
                 "field='name'" will only return the name of the task. Default is None.

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -769,15 +769,26 @@ class DockerTaskManager(DockerBaseManager):
 
             if database.get("parameters"):
                 try:
-                    parameters = json.loads(database["parameters"])
+                    # The server stores all non-label database request fields
+                    # in TaskDatabase.parameters, including `query`,
+                    # `sheet_name` and `arguments`.
+                    database_parameters = json.loads(database["parameters"])
                 except Exception:
                     self.log.warning(
                         "Unable to parse parameters for database '%s' in run context",
                         label,
                     )
                 else:
-                    if isinstance(parameters, dict) and parameters:
-                        input_item["parameters"] = parameters
+                    # For run context, only surface the nested per-input `arguments`
+                    # object, not the other database request fields.
+                    # As we mature this run context idea, this might change.
+                    arguments = (
+                        database_parameters.get("arguments")
+                        if isinstance(database_parameters, dict)
+                        else None
+                    )
+                    if isinstance(arguments, dict):
+                        input_item["arguments"] = arguments
 
             inputs.append(input_item)
 

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -3323,6 +3323,111 @@ class TestResources(unittest.TestCase):
         # delete the 1 task that was created in this unit test
         Task.get()[::-1][0].delete()
 
+    def test_create_task_with_database_arguments(self):
+        org = Organization()
+        org.save()
+        col = Collaboration(organizations=[org], encrypted=False)
+        col.save()
+        node = Node(organization=org, collaboration=col)
+        node.save()
+
+        rule = Rule.get_by_("task", Scope.COLLABORATION, Operation.CREATE)
+        headers = self.create_user_and_login(org, rules=[rule])
+        input_ = bytes_to_base64s(serialize({"method": "dummy"}))
+
+        task_json = {
+            "collaboration_id": col.id,
+            "organizations": [{"id": org.id, "input": input_}],
+            "image": "some-image.invalid/invalid:invalid",
+            "databases": [
+                {
+                    "label": "default",
+                    "query": "SELECT * FROM records",
+                    "arguments": {
+                        "bind": "input_dataset",
+                        "group": "example",
+                    },
+                }
+            ],
+        }
+        results = self.app.post("/api/task", headers=headers, json=task_json)
+        self.assertEqual(results.status_code, HTTPStatus.CREATED)
+
+        first_task = Task.get(results.json["id"])
+        self.assertEqual(first_task.databases[0].database, "default")
+        self.assertEqual(
+            json.loads(first_task.databases[0].parameters),
+            {
+                "query": "SELECT * FROM records",
+                "arguments": {
+                    "bind": "input_dataset",
+                    "group": "example",
+                },
+            },
+        )
+
+        # arguments must be a dict
+        task_json["databases"] = [{"label": "default", "arguments": "dataset"}]
+        results = self.app.post("/api/task", headers=headers, json=task_json)
+        self.assertEqual(results.status_code, HTTPStatus.BAD_REQUEST)
+
+        # empty arguments are allowed
+        task_json["databases"] = [{"label": "default", "arguments": {}}]
+        results = self.app.post("/api/task", headers=headers, json=task_json)
+        self.assertEqual(results.status_code, HTTPStatus.CREATED)
+
+        empty_arguments_task = Task.get(results.json["id"])
+        self.assertEqual(
+            json.loads(empty_arguments_task.databases[0].parameters),
+            {"arguments": {}},
+        )
+
+        # omitting arguments is also allowed
+        task_json["databases"] = [{"label": "default"}]
+        results = self.app.post("/api/task", headers=headers, json=task_json)
+        self.assertEqual(results.status_code, HTTPStatus.CREATED)
+
+        no_arguments_task = Task.get(results.json["id"])
+        self.assertEqual(
+            json.loads(no_arguments_task.databases[0].parameters),
+            {},
+        )
+
+        # multiple databases can each carry their own arguments
+        task_json["databases"] = [
+            {
+                "label": "treatment",
+                "arguments": {"bind": "treatment_data"},
+            },
+            {
+                "label": "diagnosis",
+                "arguments": {"bind": "diagnosis_data"},
+            }
+        ]
+        results = self.app.post("/api/task", headers=headers, json=task_json)
+        self.assertEqual(results.status_code, HTTPStatus.CREATED)
+
+        second_task = Task.get(results.json["id"])
+        databases_by_label = {db.database: db for db in second_task.databases}
+        self.assertIn("treatment", databases_by_label)
+        self.assertIn("diagnosis", databases_by_label)
+        self.assertEqual(
+            json.loads(databases_by_label["treatment"].parameters),
+            {"arguments": {"bind": "treatment_data"}},
+        )
+        self.assertEqual(
+            json.loads(databases_by_label["diagnosis"].parameters),
+            {"arguments": {"bind": "diagnosis_data"}},
+        )
+
+        first_task.delete()
+        empty_arguments_task.delete()
+        no_arguments_task.delete()
+        second_task.delete()
+        node.delete()
+        org.delete()
+        col.delete()
+
     def test_delete_task_permissions(self):
         # test non-existing task
         headers = self.create_user_and_login()

--- a/vantage6-server/vantage6/server/resource/common/input_schema.py
+++ b/vantage6-server/vantage6/server/resource/common/input_schema.py
@@ -437,7 +437,16 @@ class TaskInputSchema(_NameValidationSchema):
                             f"Database preprocessing {prepro} is missing a "
                             "'function'"
                         )
-            allowed_keys = {"label", "preprocessing", "query", "sheet_name"}
+            if "arguments" in database:
+                if not isinstance(database["arguments"], dict):
+                    raise ValidationError("Database arguments must be a dict")
+            allowed_keys = {
+                "label",
+                "arguments",
+                "preprocessing",
+                "query",
+                "sheet_name",
+            }
             if not set(database.keys()).issubset(set(allowed_keys)):
                 raise ValidationError(
                     f"Database {database} contains unknown keys. Allowed keys "


### PR DESCRIPTION
Addresses #2534

Since this is being implemented on top of an experimental feature (run context), we are being cautious and just letting the researcher add an extra `arguments` parameter instead of trying to merge parameters. Meaning:

```json
{
  "label": "l",
  "query": "existing param",
  "sheet_name": "exists too already",
  "arguments": {
    "role": "config"
  }
}
```

instead of flattening everything into top-level database fields:

```json
{
  "label": "l",
  "query": "existing param",
  "sheet_name": "exists too already",
  "role": "config"
}
```

Those arguments will only be exposed in run_context (under `inputs[*].arguments`), not in the current env variables setup.

Assisted-by: gpt-5.3-codex