### PR TITLE
Update default docker registry address

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,9 +161,9 @@ jobs:
         with:
           ref: ${{ env.branch }}
 
-      - # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       # We need this for building multi-arch images
@@ -199,31 +199,34 @@ jobs:
         with:
           ref: ${{ env.branch }}
 
-      - # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
-      - # We need this for building multi-arch images
-        name: Set up Docker Buildx
+      # We need this for building multi-arch images
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - # we only release a new base image if it is a major or minor release
-        name: Build and push Docker base image
+      # we only release a new base image if it is a major or minor release
+      - name: Build and push Docker base image
         if: ${{ env.patch == 0 }}
         run: make base-image TAG=${major}.${minor} PUSH_REG=true TAG_LATEST=$tag_latest
 
-      - # build the actual infrastructure images
-        name: Build and push Docker image
-        run: make image TAG=$version BASE=${major}.${minor} PUSH_REG=true TAG_LATEST=$tag_latest
+      # build the actual infrastructure images
+      - name: Build and push Docker image
+        run: make image TAG=$version BASE=${major}.${minor} PUSH_REG=true
+          TAG_LATEST=$tag_latest
 
-      - # build the algorithm store image
-        name: Build and push Docker algorithm store image
-        run: make algorithm-store-image TAG=$version BASE=${major}.${minor} PUSH_REG=true TAG_LATEST=$tag_latest
+      # build the algorithm store image
+      - name: Build and push Docker algorithm store image
+        run: make algorithm-store-image TAG=$version BASE=${major}.${minor}
+          PUSH_REG=true TAG_LATEST=$tag_latest
 
-      - # build the UI image
-        name: Build and push UI image
-        run: make ui-image TAG=$version BASE=${major}.${minor} PUSH_REG=true TAG_LATEST=$tag_latest
+      # build the UI image
+      - name: Build and push UI image
+        run: make ui-image TAG=$version BASE=${major}.${minor} PUSH_REG=true
+          TAG_LATEST=$tag_latest
 
   algorithm-base-image:
     name: Build algorithm base image
@@ -250,9 +253,9 @@ jobs:
         with:
           ref: ${{ env.branch }}
 
-      - # Add support for more platforms with QEMU (optional)
-        # https://github.com/docker/setup-qemu-action
-        name: Set up QEMU
+      # Add support for more platforms with QEMU (optional)
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
       # We need this for building multi-arch images
@@ -261,17 +264,18 @@ jobs:
 
       - name: Build and push Algorithm base image
         if: ${{ env.stage == '' || env.patch == 0 }}
-        run: make algorithm-base-image TAG=${major}.${minor} PUSH_REG=true TAG_LATEST=$tag_latest
+        run: make algorithm-base-image TAG=${major}.${minor} PUSH_REG=true
+          TAG_LATEST=$tag_latest
 
       - name: Build and push Algorithm OMOP base image
         if: ${{ env.stage == '' || env.patch == 0 }}
-        run: make algorithm-omop-base-image BASE=${major}.${minor} TAG=${major}.${minor} PUSH_REG=true TAG_LATEST=$tag_latest
+        run: make algorithm-omop-base-image BASE=${major}.${minor} TAG=${major}.${minor}
+          PUSH_REG=true TAG_LATEST=$tag_latest
 
-  # Update the server and node images on harbor2 for this major version,
-  # including the 'live' tag that triggers a redeployment of the IKNL deployment
+  # Update the server and node images
   deploy:
     runs-on: ubuntu-latest
-    needs: [version, infrastructure-images, support-images]
+    needs: [ version, infrastructure-images, support-images ]
     env:
       version: ${{ needs.version.outputs.version }}
       major: ${{ needs.version.outputs.major }}
@@ -309,10 +313,10 @@ jobs:
           docker tag ghcr.io/${{ github.repository }}/algorithm-store:${version} ghcr.io/${{ github.repository }}/algorithm-store:${major_name}
           docker tag ghcr.io/${{ github.repository }}/ui:${version} ghcr.io/${{ github.repository }}/ui:${major_name}
 
-      - # Release a node image for major.minor. This is released for any
-        # non-candidate release or if no non-candidate release has been made yet
-        # for the current minor version
-        name: Build latest node minor image
+      # Release a node image for major.minor. This is released for any
+      # non-candidate release or if no non-candidate release has been made yet
+      # for the current minor version
+      - name: Build latest node minor image
         if: ${{ env.stage == '' || env.patch == 0 }}
         run: |
           docker tag ghcr.io/${{ github.repository }}/node:${version} ghcr.io/${{ github.repository }}/node:${major}.${minor}
@@ -327,10 +331,10 @@ jobs:
           docker push ghcr.io/${{ github.repository }}/algorithm-store:${major_name}
           docker push ghcr.io/${{ github.repository }}/ui:${major_name}
 
-      - # Release matching support images for major.minor. This is released for any
-        # non-candidate release or if no non-candidate release has been made yet
-        # for the current minor version
-        name: Build latest minor version support images
+      # Release matching support images for major.minor. This is released for any
+      # non-candidate release or if no non-candidate release has been made yet
+      # for the current minor version
+      - name: Build latest minor version support images
         if: ${{ env.stage == '' || env.patch == 0 }}
         run: |
           docker tag ghcr.io/${{ github.repository }}/alpine:${version} ghcr.io/${{ github.repository }}/alpine:${major}.${minor}
@@ -357,7 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     # Note: infrastructure-images is not a required dependency, but we want
     # to ensure that step succeeds before pushing the code to PyPi
-    needs: [version, infrastructure-images]
+    needs: [ version, infrastructure-images ]
     env:
       version: ${{ needs.version.outputs.version }}
       major: ${{ needs.version.outputs.major }}
@@ -402,7 +406,7 @@ jobs:
   # When the project is built and released the Discord community is notified.
   notify:
     runs-on: ubuntu-latest
-    needs: [version, build-n-release, deploy]
+    needs: [ version, build-n-release, deploy ]
     env:
       version: ${{ needs.version.outputs.version }}
       stage: ${{ needs.version.outputs.stage }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,13 @@ jobs:
       stage: ${{ needs.version.outputs.stage }}
       tag_latest: ${{ needs.version.outputs.tag_latest }}
     steps:
-      - name: Login to harbor2.vantage6.ai
-        env:
-          USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_TOKEN }}
-        run: docker login harbor2.vantage6.ai -u $USERNAME -p $PASSWORD
+      - name: Log in to GHCR
+        # https://github.com/docker/login-action/releases/tag/v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -184,11 +186,13 @@ jobs:
       branch: ${{ needs.version.outputs.branch }}
       tag_latest: ${{ needs.version.outputs.tag_latest }}
     steps:
-      - name: Login to harbor2.vantage6.ai
-        env:
-          USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_TOKEN }}
-        run: docker login harbor2.vantage6.ai -u $USERNAME -p $PASSWORD
+      - name: Log in to GHCR
+        # https://github.com/docker/login-action/releases/tag/v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -234,12 +238,13 @@ jobs:
       tag_latest: ${{ needs.version.outputs.tag_latest }}
 
     steps:
-      - name: Login to harbor2.vantage6.ai
-        env:
-          USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_TOKEN }}
-        run: docker login harbor2.vantage6.ai -u $USERNAME -p $PASSWORD
-
+      - name: Log in to GHCR
+        # https://github.com/docker/login-action/releases/tag/v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -275,33 +280,34 @@ jobs:
       stage: ${{ needs.version.outputs.stage }}
       major_name: ${{ needs.version.outputs.major_name }}
     steps:
-      - name: Login to harbor2.vantage6.ai
-        env:
-          USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          PASSWORD: ${{ secrets.DOCKER_TOKEN }}
-        run: |
-          docker login harbor2.vantage6.ai -u $USERNAME -p $PASSWORD
+      - name: Log in to GHCR
+        # https://github.com/docker/login-action/releases/tag/v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Pull docker images
         run: |
-          docker pull harbor2.vantage6.ai/infrastructure/server:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/node:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/algorithm-store:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/ui:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/alpine:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/vpn-client:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/vpn-configurator:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/ssh-tunnel:${version}
-          docker pull harbor2.vantage6.ai/infrastructure/squid:${version}
+          docker pull ghcr.io/${{ github.repository }}/server:${version}
+          docker pull ghcr.io/${{ github.repository }}/node:${version}
+          docker pull ghcr.io/${{ github.repository }}/algorithm-store:${version}
+          docker pull ghcr.io/${{ github.repository }}/ui:${version}
+          docker pull ghcr.io/${{ github.repository }}/alpine:${version}
+          docker pull ghcr.io/${{ github.repository }}/vpn-client:${version}
+          docker pull ghcr.io/${{ github.repository }}/vpn-configurator:${version}
+          docker pull ghcr.io/${{ github.repository }}/ssh-tunnel:${version}
+          docker pull ghcr.io/${{ github.repository }}/squid:${version}
 
       - name: Tag docker images
         if: ${{  env.stage == ''  &&  env.major_name != '' }}
         run: |
-          docker tag harbor2.vantage6.ai/infrastructure/server:${version} harbor2.vantage6.ai/infrastructure/server:${major_name}
-          docker tag harbor2.vantage6.ai/infrastructure/server:${version} harbor2.vantage6.ai/infrastructure/server:${major_name}-live
-          docker tag harbor2.vantage6.ai/infrastructure/node:${version} harbor2.vantage6.ai/infrastructure/node:${major_name}
-          docker tag harbor2.vantage6.ai/infrastructure/algorithm-store:${version} harbor2.vantage6.ai/infrastructure/algorithm-store:${major_name}
-          docker tag harbor2.vantage6.ai/infrastructure/ui:${version} harbor2.vantage6.ai/infrastructure/ui:${major_name}
+          docker tag ghcr.io/${{ github.repository }}/server:${version} ghcr.io/${{ github.repository }}/server:${major_name}
+          docker tag ghcr.io/${{ github.repository }}/server:${version} ghcr.io/${{ github.repository }}/server:${major_name}-live
+          docker tag ghcr.io/${{ github.repository }}/node:${version} ghcr.io/${{ github.repository }}/node:${major_name}
+          docker tag ghcr.io/${{ github.repository }}/algorithm-store:${version} ghcr.io/${{ github.repository }}/algorithm-store:${major_name}
+          docker tag ghcr.io/${{ github.repository }}/ui:${version} ghcr.io/${{ github.repository }}/ui:${major_name}
 
       - # Release a node image for major.minor. This is released for any
         # non-candidate release or if no non-candidate release has been made yet
@@ -309,17 +315,17 @@ jobs:
         name: Build latest node minor image
         if: ${{ env.stage == '' || env.patch == 0 }}
         run: |
-          docker tag harbor2.vantage6.ai/infrastructure/node:${version} harbor2.vantage6.ai/infrastructure/node:${major}.${minor}
-          docker push harbor2.vantage6.ai/infrastructure/node:${major}.${minor}
+          docker tag ghcr.io/${{ github.repository }}/node:${version} ghcr.io/${{ github.repository }}/node:${major}.${minor}
+          docker push ghcr.io/${{ github.repository }}/node:${major}.${minor}
 
       - name: Push docker images
         if: ${{  env.stage == ''  &&  env.major_name != '' }}
         run: |
-          docker push harbor2.vantage6.ai/infrastructure/server:${major_name}
-          docker push harbor2.vantage6.ai/infrastructure/server:${major_name}-live
-          docker push harbor2.vantage6.ai/infrastructure/node:${major_name}
-          docker push harbor2.vantage6.ai/infrastructure/algorithm-store:${major_name}
-          docker push harbor2.vantage6.ai/infrastructure/ui:${major_name}
+          docker push ghcr.io/${{ github.repository }}/server:${major_name}
+          docker push ghcr.io/${{ github.repository }}/server:${major_name}-live
+          docker push ghcr.io/${{ github.repository }}/node:${major_name}
+          docker push ghcr.io/${{ github.repository }}/algorithm-store:${major_name}
+          docker push ghcr.io/${{ github.repository }}/ui:${major_name}
 
       - # Release matching support images for major.minor. This is released for any
         # non-candidate release or if no non-candidate release has been made yet
@@ -327,21 +333,20 @@ jobs:
         name: Build latest minor version support images
         if: ${{ env.stage == '' || env.patch == 0 }}
         run: |
-          docker tag harbor2.vantage6.ai/infrastructure/alpine:${version} harbor2.vantage6.ai/infrastructure/alpine:${major}.${minor}
-          docker push harbor2.vantage6.ai/infrastructure/alpine:${major}.${minor}
+          docker tag ghcr.io/${{ github.repository }}/alpine:${version} ghcr.io/${{ github.repository }}/alpine:${major}.${minor}
+          docker push ghcr.io/${{ github.repository }}/alpine:${major}.${minor}
 
-          docker tag harbor2.vantage6.ai/infrastructure/vpn-client:${version} harbor2.vantage6.ai/infrastructure/vpn-client:${major}.${minor}
-          docker push harbor2.vantage6.ai/infrastructure/vpn-client:${major}.${minor}
+          docker tag ghcr.io/${{ github.repository }}/vpn-client:${version} ghcr.io/${{ github.repository }}/vpn-client:${major}.${minor}
+          docker push ghcr.io/${{ github.repository }}/vpn-client:${major}.${minor}
 
-          docker tag harbor2.vantage6.ai/infrastructure/vpn-configurator:${version} harbor2.vantage6.ai/infrastructure/vpn-configurator:${major}.${minor}
-          docker push harbor2.vantage6.ai/infrastructure/vpn-configurator:${major}.${minor}
+          docker tag ghcr.io/${{ github.repository }}/vpn-configurator:${version} ghcr.io/${{ github.repository }}/vpn-configurator:${major}.${minor}
+          docker push ghcr.io/${{ github.repository }}/vpn-configurator:${major}.${minor}
 
-          docker tag harbor2.vantage6.ai/infrastructure/ssh-tunnel:${version} harbor2.vantage6.ai/infrastructure/ssh-tunnel:${major}.${minor}
-          docker push harbor2.vantage6.ai/infrastructure/ssh-tunnel:${major}.${minor}
+          docker tag ghcr.io/${{ github.repository }}/ssh-tunnel:${version} ghcr.io/${{ github.repository }}/ssh-tunnel:${major}.${minor}
+          docker push ghcr.io/${{ github.repository }}/ssh-tunnel:${major}.${minor}
 
-          docker tag harbor2.vantage6.ai/infrastructure/squid:${version} harbor2.vantage6.ai/infrastructure/squid:${major}.${minor}
-          docker push harbor2.vantage6.ai/infrastructure/squid:${major}.${minor}
-
+          docker tag ghcr.io/${{ github.repository }}/squid:${version} ghcr.io/${{ github.repository }}/squid:${major}.${minor}
+          docker push ghcr.io/${{ github.repository }}/squid:${major}.${minor}
 
   # Build an release all the vantage6 infrastructure packages. For all
   # the packages it will (1) update the version as specified in the tag,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # docker image tag
 TAG ?= cotopaxi
-REGISTRY ?= harbor2.vantage6.ai
+REGISTRY ?= ghcr.io/vantage6
 PLATFORMS ?= linux/arm64,linux/amd64
 # Example for local development
 # TAG ?= local

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ easily.
 ### Docker images
 
 The vantage6 infrastructure is delivered in Docker images. All Docker images are stored
-in our private [Harbor](https://goharbor.io/) registry. The most important images are:
+in the vantage6 GitHub Container Registry. The most important images are:
 
 - `ghcr.io/vantage6/node:VERSION` -> _Node application Docker image_
 - `ghcr.io/vantage6/server:VERSION` -> _Server application Docker image_

--- a/README.md
+++ b/README.md
@@ -146,34 +146,34 @@ easily.
 The vantage6 infrastructure is delivered in Docker images. All Docker images are stored
 in our private [Harbor](https://goharbor.io/) registry. The most important images are:
 
-- `harbor2.vantage6.ai/infrastructure/node:VERSION` -> _Node application Docker image_
-- `harbor2.vantage6.ai/infrastructure/server:VERSION` -> _Server application Docker image_
-- `harbor2.vantage6.ai/infrastructure/ui:VERSION` -> _User interface Docker image_
-- `harbor2.vantage6.ai/infrastructure/algorithm-store:VERSION` -> _Algorithm store Docker image_
+- `ghcr.io/vantage6/node:VERSION` -> _Node application Docker image_
+- `ghcr.io/vantage6/server:VERSION` -> _Server application Docker image_
+- `ghcr.io/vantage6/ui:VERSION` -> _User interface Docker image_
+- `ghcr.io/vantage6/algorithm-store:VERSION` -> _Algorithm store Docker image_
 
 with `VERSION` being the full semantic version of the vantage6 infrastructure, e.g.
 `4.0.0` or `4.1.0rc0`.
 
 Several other images are used to support the infrastructure:
 
-- `harbor2.vantage6.ai/infrastructure/infrastructure-base:VERSION` -> _Base image for the infrastructure_
-- `harbor2.vantage6.ai/infrastructure/squid:VERSION` -> _Squid proxy image used for the whitelisting service_
-- `harbor2.vantage6.ai/infrastructure/alpine` -> _Alpine image used for vpn traffic forwarding_
-- `harbor2.vantage6.ai/infrastructure/vpn-client` -> _VPN image used to connect to the VPN_
-- `harbor2.vantage6.ai/infrastructure/vpn-configurator` -> _VPN image used for initialization_
-- `harbor2.vantage6.ai/infrastructure/ssh-tunnel` -> _SSH tunnel image used for connecting algorithms to external services_
+- `ghcr.io/vantage6/infrastructure-base:VERSION` -> _Base image for the infrastructure_
+- `ghcr.io/vantage6/squid:VERSION` -> _Squid proxy image used for the whitelisting service_
+- `ghcr.io/vantage6/alpine` -> _Alpine image used for vpn traffic forwarding_
+- `ghcr.io/vantage6/vpn-client` -> _VPN image used to connect to the VPN_
+- `ghcr.io/vantage6/vpn-configurator` -> _VPN image used for initialization_
+- `ghcr.io/vantage6/ssh-tunnel` -> _SSH tunnel image used for connecting algorithms to external services_
 
 And finally there are some images released for algorithm development:
 
-- `harbor2.vantage6.ai/infrastructure/algorithm-base:MAJOR.MINOR` -> _Base image for algorithm development_
-- `harbor2.vantage6.ai/infrastructure/algorithm-ohdsi-base:MAJOR.MINOR` -> _Extended algorithm base image for OHDSI algorithm development_
+- `ghcr.io/vantage6/algorithm-base:MAJOR.MINOR` -> _Base image for algorithm development_
+- `ghcr.io/vantage6/algorithm-ohdsi-base:MAJOR.MINOR` -> _Extended algorithm base image for OHDSI algorithm development_
 
 ## :gift_heart: Join the community!
 
-We hope to continue developing, improving, and supporting **vantage6** with the help of 
-the federated learning community. If you are interested in contributing, first of all, 
-thank you! Second, please take a look at our 
-[contributing guidelines](https://docs.vantage6.ai/en/main/devops/contribute.html) 
+We hope to continue developing, improving, and supporting **vantage6** with the help of
+the federated learning community. If you are interested in contributing, first of all,
+thank you! Second, please take a look at our
+[contributing guidelines](https://docs.vantage6.ai/en/main/devops/contribute.html)
 and our [code of conduct](CODE_OF_CONDUCT.md).
 
 <a href="https://github.com/vantage6/vantage6/graphs/contributors">

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -23,7 +23,7 @@
 
 services:
   node:
-    image: harbor2.vantage6.ai/infrastructure/node:cotopaxi
+    image: ghcr.io/vantage6/node:cotopaxi
     container_name: vantage6-<NODE_NAME>-user
     restart: unless-stopped
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
-version: '4'
+version: "4"
 services:
-
   vantage6-server:
     # build: .
-    image: harbor2.vantage6.ai/infrastructure/server:latest
+    image: ghcr.io/vantage6/server:latest
     dockerfile: server.Dockerfile
     ports:
       - "7601:7601"
@@ -13,12 +12,12 @@ services:
       # - ./configs/sqlite.yaml:/mnt/config.yaml
       - ./configs/postgress.yaml:/mnt/config.yaml
     command: [
-      "uwsgi --http :7601 --gevent 1000 --http-websockets
+        "uwsgi --http :7601 --gevent 1000 --http-websockets
         --http-chunked-input --http-keepalive --post-buffering 0
         --master --callable app --disable-logging
         --wsgi-file /vantage6/vantage6-server/vantage6/server/wsgi.py
-        --pyargv /mnt/config.yaml"
-    ]
+        --pyargv /mnt/config.yaml",
+      ]
 
   database:
     image: postgres:10

--- a/docker/algorithm-ohdsi-base.Dockerfile
+++ b/docker/algorithm-ohdsi-base.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE=4.0
 # We could do this by supplying an environment var or store a requirements.txt
 # file in the repo.however for now lets always use the latest in a build.
 # ARG OHDSI_VERSION=0.3.2
-FROM harbor2.vantage6.ai/infrastructure/algorithm-base:${BASE}
+FROM ghcr.io/vantage6/algorithm-base:${BASE}
 
 LABEL version=${TAG}
 # LABEL ohdsi_version=${OHDSI_VERSION}
@@ -53,4 +53,3 @@ RUN pip install psycopg2-binary
 # FIXME FM 5-9-2023: This is a bit to broad, it would be better to figure out
 # a way to only set this for the OHDSI R packages.
 ENV LD_LIBRARY_PATH=/usr/lib/jvm/java-17-openjdk-amd64/lib/server/
-

--- a/docker/algorithm-store.Dockerfile
+++ b/docker/algorithm-store.Dockerfile
@@ -2,11 +2,11 @@
 #
 # IMAGE
 # -----
-# * harbor2.vantage6.ai/infrastructure/algorithm-store:x.x.x
+# * ghcr.io/vantage6/algorithm-store:x.x.x
 #
 ARG TAG=latest
 ARG BASE=4.14
-FROM harbor2.vantage6.ai/infrastructure/infrastructure-base:${BASE}
+FROM ghcr.io/vantage6/infrastructure-base:${BASE}
 
 LABEL version=${TAG}
 LABEL maintainer="Frank Martin <f.martin@iknl.nl>; Bart van Beusekom <b.vanbeusekom@iknl.nl>"

--- a/docker/node-and-server.Dockerfile
+++ b/docker/node-and-server.Dockerfile
@@ -2,12 +2,12 @@
 #
 # IMAGES
 # ------
-# * harbor2.vantage6.ai/infrastructure/node:x.x.x
-# * harbor2.vantage6.ai/infrastructure/server:x.x.x
+# * ghcr.io/vantage6/node:x.x.x
+# * ghcr.io/vantage6/server:x.x.x
 #
 ARG TAG=latest
 ARG BASE=4.14
-FROM harbor2.vantage6.ai/infrastructure/infrastructure-base:${BASE}
+FROM ghcr.io/vantage6/infrastructure-base:${BASE}
 
 LABEL version=${TAG}
 LABEL maintainer="Frank Martin <f.martin@iknl.nl>"

--- a/docs/algorithm_store/deploy.rst
+++ b/docs/algorithm_store/deploy.rst
@@ -37,7 +37,7 @@ of a docker-compose file that can be used to deploy the algorithm store.
 
     services:
       vantage6-algorithm-store:
-        image: harbor2.vantage6.ai/infrastructure/algorithm-store:cotopaxi
+        image: ghcr.io/vantage6/algorithm-store:cotopaxi
         ports:
         - "8000:5000"
         volumes:

--- a/docs/algorithm_store/install.rst
+++ b/docs/algorithm_store/install.rst
@@ -2,8 +2,8 @@
 
 .. |instance-type| replace:: algorithm store
 .. |requirements-link| replace:: :ref:`requirements <algorithm-store-requirements>`
-.. |image| replace:: ``harbor2.vantage6.ai/infrastructure/algorithm-store``
-.. |image-old| replace:: ``harbor2.vantage6.ai/infrastructure/algorithm-store:<VERSION>``
+.. |image| replace:: ``ghcr.io/vantage6/algorithm-store``
+.. |image-old| replace:: ``ghcr.io/vantage6/algorithm-store:<VERSION>``
 .. |deployment-link| replace:: :ref:`deployment <algorithm-store-deployment>`
 
 .. include:: ../common/install.rst

--- a/docs/algorithms/develop.rst
+++ b/docs/algorithms/develop.rst
@@ -263,11 +263,11 @@ Here are a few examples of how to build and upload your image:
     docker build -t my-user-name/algorithm-example:latest .
     docker push my-user-name/algorithm-example:latest
 
-    # Build and upload to private registry. Here you don't need to provide
-    # a username but you should write out the full image URL. Also, again you
+    # Build and upload to private registry (GCR as example). Here you don't need to
+    # provide a username but you should write out the full image URL. Also, again you
     # need to be logged in with ``docker login``.
-    docker build -t harbor2.vantage6.ai/PROJECT/algorithm-example:latest .
-    docker push harbor2.vantage6.ai/PROJECT/algorithm-example:latest
+    docker build -t ghcr.io/vantage6/algorithm-example:latest .
+    docker push ghcr.io/vantage6/algorithm-example:latest
 
 Now that your algorithm has been uploaded it is available for nodes to retrieve
 when they need it.
@@ -330,7 +330,7 @@ execution result. For example, to test the average algorithm, the script could l
             collaboration=1,
             organizations=[1],
             name="test_average_task",
-            image="harbor2.vantage6.ai/demo/average",
+            image="ghcr.io/vantage6/algorithm-average:latest",
             description="",
             input_=input_,
             databases=[{"label": "olympic_athletes"}],

--- a/docs/devops/release.rst
+++ b/docs/devops/release.rst
@@ -67,13 +67,13 @@ the following steps to test a release:
   .. code:: bash
 
     v6 dev create-demo-network \
-        -i harbor2.vantage6.ai/infrastructure/server:<version> \
-        --ui-image harbor2.vantage6.ai/infrastructure/ui:<version>
+        -i ghcr.io/vantage6/server:<version> \
+        --ui-image ghcr.io/vantage6/ui:<version>
 
     v6 dev start-demo-network \
-        --server-image harbor2.vantage6.ai/infrastructure/server:<version> \
-        --node-image harbor2.vantage6.ai/infrastructure/node:<version> \
-        --store-image harbor2.vantage6.ai/infrastructure/algorithm-store:<version>
+        --server-image ghcr.io/vantage6/server:<version> \
+        --node-image ghcr.io/vantage6/node:<version> \
+        --store-image ghcr.io/vantage6/algorithm-store:<version>
 
 4. *Test code changes*. Go through all issues that are part of the new release
    and test if they work as intended.
@@ -218,8 +218,8 @@ Docker images can be pulled manually with e.g.
 
 ::
 
-  docker pull harbor2.vantage6.ai/infrastructure/server:cotopaxi
-  docker pull harbor2.vantage6.ai/infrastructure/node:3.1.0
+  docker pull ghcr.io/vantage6/server:cotopaxi
+  docker pull ghcr.io/vantage6/node:3.1.0
 
 User Interface release
 ----------------------

--- a/docs/devops/release.rst
+++ b/docs/devops/release.rst
@@ -149,8 +149,8 @@ The release pipeline executes the following steps:
    tag and commit this back to the main branch.
 3. Install the dependencies and build the Python package.
 4. Upload the package to PyPi.
-5. Build and push the Docker image to `harbor2.vantage6.ai
-   <https://harbor2.vantage6.ai>`_.
+5. Build and push the Docker image to `ghcr.io/vantage6
+   <https://ghcr.io/vantage6>`_.
 6. Post a message in Discord to alert the community of the new release. This
    is not done if the version is a pre-release (e.g. version/x.y.0rc1).
 
@@ -181,7 +181,7 @@ in the table below.
      - Token from coveralls to post the test coverage stats.
    * - ``DOCKER_TOKEN``
      - Token used together ``DOCKER_USERNAME`` to upload the container images
-       to our `<https://harbor2.vantage6.ai>`_.
+       to `<https://ghcr.io/vantage6>`_.
    * - ``DOCKER_USERNAME``
      - See ``DOCKER_TOKEN``.
    * - ``PYPI_TOKEN``
@@ -239,7 +239,7 @@ The release pipeline for the UI executes the following steps:
 1. Version tag is verified (same as infrastructure).
 2. Version is updated in the code (same as infrastructure).
 3. Application is built.
-4. Docker images are built and released to harbor2.
+4. Docker images are built and released to ghcr.io/vantage6.
 5. Application is pushed to our UI deployment slot (an Azure app service).
 
 
@@ -252,7 +252,7 @@ updated upon new releases, as is for instance the case for the Cotopaxi server.
 
 For Cotopaxi, the following checks are done:
 
-- Check that harbor2.vantage6.ai has updated images ``server:cotopaxi``,
+- Check that ghcr.io/vantage6 has updated images ``server:cotopaxi``,
   ``server:cotopaxi-live`` and ``node:cotopaxi``.
 - Check if the (live) server version is updated. Go to:
   https://cotopaxi.vantage6.ai/version. Check logs if it is not updated.

--- a/docs/features/server/api_structure.rst
+++ b/docs/features/server/api_structure.rst
@@ -11,7 +11,7 @@ same way, loosely following HATEOAS rules. An example is detailed below:
       "id": 1,
       "name": "test",
       "results": "/api/result?task_id=1",
-      "image": "harbor2.vantage6.ai/testing/v6-test-py",
+      "image": "ghcr.io/vantage6/algorithm-test:latest",
       ...
   }
 

--- a/docs/node/configure.rst
+++ b/docs/node/configure.rst
@@ -111,18 +111,18 @@ There are two important steps to be taken to accomplish this:
 
       policies:
          allowed_algorithms:
-            - ^harbor2\.vantage6\.ai/[a-zA-Z]+/[a-zA-Z]+
-            - ^harbor2\.vantage6\.ai/algorithms/glm$
-            - ^harbor2\.vantage6\.ai/algorithms/glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$
+            - ^ghcr\.io/vantage6/[a-zA-Z]+/[a-zA-Z]+
+            - ^ghcr\.io/vantage6/algorithm-glm$
+            - ^ghcr\.io/vantage6/algorithm-glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$
          allowed_algorithm_stores:
             - https://store.cotopaxi.vantage6.ai
 
    These four examples lead to the following restrictions:
-   1. ``^harbor2\.vantage6\.ai/[a-zA-Z]+/[a-zA-Z]+``: allow all images
-      from the harbor2.vantage6.ai registry
-   2. ``^harbor2\.vantage6\.ai/algorithms/glm$``: only allow the GLM image, but
+   1. ``^ghcr\.io/vantage6/[a-zA-Z]+/[a-zA-Z]+``: allow all images
+      from the ghcr.io/vantage6 registry
+   2. ``^ghcr\.io/vantage6/algorithm-glm$``: only allow the GLM image, but
       all builds of this image
-   3. ``^harbor2\.vantage6\.ai/algorithms/glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8``
+   3. ``^ghcr\.io/vantage6/algorithm-glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$``
       ``a1e597d83a47fac21d6af3$``: allows only this specific build from the GLM
       image to run on your data
    4. ``https://store.cotopaxi.vantage6.ai``: allow all algorithms from the

--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -132,8 +132,8 @@ policies:
   # expected to be a valid regular expression. If you don't specify this, all algorithm
   # images are allowed to run on this node (unless other policies restrict this).
   allowed_algorithms:
-    - ^harbor2\.vantage6\.ai/[a-zA-Z]+/[a-zA-Z]+
-    - ^myalgorithm\.ai/some-algorithm
+    - ^ghcr\.io/vantage6/[a-zA-Z]+/[a-zA-Z]+$
+    - ^ghcr\.io/vantage6/algorithm-glm$
 
   # It is also possible to allow all algorithms from particular algorithm stores. Set
   # these stores here. They may be strings or regular expressions. If you don't specify
@@ -160,7 +160,7 @@ policies:
     - 6
     - root
 
-  # The basics algorithm (harbor2.vantage5.ai/algorithms/basics) is whitelisted
+  # The basics algorithm (ghcr.io/vantage6/algorithm-basics:latest) is whitelisted
   # by default. It is used to collect column names in the User Interface to
   # facilitate task creation. Set to false to disable this.
   allow_basics_algorithm: true

--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -56,12 +56,12 @@ node_extra_hosts:
 # components.
 # OPTIONAL
 images:
-  node: harbor2.vantage6.ai/infrastructure/node:cotopaxi
-  alpine: harbor2.vantage6.ai/infrastructure/alpine
-  vpn_client: harbor2.vantage6.ai/infrastructure/vpn-client
-  network_config: harbor2.vantage6.ai/infrastructure/vpn-configurator
-  ssh_tunnel: harbor2.vantage6.ai/infrastructure/ssh-tunnel
-  squid: harbor2.vantage6.ai/infrastructure/squid
+  node: ghcr.io/vantage6/node:cotopaxi
+  alpine: ghcr.io/vantage6/alpine
+  vpn_client: ghcr.io/vantage6/vpn-client
+  network_config: ghcr.io/vantage6/vpn-configurator
+  ssh_tunnel: ghcr.io/vantage6/ssh-tunnel
+  squid: ghcr.io/vantage6/squid
 
 # path or endpoint to the local data source. The client can request a
 # certain database by using its label. The type is used by the

--- a/docs/server/deploy.rst
+++ b/docs/server/deploy.rst
@@ -129,7 +129,7 @@ may want to use a different image tag, or you may want to use a different port.
 
     services:
       vantage6-server:
-        image: harbor2.vantage6.ai/infrastructure/server:cotopaxi
+        image: ghcr.io/vantage6/server:cotopaxi
         ports:
         - "8000:80"
         volumes:
@@ -147,7 +147,7 @@ look something like this if you want to use `secrets in docker compose
 
     services:
       vantage6-server:
-        image: harbor2.vantage6.ai/infrastructure/server:cotopaxi
+        image: ghcr.io/vantage6/server:cotopaxi
         ports:
         - "8000:80"
         environment:

--- a/docs/server/install.rst
+++ b/docs/server/install.rst
@@ -2,8 +2,8 @@
 
 .. |instance-type| replace:: server
 .. |requirements-link| replace:: :ref:`requirements <server-requirements>`
-.. |image| replace:: ``harbor2.vantage6.ai/infrastructure/server``
-.. |image-old| replace:: ``harbor2.vantage6.ai/infrastructure/server:<VERSION>``
+.. |image| replace:: ``ghcr.io/vantage6/server``
+.. |image-old| replace:: ``ghcr.io/vantage6/server:<VERSION>``
 .. |deployment-link| replace:: :ref:`deployment <server-deployment>`
 
 .. include:: ../common/install.rst

--- a/docs/server/optional.rst
+++ b/docs/server/optional.rst
@@ -56,7 +56,7 @@ to your own environment.
     name: run-ui
     services:
       ui:
-        image: harbor2.vantage6.ai/infrastructure/ui:cotopaxi
+        image: ghcr.io/vantage6/ui:cotopaxi
         ports:
           - "8000:80"
         environment:
@@ -396,10 +396,10 @@ Just remember that you need to configure the server to use your SMTP server
 Azure Blob Storage
 """"""""""""""""""
 
-For algorithms that require large inputs or outputs, the default relational 
+For algorithms that require large inputs or outputs, the default relational
 database is not well suited. Azure blob storage can be used
 instead. In this case, references to the inputs and results will be stored
-in the database, whereas the actual data is stored in `Azure Blob Storage 
+in the database, whereas the actual data is stored in `Azure Blob Storage
 <https://azure.microsoft.com/en-us/products/storage/blobs>`__. See
 :ref:`server-configure` for more details on the configuration,
 and :ref:`blob-storage` for more information.

--- a/docs/server/optional.rst
+++ b/docs/server/optional.rst
@@ -91,12 +91,21 @@ private registry.
   This specification is supported by all major container registry providers, such
   as Docker Hub, Harbor, Azure Container Registry and Github container registry.
 
+Github Container Registry
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Github Container Registry is a private registry that is provided by Github. It is a
+turn-key solution for hosting your own Docker images. It is free to use (at time of
+writing) and links to your Github repository. We use it to host the main vantage6
+images.
+
 Harbor
 ~~~~~~
 
-Our preferred solution for hosting a Docker registry is
+Another solution for hosting a Docker registry is
 `Harbor <https://goharbor.io>`_. Harbor provides access control, a user
-interface and automated scanning on vulnerabilities.
+interface and automated scanning on vulnerabilities. This setup is more complex, but it
+offers more features.
 
 Docker Hub
 ~~~~~~~~~~

--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -161,8 +161,8 @@ vpn_server:
 # components.
 # OPTIONAL
 images:
-  server: harbor2.vantage6.ai/infrastructure/server:cotopaxi
-  ui: harbor2.vantage6.ai/infrastructure/ui:cotopaxi
+  server: ghcr.io/vantage6/server:cotopaxi
+  ui: ghcr.io/vantage6/ui:cotopaxi
 
 # options for starting the User Interface when starting the server
 ui:

--- a/docs/user/pyclient.rst
+++ b/docs/user/pyclient.rst
@@ -316,7 +316,7 @@ Here we assume that
 -  the nodes are configured to look at the right database
 
 In this manual, we'll use the averaging algorithm from
-``harbor2.vantage6.ai/demo/average``, so the second requirement is met.
+``ghcr.io/vantage6/algorithm-average:latest``, so the second requirement is met.
 We'll assume the nodes in your collaboration have been configured to look as
 something like:
 
@@ -383,7 +383,7 @@ on each node). Typically, the partial methods only run the node local analysis
 performs aggregation of those results as well (e.g. starts the partial
 analyses and then computes the overall average). First, let
 us create a task that runs the central part of the
-``harbor2.vantage6.ai/demo/average`` algorithm:
+``ghcr.io/vantage6/algorithm-average:latest`` algorithm:
 
 .. code:: python
 
@@ -396,7 +396,7 @@ us create a task that runs the central part of the
       collaboration=1,
       organizations=[2],
       name="an-awesome-task",
-      image="harbor2.vantage6.ai/demo/average",
+      image="ghcr.io/vantage6/algorithm-average:latest",
       description='',
       input_=input_,
       databases=[
@@ -445,12 +445,14 @@ central part of the algorithm will normally do:
        'kwargs': {'column_name': 'age'},
    }
 
-   average_task = client.task.create(collaboration=1,
-                                     organizations=[2,3],
-                                     name="an-awesome-task",
-                                     image="harbor2.vantage6.ai/demo/average",
-                                     description='',
-                                     input_=input_)
+   average_task = client.task.create(
+      collaboration=1,
+      organizations=[2,3],
+      name="an-awesome-task",
+      image="ghcr.io/vantage6/algorithm-average:latest",
+      description='',
+      input_=input_
+   )
 
 Note that when running the partial algorithm, you should run it on all organizations
 that you want to get the results from. In this example, we run the partial algorithm

--- a/tools/update-discord.py
+++ b/tools/update-discord.py
@@ -110,7 +110,7 @@ class PostUpdates(commands.Cog):
         )
 
         links = (
-            "[harbor2](https://harbor2.vantage6.ai)\n"
+            "[Github Container Registry](https://ghcr.io/vantage6)\n"
             "[Project website](https://vantage6.ai)\n"
             "[Build status](https://github.com/vantage6/vantage6/actions)"
         )

--- a/tools/update-discord.py
+++ b/tools/update-discord.py
@@ -137,8 +137,7 @@ class PostUpdates(commands.Cog):
         embed.add_field(
             name="Docker Images",
             value=(
-                f"harbor2.vantage6.ai/infrastructure/node:{version} \n"
-                f" harbor2.vantage6.ai/infrastructure/server:{version}"
+                f"ghcr.io/vantage6/node:{version} \n ghcr.io/vantage6/server:{version}"
             ),
             inline=False,
         )

--- a/vantage6-algorithm-store/vantage6/algorithm/store/model/permission.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/model/permission.py
@@ -13,7 +13,6 @@ from sqlalchemy import Column, Integer, ForeignKey, Table
 
 from vantage6.algorithm.store.model.base import Base
 
-
 Permission = Table(
     "Permission",
     Base.metadata,

--- a/vantage6-algorithm-store/vantage6/algorithm/store/resource/rule.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/resource/rule.py
@@ -15,7 +15,6 @@ from vantage6.algorithm.store.resource import (
 from vantage6.algorithm.store.resource.schema.output_schema import RuleOutputSchema
 from vantage6.backend.common.resource.pagination import Pagination
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 rule_schema = RuleOutputSchema()
@@ -44,13 +43,6 @@ def setup(api: Api, api_base: str, services: dict) -> None:
         methods=("GET",),
         resource_class_kwargs=services,
     )
-    # api.add_resource(
-    #     Rule,
-    #     path + "/<int:id>",
-    #     endpoint="rule_with_id",
-    #     methods=("GET",),
-    #     resource_class_kwargs=services,
-    # )
 
 
 # ------------------------------------------------------------------------------
@@ -143,7 +135,7 @@ class Rules(AlgorithmStoreResources):
             role = db.Role.get(args["role_id"])
             if not role:
                 return {
-                    "msg": f'Role with id={args["role_id"]} does not exist!'
+                    "msg": f"Role with id={args['role_id']} does not exist!"
                 }, HTTPStatus.BAD_REQUEST
             q = (
                 q.join(db.role_rule_association)
@@ -203,41 +195,3 @@ class Rules(AlgorithmStoreResources):
 
         # model serialization
         return self.response(page, rule_schema)
-
-
-# class Rule(ServicesResources):
-#     @with_user
-#     def get(self, id):
-#         """Returns a specific rule
-#         ---
-#         description: >-
-#             Get a rule by it's id. The user must be authenticated, but does
-#             not require any additional permissions to view rules.\n
-
-#             Accesible to users.
-
-#         parameters:
-#         - in: path
-#           name: id
-#           schema:
-#               type: integer
-#           minimum: 1
-#           description: rule_id
-#           required: true
-
-#         responses:
-#           200:
-#             description: Ok
-#           404:
-#             description: Rule not found
-
-#         security:
-#             - bearerAuth: []
-
-#         tags: ["Rule"]
-#         """
-#         rule = db.Rule.get(id)
-#         if not rule:
-#             return {"msg": f"Rule id={id} not found!"}, HTTPStatus.NOT_FOUND
-
-#         return rule_schema.dump(rule, many=False), HTTPStatus.OK

--- a/vantage6-algorithm-store/vantage6/algorithm/store/resource/vantage6_server.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/resource/vantage6_server.py
@@ -28,7 +28,6 @@ from vantage6.algorithm.store.resource import (
 from vantage6.algorithm.store.resource import AlgorithmStoreResources
 from vantage6.algorithm.store.default_roles import DefaultRole
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(logger_name(__name__))
 

--- a/vantage6-algorithm-store/vantage6/algorithm/store/resource/version.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/resource/version.py
@@ -12,7 +12,6 @@ from vantage6.algorithm.store._version import __version__
 # TODO move to common / refactor
 from vantage6.algorithm.store.resource import AlgorithmStoreResources
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-backend-common/vantage6/backend/common/base.py
+++ b/vantage6-backend-common/vantage6/backend/common/base.py
@@ -21,7 +21,6 @@ from vantage6.backend.common.globals import (
     RETRY_DELAY_IN_SECONDS,
 )
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-backend-common/vantage6/backend/common/resource/output_schema.py
+++ b/vantage6-backend-common/vantage6/backend/common/resource/output_schema.py
@@ -6,7 +6,6 @@ from sqlalchemy.ext.declarative import DeclarativeMeta
 from vantage6.common import logger_name
 from vantage6.backend.common.resource.pagination import Pagination
 
-
 log = logging.getLogger(logger_name(__name__))
 
 

--- a/vantage6-backend-common/vantage6/backend/common/resource/pagination.py
+++ b/vantage6-backend-common/vantage6/backend/common/resource/pagination.py
@@ -11,7 +11,6 @@ from sqlalchemy.orm.decl_api import DeclarativeMeta
 from vantage6.common import logger_name
 from vantage6.backend.common.globals import DEFAULT_PAGE, DEFAULT_PAGE_SIZE
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-client/tests/client/test_client.py
+++ b/vantage6-client/tests/client/test_client.py
@@ -8,7 +8,6 @@ from unittest.mock import patch, MagicMock
 from vantage6.client import UserClient
 from vantage6.common.globals import STRING_ENCODING
 
-
 # Mock server
 HOST = "mock_server"
 PORT = 1234

--- a/vantage6-common/tests/vantage6/common/docker/test_addons.py
+++ b/vantage6-common/tests/vantage6/common/docker/test_addons.py
@@ -142,8 +142,8 @@ class TestParseImageName(TestCase):
                 "1234567890abcdef1234567890abcdef1234567890abcdef"
             ),
             (
-                "harbor2.vantage6.ai",
-                "infrastructure/node",
+                "ghcr.io",
+                "vantage6/node",
                 "4.5",
             ),
         )

--- a/vantage6-common/tests/vantage6/common/docker/test_addons.py
+++ b/vantage6-common/tests/vantage6/common/docker/test_addons.py
@@ -111,28 +111,28 @@ class TestParseImageName(TestCase):
             ("example.com", "nested/double/triple/image", "Three"),
         )
 
-    def test_parse_image_name_harbor2_average(self):
+    def test_parse_image_name_ghcr_average(self):
         self.assertEqual(
-            parse_image_name("harbor2.vantage6.ai/demo/average"),
-            ("harbor2.vantage6.ai", "demo/average", "latest"),
+            parse_image_name("ghcr.io/vantage6/algorithm-average:latest"),
+            ("ghcr.io", "vantage6/algorithm-average", "latest"),
         )
 
-    def test_parse_image_name_harbor2_average_tag_latest(self):
+    def test_parse_image_name_ghcr_average_tag_latest(self):
         self.assertEqual(
-            parse_image_name("harbor2.vantage6.ai/demo/average:latest"),
-            ("harbor2.vantage6.ai", "demo/average", "latest"),
+            parse_image_name("ghcr.io/vantage6/algorithm-average:latest"),
+            ("ghcr.io", "vantage6/algorithm-average", "latest"),
         )
 
-    def test_parse_image_name_harbor2_average_tag_4(self):
+    def test_parse_image_name_ghcr_average_tag_4(self):
         self.assertEqual(
-            parse_image_name("harbor2.vantage6.ai/demo/average:4"),
-            ("harbor2.vantage6.ai", "demo/average", "4"),
+            parse_image_name("ghcr.io/vantage6/algorithm-average:4"),
+            ("ghcr.io", "vantage6/algorithm-average", "4"),
         )
 
     def test_parse_image_name_with_sha(self):
         self.assertEqual(
-            parse_image_name("harbor2.vantage6.ai/demo/average@sha256:1234"),
-            ("harbor2.vantage6.ai", "demo/average", "sha256:1234"),
+            parse_image_name("ghcr.io/vantage6/algorithm-average@sha256:1234"),
+            ("ghcr.io", "vantage6/algorithm-average", "sha256:1234"),
         )
 
     def test_parse_image_name_with_sha_and_tag(self):

--- a/vantage6-common/tests/vantage6/common/docker/test_addons.py
+++ b/vantage6-common/tests/vantage6/common/docker/test_addons.py
@@ -138,7 +138,7 @@ class TestParseImageName(TestCase):
     def test_parse_image_name_with_sha_and_tag(self):
         self.assertEqual(
             parse_image_name(
-                "harbor2.vantage6.ai/infrastructure/node:4.5@sha256:1234567890abcdef"
+                "ghcr.io/vantage6/node:4.5@sha256:1234567890abcdef"
                 "1234567890abcdef1234567890abcdef1234567890abcdef"
             ),
             (

--- a/vantage6-common/vantage6/common/__init__.py
+++ b/vantage6-common/vantage6/common/__init__.py
@@ -17,7 +17,6 @@ from vantage6.common.globals import APPNAME, STRING_ENCODING
 # make sure the version is available
 from vantage6.common._version import __version__  # noqa: F401
 
-
 # init colorstuff
 init()
 
@@ -384,9 +383,9 @@ def split_rabbitmq_uri(rabbit_uri: str) -> dict:
     dict[str]
         The vhost defined in the RabbitMQ URI
     """
-    (user_details, location_details) = rabbit_uri.split("@", 1)
-    (user, password) = user_details.split("/")[-1].split(":", 1)
-    (host, remainder) = location_details.split(":", 1)
+    user_details, location_details = rabbit_uri.split("@", 1)
+    user, password = user_details.split("/")[-1].split(":", 1)
+    host, remainder = location_details.split(":", 1)
     port, vhost = remainder.split("/", 1)
     return {
         "user": user,

--- a/vantage6-common/vantage6/common/docker/addons.py
+++ b/vantage6-common/vantage6/common/docker/addons.py
@@ -319,7 +319,7 @@ def parse_image_name(image: str) -> tuple[str, str, str]:
     Parameters
     ----------
     image: str
-        Image name. E.g. "harbor2.vantage6.ai/algorithms/average:latest" or
+        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest" or
         "library/hello-world"
 
     Returns
@@ -349,12 +349,12 @@ def get_image_name_wo_tag(image: str) -> str:
     Parameters
     ----------
     image: str
-        Image name. E.g. "harbor2.vantage6.ai/algorithms/average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
 
     Returns
     -------
     str
-        Image name without tag. E.g. "harbor2.vantage6.ai/algorithms/average"
+        Image name without tag. E.g. "ghcr.io/vantage6/algorithm-average"
     """
     registry, repository, _ = parse_image_name(image)
     if registry == "docker.io":
@@ -377,7 +377,7 @@ def _get_manifest(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "harbor2.vantage6.ai/algorithms/average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
     registry_user: str | None
         Docker username to authenticate with at the registry. Required if the image is
         private
@@ -437,8 +437,7 @@ def _get_manifest(
                     timeout=60,
                 )
 
-    # If still getting unauthorize, try with username and password. The following code
-    # was tested with private images on harbor2.vantage6.ai.
+    # If still getting unauthorize, try with username and password.
     if response.status_code == HTTPStatus.UNAUTHORIZED:
         response = requests.get(
             manifest_endpoint,
@@ -470,7 +469,7 @@ def _get_digest_via_docker(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "harbor2.vantage6.ai/algorithms/average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
     client: DockerClient
         Docker client.
     docker_username: str | None
@@ -517,7 +516,7 @@ def _get_digest_via_manifest(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "harbor2.vantage6.ai/algorithms/average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
     docker_username: str | None
         Docker username to authenticate with at the registry. Required if the image is
         private
@@ -554,7 +553,7 @@ def get_digest(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "harbor2.vantage6.ai/algorithms/average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
     client: DockerClient | None
         Docker client to use. If not provided, a new client will be created. An existing
         client could be useful to provide if it has already been authenticated with one

--- a/vantage6-common/vantage6/common/globals.py
+++ b/vantage6-common/vantage6/common/globals.py
@@ -10,7 +10,7 @@ APPNAME = "vantage6"
 
 MAIN_VERSION_NAME = "cotopaxi"
 
-DEFAULT_DOCKER_REGISTRY = "harbor2.vantage6.ai"
+DEFAULT_DOCKER_REGISTRY = "ghcr.io/vantage6"
 
 DEFAULT_NODE_IMAGE = f"infrastructure/node:{MAIN_VERSION_NAME}"
 
@@ -41,7 +41,7 @@ PING_INTERVAL_SECONDS = 60
 NODE_CLIENT_REFRESH_BEFORE_EXPIRES_SECONDS = 600
 
 # The basics image can be used (mainly by the UI) to collect column names
-BASIC_PROCESSING_IMAGE = "harbor2.vantage6.ai/algorithms/basics"
+BASIC_PROCESSING_IMAGE = "ghcr.io/vantage6/algorithm-basics:latest"
 
 # Character to replace '=' with in encoded environment variables
 ENV_VAR_EQUALS_REPLACEMENT = "!"

--- a/vantage6-common/vantage6/common/serialization.py
+++ b/vantage6-common/vantage6/common/serialization.py
@@ -5,7 +5,6 @@ import logging
 from vantage6.common.globals import STRING_ENCODING
 from vantage6.common import logger_name
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from enum import Enum
 from vantage6.common.globals import APPNAME
 
 #
@@ -31,9 +30,9 @@ TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET = 60
 #    VPN CONFIGURATION RELATED CONSTANTS
 #
 # TODO move part of these constants elsewhere?! Or make context?
-VPN_CLIENT_IMAGE = "harbor2.vantage6.ai/infrastructure/vpn-client"
-NETWORK_CONFIG_IMAGE = "harbor2.vantage6.ai/infrastructure/vpn-configurator"
-ALPINE_IMAGE = "harbor2.vantage6.ai/infrastructure/alpine"
+VPN_CLIENT_IMAGE = "ghcr.io/vantage6/vpn-client"
+NETWORK_CONFIG_IMAGE = "ghcr.io/vantage6/vpn-configurator"
+ALPINE_IMAGE = "ghcr.io/vantage6/alpine"
 MAX_CHECK_VPN_ATTEMPTS = 60  # max attempts to obtain VPN IP (1 second apart)
 FREE_PORT_RANGE = range(49152, 65535)
 DEFAULT_ALGO_VPN_PORT = "8888"  # default VPN port for algorithm container
@@ -41,12 +40,12 @@ DEFAULT_ALGO_VPN_PORT = "8888"  # default VPN port for algorithm container
 #
 #   SSH TUNNEL RELATED CONSTANTS
 #
-SSH_TUNNEL_IMAGE = "harbor2.vantage6.ai/infrastructure/ssh-tunnel"
+SSH_TUNNEL_IMAGE = "ghcr.io/vantage6/ssh-tunnel"
 
 #
 #   SQUID RELATED CONSTANTS
 #
-SQUID_IMAGE = "harbor2.vantage6.ai/infrastructure/squid"
+SQUID_IMAGE = "ghcr.io/vantage6/squid"
 
 # Environment variables that should be set in the Dockerfile and that may not
 # be overwritten by the user.

--- a/vantage6-node/vantage6/node/proxy_server.py
+++ b/vantage6-node/vantage6/node/proxy_server.py
@@ -22,7 +22,6 @@ from vantage6.common.client.node_client import NodeClient
 from vantage6.common.client.utils import is_uuid
 from vantage6.common.globals import STRING_ENCODING
 
-
 # Initialize FLASK
 app = Flask(__name__)
 log = logging.getLogger(logger_name(__name__))

--- a/vantage6-server/tests_server/test_models.py
+++ b/vantage6-server/tests_server/test_models.py
@@ -23,7 +23,6 @@ from vantage6.server.model import (
 )
 from vantage6.server.model.rule import Scope, Operation
 
-
 log = logging.getLogger(__name__.split(".")[-1])
 log.level = logging.CRITICAL
 logging.basicConfig(level=logging.CRITICAL)

--- a/vantage6-server/tests_server/test_resources.py
+++ b/vantage6-server/tests_server/test_resources.py
@@ -43,7 +43,6 @@ from vantage6.server._version import __version__
 from vantage6.server.model.base import Database, DatabaseSessionManager
 from vantage6.server.controller.fixture import load
 
-
 logger = logger_name(__name__)
 log = logging.getLogger(logger)
 
@@ -3537,7 +3536,7 @@ class TestResources(unittest.TestCase):
             {
                 "label": "diagnosis",
                 "arguments": {"bind": "diagnosis_data"},
-            }
+            },
         ]
         results = self.app.post("/api/task", headers=headers, json=task_json)
         self.assertEqual(results.status_code, HTTPStatus.CREATED)

--- a/vantage6-server/vantage6/server/__init__.py
+++ b/vantage6-server/vantage6/server/__init__.py
@@ -82,10 +82,8 @@ from vantage6.server.hashedpassword import HashedPassword
 from vantage6.server.controller import cleanup
 from vantage6.server.service.azure_storage_service import AzureStorageService
 
-
 # make sure the version is available
 from vantage6.server._version import __version__  # noqa: F401
-
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
@@ -611,10 +609,8 @@ class ServerApp:
             if isinstance(identity, dict):
                 return identity
 
-            log.error(
-                f"Could not create a JSON serializable identity \
-                        from '{str(identity)}'"
-            )
+            log.error(f"Could not create a JSON serializable identity \
+                        from '{str(identity)}'")
 
         @self.jwt.user_lookup_loader
         # pylint: disable=unused-argument

--- a/vantage6-server/vantage6/server/algo_store_communication.py
+++ b/vantage6-server/vantage6/server/algo_store_communication.py
@@ -9,7 +9,6 @@ from vantage6.backend.common.globals import HOST_URI_ENV
 from vantage6.backend.common import get_server_url
 from vantage6.server import db
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/cli/server.py
+++ b/vantage6-server/vantage6/server/cli/server.py
@@ -18,7 +18,6 @@ from vantage6.cli.configuration_wizard import select_configuration_questionaire
 from vantage6.cli.context.server import ServerContext
 from vantage6.server._version import __version__
 
-
 help_ = {
     "name": "name of the configutation you want to use.",
     "config": "absolute path to configuration-file; overrides NAME",

--- a/vantage6-server/vantage6/server/default_roles.py
+++ b/vantage6-server/vantage6/server/default_roles.py
@@ -110,26 +110,30 @@ def get_default_roles(db) -> list[dict]:
     researcher_only_rules = [
         rule for rule in RESEARCHER_RULES if rule not in ORG_ADMIN_RULES
     ]
-    COLLAB_ADMIN_RULES = ORG_ADMIN_RULES + researcher_only_rules + [
-        db.Rule.get_by_("user", Scope.COLLABORATION, Operation.VIEW),
-        db.Rule.get_by_("user", Scope.COLLABORATION, Operation.CREATE),
-        db.Rule.get_by_("user", Scope.COLLABORATION, Operation.EDIT),
-        # The following rule is given so that a collaboration admin can
-        # view which organizations they may add to their collaboration
-        db.Rule.get_by_("organization", Scope.GLOBAL, Operation.VIEW),
-        db.Rule.get_by_("organization", Scope.COLLABORATION, Operation.EDIT),
-        db.Rule.get_by_("collaboration", Scope.ORGANIZATION, Operation.VIEW),
-        db.Rule.get_by_("collaboration", Scope.COLLABORATION, Operation.EDIT),
-        db.Rule.get_by_("role", Scope.COLLABORATION, Operation.VIEW),
-        db.Rule.get_by_("node", Scope.COLLABORATION, Operation.CREATE),
-        db.Rule.get_by_("node", Scope.COLLABORATION, Operation.VIEW),
-        db.Rule.get_by_("node", Scope.COLLABORATION, Operation.DELETE),
-        db.Rule.get_by_("event", Scope.COLLABORATION, Operation.SEND),
-        db.Rule.get_by_("study", Scope.COLLABORATION, Operation.VIEW),
-        db.Rule.get_by_("study", Scope.COLLABORATION, Operation.CREATE),
-        db.Rule.get_by_("study", Scope.COLLABORATION, Operation.EDIT),
-        db.Rule.get_by_("study", Scope.COLLABORATION, Operation.DELETE),
-    ]
+    COLLAB_ADMIN_RULES = (
+        ORG_ADMIN_RULES
+        + researcher_only_rules
+        + [
+            db.Rule.get_by_("user", Scope.COLLABORATION, Operation.VIEW),
+            db.Rule.get_by_("user", Scope.COLLABORATION, Operation.CREATE),
+            db.Rule.get_by_("user", Scope.COLLABORATION, Operation.EDIT),
+            # The following rule is given so that a collaboration admin can
+            # view which organizations they may add to their collaboration
+            db.Rule.get_by_("organization", Scope.GLOBAL, Operation.VIEW),
+            db.Rule.get_by_("organization", Scope.COLLABORATION, Operation.EDIT),
+            db.Rule.get_by_("collaboration", Scope.ORGANIZATION, Operation.VIEW),
+            db.Rule.get_by_("collaboration", Scope.COLLABORATION, Operation.EDIT),
+            db.Rule.get_by_("role", Scope.COLLABORATION, Operation.VIEW),
+            db.Rule.get_by_("node", Scope.COLLABORATION, Operation.CREATE),
+            db.Rule.get_by_("node", Scope.COLLABORATION, Operation.VIEW),
+            db.Rule.get_by_("node", Scope.COLLABORATION, Operation.DELETE),
+            db.Rule.get_by_("event", Scope.COLLABORATION, Operation.SEND),
+            db.Rule.get_by_("study", Scope.COLLABORATION, Operation.VIEW),
+            db.Rule.get_by_("study", Scope.COLLABORATION, Operation.CREATE),
+            db.Rule.get_by_("study", Scope.COLLABORATION, Operation.EDIT),
+            db.Rule.get_by_("study", Scope.COLLABORATION, Operation.DELETE),
+        ]
+    )
     COLLAB_ADMIN_ROLE = {
         "name": DefaultRole.COL_ADMIN,
         "description": "Can manage a collaboration including its organization and users."

--- a/vantage6-server/vantage6/server/model/member.py
+++ b/vantage6-server/vantage6/server/model/member.py
@@ -13,7 +13,6 @@ from sqlalchemy import Column, Integer, ForeignKey, Table
 
 from vantage6.server.model.base import Base
 
-
 Member = Table(
     "Member",
     Base.metadata,

--- a/vantage6-server/vantage6/server/model/permission.py
+++ b/vantage6-server/vantage6/server/model/permission.py
@@ -13,7 +13,6 @@ from sqlalchemy import Column, Integer, ForeignKey, Table
 
 from vantage6.server.model.base import Base
 
-
 Permission = Table(
     "Permission",
     Base.metadata,

--- a/vantage6-server/vantage6/server/model/role.py
+++ b/vantage6-server/vantage6/server/model/role.py
@@ -39,9 +39,7 @@ class Role(Base):
     users = relationship("User", back_populates="roles", secondary="Permission")
 
     @classmethod
-    def get_by_name(
-        cls, name: str, is_default_role: bool | None = None
-    ) -> Role | None:
+    def get_by_name(cls, name: str, is_default_role: bool | None = None) -> Role | None:
         """
         Get a role by its name.
 

--- a/vantage6-server/vantage6/server/resource/algorithm_store.py
+++ b/vantage6-server/vantage6/server/resource/algorithm_store.py
@@ -17,7 +17,6 @@ from vantage6.server.algo_store_communication import (
     request_algo_store,
 )
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/blobstream.py
+++ b/vantage6-server/vantage6/server/resource/blobstream.py
@@ -23,7 +23,6 @@ from vantage6.server.resource import (
 )
 from vantage6.server.model import Run as db_Run, Task as db_Task
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/collaboration.py
+++ b/vantage6-server/vantage6/server/resource/collaboration.py
@@ -25,7 +25,6 @@ from vantage6.server.resource.common.output_schema import (
 )
 from vantage6.server.resource import with_user, only_for, ServicesResources
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/health.py
+++ b/vantage6-server/vantage6/server/resource/health.py
@@ -7,7 +7,6 @@ from flask_restful import Api
 from vantage6.server.resource import ServicesResources
 from vantage6.common import logger_name
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/node.py
+++ b/vantage6-server/vantage6/server/resource/node.py
@@ -19,7 +19,6 @@ from vantage6.server import db
 from vantage6.server.resource.common.output_schema import NodeSchema
 from vantage6.server.resource.common.input_schema import NodeInputSchema
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/organization.py
+++ b/vantage6-server/vantage6/server/resource/organization.py
@@ -17,7 +17,6 @@ from vantage6.server.resource.common.input_schema import OrganizationInputSchema
 from vantage6.server.resource import only_for, with_user, ServicesResources
 from vantage6.server.resource.common.output_schema import OrganizationSchema
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/rule.py
+++ b/vantage6-server/vantage6/server/resource/rule.py
@@ -12,7 +12,6 @@ from vantage6.server import db
 from vantage6.server.resource.common.output_schema import RuleSchema
 from vantage6.backend.common.resource.pagination import Pagination
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 rule_schema = RuleSchema()

--- a/vantage6-server/vantage6/server/resource/run.py
+++ b/vantage6-server/vantage6/server/resource/run.py
@@ -33,7 +33,6 @@ from vantage6.server.resource.common.output_schema import (
 )
 from vantage6.server.model import Run as db_Run, Node, Task, Collaboration, Organization
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/study.py
+++ b/vantage6-server/vantage6/server/resource/study.py
@@ -23,7 +23,6 @@ from vantage6.server.resource.common.output_schema import (
 )
 from vantage6.server.resource import with_user, only_for, ServicesResources
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/task.py
+++ b/vantage6-server/vantage6/server/resource/task.py
@@ -33,7 +33,6 @@ from vantage6.server.resource.common.input_schema import TaskInputSchema
 from vantage6.backend.common.resource.pagination import Pagination
 from vantage6.server.resource.event import kill_task
 
-
 module_name = __name__.split(".")[-1]
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/ui/column.py
+++ b/vantage6-server/vantage6/server/resource/ui/column.py
@@ -12,7 +12,6 @@ from vantage6.server.resource import ServicesResources, with_user
 from vantage6.server.resource.common.input_schema import ColumnNameInputSchema
 from vantage6.server.resource.task import Tasks
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/user.py
+++ b/vantage6-server/vantage6/server/resource/user.py
@@ -26,7 +26,6 @@ from vantage6.server.resource.common.output_schema import (
     UserWithPermissionDetailsSchema,
 )
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/version.py
+++ b/vantage6-server/vantage6/server/resource/version.py
@@ -10,7 +10,6 @@ from vantage6.common import logger_name
 from vantage6.server.resource import ServicesResources
 from vantage6.server._version import __version__
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/resource/websocket_test.py
+++ b/vantage6-server/vantage6/server/resource/websocket_test.py
@@ -6,7 +6,6 @@ from flask_restful import Api
 from vantage6.common import logger_name
 from vantage6.server.resource import ServicesResources
 
-
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 

--- a/vantage6-server/vantage6/server/websockets.py
+++ b/vantage6-server/vantage6/server/websockets.py
@@ -15,7 +15,6 @@ from vantage6.server.model.authenticatable import Authenticatable
 from vantage6.server.model.rule import Operation, Scope
 from vantage6.server.model.base import DatabaseSessionManager
 
-
 ALL_NODES_ROOM = "all_nodes"
 
 

--- a/vantage6-ui/README.md
+++ b/vantage6-ui/README.md
@@ -59,11 +59,11 @@ Angular production servers can be deployed in many ways. Angular's
 [deployment documentation](https://angular.io/guide/deployment) offers a number
 of options.
 
-Alternatively, we provide the Docker image `harbor2.vantage6.ai/infrastructure/ui`
+Alternatively, we provide the Docker image `ghcr.io/vantage6/ui`
 to help you deploy your own UI. In that case, run
 
 ```
-docker run --env SERVER_URL="<your_url>" --env API_PATH="<your_path>" -p 8080:80 harbor2.vantage6.ai/infrastructure/ui:latest
+docker run --env SERVER_URL="<your_url>" --env API_PATH="<your_path>" -p 8080:80 ghcr.io/vantage6/ui:latest
 ```
 
 to run a UI on port 8080 that communicates with your own server. For instance,

--- a/vantage6-ui/src/app/pages/analyze/template-task/create/mock.ts
+++ b/vantage6-ui/src/app/pages/analyze/template-task/create/mock.ts
@@ -1,6 +1,6 @@
 export const mockDataQualityTemplateTask = {
   name: 'Quality check',
-  image: 'harbor2.vantage6.ai/starter/utils',
+  image: 'ghcr.io/vantage6/algorithm-starter-utils:latest',
   function: 'fetch_static_file',
   collaboration: 2,
   fixed: { name: 'Quality check', databases: [] },
@@ -18,7 +18,7 @@ export const mockDataQualityTemplateTask = {
 
 export const mockDataCrossTabTemplateTask = {
   name: 'Cross tabulation',
-  image: 'harbor2.vantage6.ai/starter/crosstab',
+  image: 'ghcr.io/vantage6/algorithm-starter-crosstab:latest',
   function: 'dct',
   collaboration: 2,
   fixed: {

--- a/vantage6/vantage6/cli/configuration_wizard.py
+++ b/vantage6/vantage6/cli/configuration_wizard.py
@@ -175,8 +175,7 @@ def node_configuration_questionaire(dirs: dict, instance_name: str) -> dict:
         error(f"Could not authenticate with server: {e}")
         error("Please check (1) your API key and (2) if your server is online")
         warning(
-            "If you continue, you should provide your collaboration "
-            "settings manually."
+            "If you continue, you should provide your collaboration settings manually."
         )
         if q.confirm("Do you want to abort?", default=True).unsafe_ask():
             exit(0)
@@ -221,13 +220,15 @@ def _get_allowed_algorithms() -> list[str]:
         "use strings to provide one algorithm at a time."
     )
     info("Examples:")
-    info(r"^harbor2\.vantage6\.ai/demo/average$    Allow the demo average algorithm")
     info(
-        r"^harbor2\.vantage6\.ai/algorithms/.*   Allow all algorithms from "
-        "harbor2.vantage6.ai/algorithms"
+        r"^ghcr\.io/vantage6/algorithm-average:latest$    Allow the demo average algorithm"
     )
     info(
-        r"^harbor2\.vantage6\.ai/demo/average@sha256:82becede...$    Allow a "
+        r"^ghcr\.io/vantage6/algorithm-*.   Allow all algorithms from "
+        "ghcr.io/vantage6"
+    )
+    info(
+        r"^ghcr\.io/vantage6/algorithm-average@sha256:82becede...$    Allow a "
         "specific hash of average algorithm"
     )
     allowed_algorithms = []

--- a/vantage6/vantage6/cli/dev/create.py
+++ b/vantage6/vantage6/cli/dev/create.py
@@ -654,7 +654,7 @@ def create_demo_network(
     else:
         error(f"Configuration {Fore.RED}{server_name}{Style.RESET_ALL} already exists!")
         exit(1)
-    (node_config, server_import_config, server_config, store_config) = demo
+    node_config, server_import_config, server_config, store_config = demo
     ctx = get_server_context(server_name, False, ServerContext)
     click_ctx.invoke(
         cli_server_import,

--- a/vantage6/vantage6/cli/globals.py
+++ b/vantage6/vantage6/cli/globals.py
@@ -37,7 +37,7 @@ RABBIT_TIMEOUT = 300
 ALGORITHM_TEMPLATE_REPO = "gh:vantage6/v6-algorithm-template.git"
 
 # image to use for diagnostics in `v6 test` commands
-DIAGNOSTICS_IMAGE = "harbor2.vantage6.ai/algorithms/diagnostic"
+DIAGNOSTICS_IMAGE = "ghcr.io/vantage6/algorithm-diagnostic:latest"
 
 # Address of community algorithm store
 COMMUNITY_STORE = "https://store.cotopaxi.vantage6.ai/api"

--- a/vantage6/vantage6/cli/rabbitmq/queue_manager.py
+++ b/vantage6/vantage6/cli/rabbitmq/queue_manager.py
@@ -17,7 +17,7 @@ from vantage6.cli.context.server import ServerContext
 from vantage6.cli.rabbitmq.definitions import RABBITMQ_DEFINITIONS
 from vantage6.cli.globals import RABBIT_TIMEOUT
 
-DEFAULT_RABBIT_IMAGE = "harbor2.vantage6.ai/infrastructure/rabbitmq"
+DEFAULT_RABBIT_IMAGE = "ghcr.io/vantage6/rabbitmq"
 RABBIT_CONFIG = "rabbitmq.config"
 RABBIT_DIR = "rabbitmq"
 
@@ -34,7 +34,7 @@ class RabbitMQManager:
         Network manager for network in which server container resides
     image: str
         Docker image to use for RabbitMQ container. By default, the image
-        harbor2.vantage6.ai/infrastructure/rabbitmq is used.
+        ghcr.io/vantage6/rabbitmq is used.
     """
 
     def __init__(
@@ -75,7 +75,7 @@ class RabbitMQManager:
         # check if a RabbitMQ container is already running
         self.rabbit_container = get_container(docker_client=self.docker, name=self.host)
         if self.rabbit_container:
-            info("RabbitMQ is already running! Linking the server to that " "queue")
+            info("RabbitMQ is already running! Linking the server to that queue")
             if not self.network_mgr.contains(self.rabbit_container):
                 self.network_mgr.connect(self.rabbit_container)
             return
@@ -161,8 +161,10 @@ class RabbitMQManager:
                 "bind": "/etc/rabbitmq/definitions.json",
                 "mode": "ro",
             },
-            self.ctx.data_dir
-            / RABBIT_CONFIG: {"bind": "/etc/rabbitmq/rabbitmq.config", "mode": "ro"},
+            self.ctx.data_dir / RABBIT_CONFIG: {
+                "bind": "/etc/rabbitmq/rabbitmq.config",
+                "mode": "ro",
+            },
             rabbit_data_dir: {"bind": "/var/lib/rabbitmq", "mode": "rw"},
         }
 

--- a/vantage6/vantage6/cli/rabbitmq/queue_manager.py
+++ b/vantage6/vantage6/cli/rabbitmq/queue_manager.py
@@ -161,7 +161,8 @@ class RabbitMQManager:
                 "bind": "/etc/rabbitmq/definitions.json",
                 "mode": "ro",
             },
-            self.ctx.data_dir / RABBIT_CONFIG: {
+            self.ctx.data_dir
+            / RABBIT_CONFIG: {
                 "bind": "/etc/rabbitmq/rabbitmq.config",
                 "mode": "ro",
             },

--- a/vantage6/vantage6/cli/test/algo_test_scripts/algo_test_arguments.py
+++ b/vantage6/vantage6/cli/test/algo_test_scripts/algo_test_arguments.py
@@ -2,7 +2,7 @@ average = {
     "collaboration": 1,
     "organizations": [1],
     "name": "test_average_task",
-    "image": "harbor2.vantage6.ai/demo/average",
+    "image": "ghcr.io/vantage6/algorithm-average:latest",
     "description": "",
     "input_": {
         "method": "central_average",
@@ -16,7 +16,7 @@ kaplan_meier = {
     "collaboration": 1,
     "organizations": [1],
     "name": "test_average_task",
-    "image": "harbor2.vantage6.ai/algorithms/kaplan-meier",
+    "image": "ghcr.io/vantage6/algorithm-kaplan-meier:latest",
     "description": "",
     "input_": {
         "method": "kaplan_meier_central",


### PR DESCRIPTION
Switching to use using Github Container Registry.

DON'T MERGE YET - we still need to test that this works, and before doing that, we also need to verify that we follow instructions in https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry to set up right tokens etc.

Then we also need to merge this into v5 (where we need to take the changes into account for helm charts as well)