### PR TITLE
Feature - private docker registry build + deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # docker image tag
 TAG ?= cotopaxi
-REGISTRY ?= harbor2.vantage6.ai
+REGISTRY ?= ghcr.io/vantage6
 PLATFORMS ?= linux/arm64,linux/amd64
 # Example for local development
 # TAG ?= local
@@ -100,20 +100,20 @@ install-dev:
 	cd vantage6-algorithm-store && pip install -e .[dev]
 
 base-image:
-	@echo "Building ${REGISTRY}/infrastructure/infrastructure-base:${TAG}"
-	@echo "Building ${REGISTRY}/infrastructure/infrastructure-base:latest"
+	@echo "Building ${REGISTRY}/infrastructure-base:${TAG}"
+	@echo "Building ${REGISTRY}/infrastructure-base:latest"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/infrastructure-base:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/infrastructure-base:latest) \
+		--tag ${REGISTRY}/infrastructure-base:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure-base:latest) \
 		--platform ${PLATFORMS} \
 		-f ./docker/infrastructure-base.Dockerfile \
 		$(if ${_condition_push},--push .,.)
 
 algorithm-base-image:
-	@echo "Building ${REGISTRY}/algorithms/algorithm-base:${TAG}"
+	@echo "Building ${REGISTRY}/algorithm-base:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/algorithm-base:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/algorithm-base:latest) \
+		--tag ${REGISTRY}/algorithm-base:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/algorithm-base:latest) \
 		--platform ${PLATFORMS} \
 		--build-arg TAG=${TAG} \
 		-f ./docker/algorithm-base.Dockerfile \
@@ -122,10 +122,10 @@ algorithm-base-image:
 # FIXME FM 17-10-2023: This fails to build for arm64, this is because of
 # the r-base image.
 algorithm-omop-base-image:
-	@echo "Building ${REGISTRY}/algorithms/algorithm-ohdsi-base:${TAG}"
+	@echo "Building ${REGISTRY}/algorithm-ohdsi-base:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/algorithm-ohdsi-base:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/algorithm-ohdsi-base:latest) \
+		--tag ${REGISTRY}/algorithm-ohdsi-base:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/algorithm-ohdsi-base:latest) \
 		--build-arg BASE=${BASE} \
 		--build-arg TAG=${TAG} \
 		--build-arg REGISTRY=${REGISTRY} \
@@ -143,58 +143,58 @@ support-image:
 	make support-squid-image
 
 support-squid-image:
-	@echo "Building ${REGISTRY}/infrastructure/squid:${TAG}"
+	@echo "Building ${REGISTRY}/squid:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/squid:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/squid:latest) \
+		--tag ${REGISTRY}/squid:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/squid:latest) \
 		--platform ${PLATFORMS} \
 		-f ./docker/squid.Dockerfile \
 		$(if ${_condition_push},--push .,.)
 
 support-alpine-image:
-	@echo "Building ${REGISTRY}/infrastructure/alpine:${TAG}"
+	@echo "Building ${REGISTRY}/alpine:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/alpine:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/alpine:latest) \
+		--tag ${REGISTRY}/alpine:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/alpine:latest) \
 		--platform ${PLATFORMS} \
 		-f ./docker/alpine.Dockerfile \
 		$(if ${_condition_push},--push .,.)
 
 support-vpn-client-image:
-	@echo "Building ${REGISTRY}/infrastructure/vpn-client:${TAG}"
+	@echo "Building ${REGISTRY}/vpn-client:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/vpn-client:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/vpn-client:latest) \
+		--tag ${REGISTRY}/vpn-client:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/vpn-client:latest) \
 		--platform ${PLATFORMS} \
 		-f ./docker/vpn-client.Dockerfile \
 		$(if ${_condition_push},--push .,.)
 
 support-vpn-configurator-image:
-	@echo "Building ${REGISTRY}/infrastructure/vpn-configurator:${TAG}"
+	@echo "Building ${REGISTRY}/vpn-configurator:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/vpn-configurator:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/vpn-configurator:latest) \
+		--tag ${REGISTRY}/vpn-configurator:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/vpn-configurator:latest) \
 		--platform ${PLATFORMS} \
 		-f ./docker/vpn-configurator.Dockerfile \
 		$(if ${_condition_push},--push .,.)
 
 support-ssh-tunnel-image:
-	@echo "Building ${REGISTRY}/infrastructure/ssh-tunnel:${TAG}"
+	@echo "Building ${REGISTRY}/ssh-tunnel:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/ssh-tunnel:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/ssh-tunnel:latest) \
+		--tag ${REGISTRY}/ssh-tunnel:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/ssh-tunnel:latest) \
 		--platform ${PLATFORMS} \
 		-f ./docker/ssh-tunnel.Dockerfile \
 		$(if ${_condition_push},--push .,.)
 
 image:
-	@echo "Building ${REGISTRY}/infrastructure/node:${TAG}"
-	@echo "Building ${REGISTRY}/infrastructure/server:${TAG}"
+	@echo "Building ${REGISTRY}/node:${TAG}"
+	@echo "Building ${REGISTRY}/server:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/node:${TAG} \
-		--tag ${REGISTRY}/infrastructure/server:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/node:latest) \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/server:latest) \
+		--tag ${REGISTRY}/node:${TAG} \
+		--tag ${REGISTRY}/server:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/node:latest) \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/server:latest) \
 		--build-arg TAG=${TAG} \
 		--build-arg BASE=${BASE} \
 		--build-arg REGISTRY=${REGISTRY} \
@@ -203,10 +203,10 @@ image:
 		$(if ${_condition_push},--push .,.)
 
 algorithm-store-image:
-	@echo "Building ${REGISTRY}/infrastructure/algorithm-store:${TAG}"
+	@echo "Building ${REGISTRY}/algorithm-store:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/algorithm-store:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/algorithm-store:latest) \
+		--tag ${REGISTRY}/algorithm-store:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/algorithm-store:latest) \
 		--build-arg TAG=${TAG} \
 		--build-arg BASE=${BASE} \
 		--build-arg REGISTRY=${REGISTRY} \
@@ -215,12 +215,11 @@ algorithm-store-image:
 		$(if ${_condition_push},--push .,.)
 
 ui-image:
-	@echo "Building ${REGISTRY}/infrastructure/ui:${TAG}"
+	@echo "Building ${REGISTRY}/ui:${TAG}"
 	docker buildx build \
-		--tag ${REGISTRY}/infrastructure/ui:${TAG} \
-		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/ui:latest) \
+		--tag ${REGISTRY}/ui:${TAG} \
+		$(if ${_condition_tag_latest},--tag ${REGISTRY}/ui:latest) \
 		--build-arg TAG=${TAG} \
-		--build-arg BASE=${BASE} \
 		--platform ${PLATFORMS} \
 		-f ./docker/ui.Dockerfile \
 		$(if ${_condition_push},--push .,.)

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ algorithm-omop-base-image:
 		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/algorithm-ohdsi-base:latest) \
 		--build-arg BASE=${BASE} \
 		--build-arg TAG=${TAG} \
+		--build-arg REGISTRY=${REGISTRY} \
 		--platform linux/amd64 \
 		-f ./docker/algorithm-ohdsi-base.Dockerfile \
 		$(if ${_condition_push},--push .,.)
@@ -196,6 +197,7 @@ image:
 		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/server:latest) \
 		--build-arg TAG=${TAG} \
 		--build-arg BASE=${BASE} \
+		--build-arg REGISTRY=${REGISTRY} \
 		--platform ${PLATFORMS} \
 		-f ./docker/node-and-server.Dockerfile \
 		$(if ${_condition_push},--push .,.)
@@ -207,6 +209,7 @@ algorithm-store-image:
 		$(if ${_condition_tag_latest},--tag ${REGISTRY}/infrastructure/algorithm-store:latest) \
 		--build-arg TAG=${TAG} \
 		--build-arg BASE=${BASE} \
+		--build-arg REGISTRY=${REGISTRY} \
 		--platform ${PLATFORMS} \
 		-f ./docker/algorithm-store.Dockerfile \
 		$(if ${_condition_push},--push .,.)

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -1,0 +1,73 @@
+# =============================================================================
+# Docker Compose — vantage6 node
+# =============================================================================
+#
+# Template for running a vantage6 node via Docker Compose instead of the
+# `v6 node start` CLI. The node manages all helper containers (squid, VPN,
+# SSH tunnel) itself via the Docker socket.
+#
+# SETUP
+# -----
+# 1. Copy this file and replace every <PLACEHOLDER> with your values.
+# 2. Make sure the node config YAML exists at the path you mount below.
+# 3. If you use a private registry, set `images:` in the node config YAML
+#    to point to that registry so the node can pull helper images.
+#
+# USAGE
+# -----
+#   docker compose -f docker-compose.node.yml up -d
+#   docker compose -f docker-compose.node.yml logs -f node
+#   docker compose -f docker-compose.node.yml down
+#
+# =============================================================================
+
+services:
+  node:
+    image: harbor2.vantage6.ai/infrastructure/node:cotopaxi
+    container_name: vantage6-<NODE_NAME>-user
+    restart: unless-stopped
+    tty: true
+    command: >-
+      vnode-local start
+        -c /mnt/config/<NODE_NAME>.yaml
+        -n <NODE_NAME>
+        --dockerized
+        --user
+    environment:
+      DATA_VOLUME_NAME: vantage6-<NODE_NAME>-user-vol
+      VPN_VOLUME_NAME: vantage6-<NODE_NAME>-user-vpn-vol
+      SSH_TUNNEL_VOLUME_NAME: vantage6-<NODE_NAME>-user-ssh-vol
+      SSH_SQUID_VOLUME_NAME: vantage6-<NODE_NAME>-user-squid-vol
+      PRIVATE_KEY: /mnt/private_key.pem
+      # For each database defined in the node config, add an env var:
+      #   <LABEL>_DATABASE_URI: <filename-or-connection-string>
+      # If the database is file-based, also add a bind mount below.
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      # Node config — mount the single YAML file, read-only
+      - <PATH_TO_CONFIG>/<NODE_NAME>.yaml:/mnt/config/<NODE_NAME>.yaml:ro
+      # Named volumes for internal state
+      - node-data:/mnt/data:rw
+      - node-vpn:/mnt/vpn:rw
+      - node-ssh:/mnt/ssh:rw
+      - node-squid:/mnt/squid:rw
+      # Log directory
+      - <PATH_TO_LOG_DIR>:/mnt/log:rw
+      # Encryption private key (remove if encryption is disabled)
+      - <PATH_TO_PRIVATE_KEY>:/mnt/private_key.pem:ro
+      # Database files — one bind mount per file-based database
+      # - /data/my_database.csv:/mnt/my_database.csv:ro
+    labels:
+      vantage6-type: node
+      system: "False"
+      name: <NODE_NAME>
+
+volumes:
+  node-data:
+    name: vantage6-<NODE_NAME>-user-vol
+  node-vpn:
+    name: vantage6-<NODE_NAME>-user-vpn-vol
+  node-ssh:
+    name: vantage6-<NODE_NAME>-user-ssh-vol
+  node-squid:
+    name: vantage6-<NODE_NAME>-user-squid-vol

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -39,9 +39,13 @@ services:
       SSH_TUNNEL_VOLUME_NAME: vantage6-<NODE_NAME>-user-ssh-vol
       SSH_SQUID_VOLUME_NAME: vantage6-<NODE_NAME>-user-squid-vol
       PRIVATE_KEY: /mnt/private_key.pem
-      # For each database defined in the node config, add an env var:
-      #   <LABEL>_DATABASE_URI: <filename-or-connection-string>
-      # If the database is file-based, also add a bind mount below.
+      # For each database in the node config, add an env var that matches
+      # what `v6 node start` would set: <LABEL>_DATABASE_URI: <label><suffix>
+      # For file-based databases, also add a bind mount to /mnt/<label><suffix>
+      # Example for a database with label "default" and uri "/data/mydb.csv":
+      #   DEFAULT_DATABASE_URI: default.csv
+      # For non-file databases (e.g. SQL), use the connection string directly:
+      #   MYDB_DATABASE_URI: postgresql://user:pass@host/db
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       # Node config — mount the single YAML file, read-only
@@ -55,8 +59,9 @@ services:
       - <PATH_TO_LOG_DIR>:/mnt/log:rw
       # Encryption private key (remove if encryption is disabled)
       - <PATH_TO_PRIVATE_KEY>:/mnt/private_key.pem:ro
-      # Database files — one bind mount per file-based database
-      # - /data/my_database.csv:/mnt/my_database.csv:ro
+      # Database files — one bind mount per file-based database.
+      # The container target must be /mnt/<label><suffix> to match the env var.
+      # - /data/my_database.csv:/mnt/default.csv:ro
     labels:
       vantage6-type: node
       system: "False"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,26 @@
-version: '4'
 services:
 
   vantage6-server:
-    # build: .
     image: harbor2.vantage6.ai/infrastructure/server:latest
-    dockerfile: server.Dockerfile
     ports:
       - "7601:7601"
     depends_on:
       - database
     volumes:
-      # - ./configs/sqlite.yaml:/mnt/config.yaml
       - ./configs/postgress.yaml:/mnt/config.yaml
     command: [
-      "uwsgi --http :7601 --gevent 1000 --http-websockets
-        --http-chunked-input --http-keepalive --post-buffering 0
-        --master --callable app --disable-logging
-        --wsgi-file /vantage6/vantage6-server/vantage6/server/wsgi.py
-        --pyargv /mnt/config.yaml"
+      "uwsgi",
+      "--http", ":7601",
+      "--gevent", "1000",
+      "--http-websockets",
+      "--http-chunked-input",
+      "--http-keepalive",
+      "--post-buffering", "0",
+      "--master",
+      "--callable", "app",
+      "--disable-logging",
+      "--wsgi-file", "/vantage6/vantage6-server/vantage6/server/wsgi.py",
+      "--pyargv", "/mnt/config.yaml"
     ]
 
   database:

--- a/docker/algorithm-ohdsi-base.Dockerfile
+++ b/docker/algorithm-ohdsi-base.Dockerfile
@@ -4,7 +4,8 @@ ARG BASE=4.0
 # We could do this by supplying an environment var or store a requirements.txt
 # file in the repo.however for now lets always use the latest in a build.
 # ARG OHDSI_VERSION=0.3.2
-FROM harbor2.vantage6.ai/infrastructure/algorithm-base:${BASE}
+ARG REGISTRY=ghcr.io/vantage6
+FROM ${REGISTRY}/algorithm-base:${BASE}
 
 LABEL version=${TAG}
 # LABEL ohdsi_version=${OHDSI_VERSION}

--- a/docker/algorithm-store.Dockerfile
+++ b/docker/algorithm-store.Dockerfile
@@ -4,11 +4,11 @@
 # -----
 # * harbor2.vantage6.ai/infrastructure/algorithm-store:x.x.x
 #
-ARG TAG=latest
 ARG BASE=4.14
-ARG REGISTRY=harbor2.vantage6.ai
-FROM ${REGISTRY}/infrastructure/infrastructure-base:${BASE}
+ARG REGISTRY=ghcr.io/vantage6
+FROM ${REGISTRY}/infrastructure-base:${BASE}
 
+ARG TAG=latest
 LABEL version=${TAG}
 LABEL maintainer="Frank Martin <f.martin@iknl.nl>; Bart van Beusekom <b.vanbeusekom@iknl.nl>"
 

--- a/docker/algorithm-store.Dockerfile
+++ b/docker/algorithm-store.Dockerfile
@@ -6,13 +6,15 @@
 #
 ARG TAG=latest
 ARG BASE=4.14
-FROM harbor2.vantage6.ai/infrastructure/infrastructure-base:${BASE}
+ARG REGISTRY=harbor2.vantage6.ai
+FROM ${REGISTRY}/infrastructure/infrastructure-base:${BASE}
 
 LABEL version=${TAG}
 LABEL maintainer="Frank Martin <f.martin@iknl.nl>; Bart van Beusekom <b.vanbeusekom@iknl.nl>"
 
-RUN apt update -y
-RUN apt upgrade -y
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Fix DB issue
 RUN pip install psycopg2-binary
@@ -30,8 +32,10 @@ RUN pip install -e /vantage6/vantage6-algorithm-store
 
 # Overwrite uWSGI installation from the requirements.txt
 # Install uWSGI from source (for RabbitMQ)
-RUN apt-get install --no-install-recommends --no-install-suggests -y \
-  libssl-dev python3-setuptools
+RUN apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+  libssl-dev python3-setuptools \
+  && rm -rf /var/lib/apt/lists/*
 RUN CFLAGS="-I/usr/local/opt/openssl/include" \
   LDFLAGS="-L/usr/local/opt/openssl/lib" \
   UWSGI_PROFILE_OVERRIDE=ssl=true \

--- a/docker/infrastructure-base.Dockerfile
+++ b/docker/infrastructure-base.Dockerfile
@@ -6,7 +6,8 @@ LABEL maintainer="Frank Martin <f.martin@iknl.nl>"
 # slim bookworm does not have gcc installed
 # libdev is needed for arm compilation
 RUN apt-get update \
-    && apt-get install -y gcc python3-dev libffi-dev
+    && apt-get install -y gcc python3-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # install requirements. We cannot rely on setup.py because of the way
 # python resolves package versions. To control all dependencies we install

--- a/docker/node-and-server.Dockerfile
+++ b/docker/node-and-server.Dockerfile
@@ -2,14 +2,14 @@
 #
 # IMAGES
 # ------
-# * harbor2.vantage6.ai/infrastructure/node:x.x.x
-# * harbor2.vantage6.ai/infrastructure/server:x.x.x
+# * ghcr.io/vantage6/node:x.x.x
+# * ghcr.io/vantage6/server:x.x.x
 #
-ARG TAG=latest
 ARG BASE=4.14
-ARG REGISTRY=harbor2.vantage6.ai
-FROM ${REGISTRY}/infrastructure/infrastructure-base:${BASE}
+ARG REGISTRY=ghcr.io/vantage6
+FROM ${REGISTRY}/infrastructure-base:${BASE}
 
+ARG TAG=latest
 LABEL version=${TAG}
 LABEL maintainer="Frank Martin <f.martin@iknl.nl>"
 

--- a/docker/node-and-server.Dockerfile
+++ b/docker/node-and-server.Dockerfile
@@ -7,14 +7,16 @@
 #
 ARG TAG=latest
 ARG BASE=4.14
-FROM harbor2.vantage6.ai/infrastructure/infrastructure-base:${BASE}
+ARG REGISTRY=harbor2.vantage6.ai
+FROM ${REGISTRY}/infrastructure/infrastructure-base:${BASE}
 
 LABEL version=${TAG}
 LABEL maintainer="Frank Martin <f.martin@iknl.nl>"
 
 # Update and upgrade
-RUN apt update -y
-RUN apt upgrade -y
+RUN apt-get update -y \
+    && apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
 
 # Fix DB issue
 RUN pip install psycopg2-binary
@@ -43,8 +45,10 @@ RUN pip install -e /vantage6/vantage6-server
 
 # Overwrite uWSGI installation from the requirements.txt
 # Install uWSGI from source (for RabbitMQ)
-RUN apt-get install --no-install-recommends --no-install-suggests -y \
-  libssl-dev python3-setuptools
+RUN apt-get update \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+  libssl-dev python3-setuptools \
+  && rm -rf /var/lib/apt/lists/*
 RUN CFLAGS="-I/usr/local/opt/openssl/include" \
   LDFLAGS="-L/usr/local/opt/openssl/lib" \
   UWSGI_PROFILE_OVERRIDE=ssl=true \

--- a/docker/squid.Dockerfile
+++ b/docker/squid.Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:12
 
-RUN apt-get update
-RUN apt-get upgrade -y
-
-RUN apt-get install -y squid
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y squid \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
 

--- a/docker/ssh-tunnel.Dockerfile
+++ b/docker/ssh-tunnel.Dockerfile
@@ -1,10 +1,9 @@
 FROM debian:12
 
-RUN apt update
-RUN apt upgrade -y
-
-RUN apt install -y openssh-server
-RUN apt install -y curl
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y openssh-server curl \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /app
 

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,8 +1,6 @@
-ARG TAG=latest
-ARG BASE=4.3
 FROM node:20-alpine AS node
 
-ARG TAG
+ARG TAG=latest
 LABEL version=${TAG}
 LABEL maintainer="Bart van Beusekom <b.vanbeusekom@iknl.nl>, Frank Martin <f.martin@iknl.nl>"
 

--- a/docker/ui.Dockerfile
+++ b/docker/ui.Dockerfile
@@ -1,7 +1,8 @@
 ARG TAG=latest
 ARG BASE=4.3
-FROM node:20-alpine as node
+FROM node:20-alpine AS node
 
+ARG TAG
 LABEL version=${TAG}
 LABEL maintainer="Bart van Beusekom <b.vanbeusekom@iknl.nl>, Frank Martin <f.martin@iknl.nl>"
 

--- a/docker/vpn-configurator.Dockerfile
+++ b/docker/vpn-configurator.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:22.04
 
-RUN apt update
-RUN apt install iproute2 iptables -y
+RUN apt-get update \
+    && apt-get install -y iproute2 iptables \
+    && rm -rf /var/lib/apt/lists/*

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -64,6 +64,7 @@ from vantage6.common.client.node_client import NodeClient
 from vantage6.node import proxy_server
 from vantage6.node.util import get_parent_id
 from vantage6.node.docker.docker_manager import DockerManager
+from vantage6.node.docker.docker_manager import login_to_registries
 from vantage6.node.docker.vpn_manager import VPNManager
 from vantage6.node.socket import NodeTaskNamespace
 from vantage6.node.docker.ssh_tunnel import SSHTunnel
@@ -153,14 +154,28 @@ class Node:
         # Setup tasks dir
         self._set_task_dir(self.ctx)
 
+        # Login to docker registries early, so that credentials are available
+        # when infrastructure images (VPN, squid, SSH tunnel) are pulled
+        docker_registries = self.config.get("docker_registries", [])
+        docker_client = None
+        if docker_registries:
+            self.log.info("Logging in to docker registries")
+            docker_client = login_to_registries(docker_registries)
+
         # Setup VPN connection
-        self.vpn_manager = self.setup_vpn_connection(isolated_network_mgr, self.ctx)
+        self.vpn_manager = self.setup_vpn_connection(
+            isolated_network_mgr, self.ctx, docker_client=docker_client
+        )
 
         # Create SSH tunnel according to the node configuration
-        self.ssh_tunnels = self.setup_ssh_tunnels(isolated_network_mgr)
+        self.ssh_tunnels = self.setup_ssh_tunnels(
+            isolated_network_mgr, docker_client=docker_client
+        )
 
         # Create Squid proxy server
-        self.squid = self.setup_squid_proxy(isolated_network_mgr)
+        self.squid = self.setup_squid_proxy(
+            isolated_network_mgr, docker_client=docker_client
+        )
 
         # setup the docker manager
         self.log.debug("Setting up the docker manager")
@@ -171,6 +186,7 @@ class Node:
             tasks_dir=self.__tasks_dir,
             client=self.client,
             proxy=self.squid,
+            docker_client=docker_client,
         )
 
         # Create a long-lasting websocket connection.
@@ -582,8 +598,7 @@ class Node:
 
                 if not task_id:
                     self.log.error(
-                        f"task_id of run (id={results.run_id}) "
-                        f"could not be retrieved"
+                        f"task_id of run (id={results.run_id}) could not be retrieved"
                     )
                     return
 
@@ -763,7 +778,9 @@ class Node:
             self.__tasks_dir = ctx.data_dir
             self.__vpn_dir = ctx.vpn_dir
 
-    def setup_squid_proxy(self, isolated_network_mgr: NetworkManager) -> Squid:
+    def setup_squid_proxy(
+        self, isolated_network_mgr: NetworkManager, docker_client=None
+    ) -> Squid:
         """
         Initiates a Squid proxy if configured in the config.yml
 
@@ -786,6 +803,8 @@ class Node:
         ----------
         isolated_network_mgr: NetworkManager
             Network manager for isolated network
+        docker_client: DockerClient | None
+            Authenticated docker client
 
         Returns
         -------
@@ -813,7 +832,12 @@ class Node:
 
         try:
             squid = Squid(
-                isolated_network_mgr, config, self.ctx.name, volume, custom_squid_image
+                isolated_network_mgr,
+                config,
+                self.ctx.name,
+                volume,
+                custom_squid_image,
+                docker_client=docker_client,
             )
         except Exception as e:
             self.log.critical("Squid proxy failed to initialize. Continuing without.")
@@ -823,7 +847,7 @@ class Node:
         return squid
 
     def setup_ssh_tunnels(
-        self, isolated_network_mgr: NetworkManager
+        self, isolated_network_mgr: NetworkManager, docker_client=None
     ) -> list[SSHTunnel]:
         """
         Create a SSH tunnels when they are defined in the configuration file.
@@ -835,6 +859,8 @@ class Node:
         ----------
         isolated_network_mgr: NetworkManager
             Manager for the isolated network
+        docker_client: DockerClient | None
+            Authenticated docker client
         """
         if "ssh-tunnels" not in self.config:
             self.log.info("No SSH tunnels configured")
@@ -876,6 +902,7 @@ class Node:
                     self.ctx.name,
                     volume,
                     custom_tunnel_image,
+                    docker_client=docker_client,
                 )
             except Exception as e:
                 self.log.error("Error setting up SSH tunnel")
@@ -887,8 +914,11 @@ class Node:
         return tunnels
 
     def setup_vpn_connection(
-        self, isolated_network_mgr: NetworkManager, ctx: DockerNodeContext | NodeContext
-    ) -> VPNManager:
+        self,
+        isolated_network_mgr: NetworkManager,
+        ctx: DockerNodeContext | NodeContext,
+        docker_client=None,
+    ) -> VPNManager | None:
         """
         Setup container which has a VPN connection
 
@@ -898,12 +928,18 @@ class Node:
             Manager for the isolated Docker network
         ctx: DockerNodeContext | NodeContext
             Context object for the node
+        docker_client: DockerClient | None
+            Authenticated docker client
 
         Returns
         -------
-        VPNManager
-            Manages the VPN connection
+        VPNManager | None
+            Manages the VPN connection, or None if VPN is not configured
         """
+        if not self.config.get("vpn_subnet"):
+            self.log.info("VPN subnet is not defined, skipping VPN setup")
+            return None
+
         ovpn_file = os.path.join(self.__vpn_dir, VPN_CONFIG_FILE)
 
         self.log.info("Setting up VPN client container")
@@ -939,11 +975,10 @@ class Node:
             vpn_client_image=custom_vpn_client,
             network_config_image=custom_network,
             extra_hosts=extra_hosts,
+            docker_client=docker_client,
         )
 
-        if not self.config.get("vpn_subnet"):
-            self.log.warn("VPN subnet is not defined! VPN disabled.")
-        elif not os.path.isfile(ovpn_file):
+        if not os.path.isfile(ovpn_file):
             # if vpn config doesn't exist, get it and write to disk
             self._connect_vpn(vpn_manager, VPNConnectMode.REFRESH_COMPLETE, ovpn_file)
         else:
@@ -1067,7 +1102,7 @@ class Node:
             i += 1
 
         self.log.info(
-            f"Connected to host={self.client.host} on port=" f"{self.client.port}"
+            f"Connected to host={self.client.host} on port={self.client.port}"
         )
 
         self.log.debug(
@@ -1233,6 +1268,7 @@ class Node:
         adapter.
         """
         self.log.info("Cleaning up node...")
+
         if hasattr(self, "socketIO") and self.socketIO:
             try:
                 self.socketIO.disconnect()
@@ -1251,6 +1287,7 @@ class Node:
                     tunnel.stop()
                 except Exception:
                     self.log.exception("Error stopping SSH tunnel during cleanup")
+
         if hasattr(self, "_Node__docker") and self.__docker:
             try:
                 self.__docker.cleanup()

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -35,6 +35,8 @@ import requests.exceptions
 import psutil
 import pynvml
 
+from docker import DockerClient
+
 from pathlib import Path
 from threading import Thread
 from socketio import Client as SocketIO
@@ -64,7 +66,7 @@ from vantage6.common.client.node_client import NodeClient
 from vantage6.node import proxy_server
 from vantage6.node.util import get_parent_id
 from vantage6.node.docker.docker_manager import DockerManager
-from vantage6.node.docker.docker_manager import login_to_registries
+from vantage6.node.docker.utils import login_to_registries
 from vantage6.node.docker.vpn_manager import VPNManager
 from vantage6.node.socket import NodeTaskNamespace
 from vantage6.node.docker.ssh_tunnel import SSHTunnel
@@ -157,10 +159,10 @@ class Node:
         # Login to docker registries early, so that credentials are available
         # when infrastructure images (VPN, squid, SSH tunnel) are pulled
         docker_registries = self.config.get("docker_registries", [])
-        docker_client = None
+        docker_client = DockerClient.from_env()
         if docker_registries:
             self.log.info("Logging in to docker registries")
-            docker_client = login_to_registries(docker_registries)
+            login_to_registries(docker_registries, docker_client=docker_client)
 
         # Setup VPN connection
         self.vpn_manager = self.setup_vpn_connection(

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -48,47 +48,11 @@ from vantage6.node.docker.exceptions import (
     AlgorithmContainerNotFound,
 )
 from vantage6.node.globals import DEFAULT_REQUIRE_ALGO_IMAGE_PULL
+from vantage6.node.docker.utils import login_to_registries
 
 log = logging.getLogger(logger_name(__name__))
 
 SUPPORTED_DATABASE_MOUNT_MODES = {"copy", "ro"}
-
-
-def login_to_registries(
-    registries: list, docker_client: docker.DockerClient | None = None
-) -> docker.DockerClient:
-    """
-    Login to docker registries.
-
-    This is a module-level function so it can be called early in node
-    initialization, before DockerManager is instantiated.
-
-    Parameters
-    ----------
-    registries : list
-        List of registry dicts with 'username', 'password', 'registry' keys
-    docker_client : docker.DockerClient | None
-        Docker client to use. If None, a new client will be created.
-
-    Returns
-    -------
-    docker.DockerClient
-        The authenticated docker client
-    """
-    if docker_client is None:
-        docker_client = docker.from_env()
-    for registry in registries:
-        try:
-            docker_client.login(
-                username=registry.get("username"),
-                password=registry.get("password"),
-                registry=registry.get("registry"),
-            )
-            log.info(f"Logged in to {registry.get('registry')}")
-        except docker.errors.APIError as e:
-            log.warning(f"Could not login to {registry.get('registry')}")
-            log.warning(e)
-    return docker_client
 
 
 class Result(NamedTuple):
@@ -209,7 +173,7 @@ class DockerManager(DockerBaseManager):
 
         # login to the registries
         docker_registries = ctx.config.get("docker_registries", [])
-        self.login_to_registries(docker_registries)
+        login_to_registries(docker_registries, docker_client=self.docker)
 
         # set database uri and whether or not it is a file
         self._set_database(ctx.databases)
@@ -876,17 +840,6 @@ class DockerManager(DockerBaseManager):
             status=finished_task.status,
             parent_id=finished_task.parent_id,
         )
-
-    def login_to_registries(self, registries: list = []) -> None:
-        """
-        Login to the docker registries
-
-        Parameters
-        ----------
-        registries: list
-            list of registries to login to
-        """
-        login_to_registries(registries, docker_client=self.docker)
 
     def link_container_to_network(self, container_name: str, config_alias: str) -> None:
         """

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -14,7 +14,6 @@ import logging
 import docker
 import re
 import shutil
-from docker.utils import parse_repository_tag
 
 from typing import NamedTuple
 from pathlib import Path
@@ -53,6 +52,43 @@ from vantage6.node.globals import DEFAULT_REQUIRE_ALGO_IMAGE_PULL
 log = logging.getLogger(logger_name(__name__))
 
 SUPPORTED_DATABASE_MOUNT_MODES = {"copy", "ro"}
+
+
+def login_to_registries(
+    registries: list, docker_client: docker.DockerClient | None = None
+) -> docker.DockerClient:
+    """
+    Login to docker registries.
+
+    This is a module-level function so it can be called early in node
+    initialization, before DockerManager is instantiated.
+
+    Parameters
+    ----------
+    registries : list
+        List of registry dicts with 'username', 'password', 'registry' keys
+    docker_client : docker.DockerClient | None
+        Docker client to use. If None, a new client will be created.
+
+    Returns
+    -------
+    docker.DockerClient
+        The authenticated docker client
+    """
+    if docker_client is None:
+        docker_client = docker.from_env()
+    for registry in registries:
+        try:
+            docker_client.login(
+                username=registry.get("username"),
+                password=registry.get("password"),
+                registry=registry.get("registry"),
+            )
+            log.info(f"Logged in to {registry.get('registry')}")
+        except docker.errors.APIError as e:
+            log.warning(f"Could not login to {registry.get('registry')}")
+            log.warning(e)
+    return docker_client
 
 
 class Result(NamedTuple):
@@ -111,10 +147,11 @@ class DockerManager(DockerBaseManager):
         self,
         ctx: DockerNodeContext | NodeContext,
         isolated_network_mgr: NetworkManager,
-        vpn_manager: VPNManager,
+        vpn_manager: VPNManager | None,
         tasks_dir: Path,
         client: NodeClient,
         proxy: Squid | None = None,
+        docker_client: docker.DockerClient | None = None,
     ) -> None:
         """Initialization of DockerManager creates docker connection and
         sets some default values.
@@ -125,17 +162,19 @@ class DockerManager(DockerBaseManager):
             Context object from which some settings are obtained
         isolated_network_mgr: NetworkManager
             Manager for the isolated network
-        vpn_manager: VPNManager
-            VPN Manager object
+        vpn_manager: VPNManager | None
+            VPN Manager object, or None if VPN is not configured
         tasks_dir: Path
             Directory in which this task's data are stored
         client: NodeClient
             Client object to communicate with the server
         proxy: Squid | None
             Squid proxy object
+        docker_client: docker.DockerClient | None
+            Authenticated docker client to reuse
         """
         self.log.debug("Initializing DockerManager")
-        super().__init__(isolated_network_mgr)
+        super().__init__(isolated_network_mgr, docker_client=docker_client)
 
         self.data_volume_name = ctx.docker_volume_name
         self.ctx = ctx
@@ -648,6 +687,7 @@ class DockerManager(DockerBaseManager):
         # killed, but we don't register them as killed so they will be run
         # again when the node is restarted
         self.cleanup_tasks()
+
         for service in self.linked_services:
             self.isolated_network_mgr.disconnect(service)
 
@@ -750,8 +790,7 @@ class DockerManager(DockerBaseManager):
 
             except UnknownAlgorithmStartFail:
                 self.log.exception(
-                    f"Failed to start run {run_id} for an "
-                    "unknown reason. Retrying..."
+                    f"Failed to start run {run_id} for an unknown reason. Retrying..."
                 )
                 time.sleep(1)  # add some time before retrying the next attempt
 
@@ -794,7 +833,7 @@ class DockerManager(DockerBaseManager):
                         break
                 except AlgorithmContainerNotFound:
                     self.log.exception(
-                        "Failed to find container for " "algorithm with run_id %s",
+                        "Failed to find container for algorithm with run_id %s",
                         task.run_id,
                     )
                     self.failed_tasks.append(task)
@@ -847,17 +886,7 @@ class DockerManager(DockerBaseManager):
         registries: list
             list of registries to login to
         """
-        for registry in registries:
-            try:
-                self.docker.login(
-                    username=registry.get("username"),
-                    password=registry.get("password"),
-                    registry=registry.get("registry"),
-                )
-                self.log.info(f"Logged in to {registry.get('registry')}")
-            except docker.errors.APIError as e:
-                self.log.warning(f"Could not login to {registry.get('registry')}")
-                self.log.warning(e)
+        login_to_registries(registries, docker_client=self.docker)
 
     def link_container_to_network(self, container_name: str, config_alias: str) -> None:
         """

--- a/vantage6-node/vantage6/node/docker/squid.py
+++ b/vantage6-node/vantage6/node/docker/squid.py
@@ -22,6 +22,8 @@ from vantage6.common.docker.addons import (
     remove_container_if_exists,
     pull_image,
 )
+from docker import DockerClient
+
 from vantage6.node.docker.docker_base import DockerBaseManager
 from vantage6.node.docker.docker_manager import NetworkManager
 from vantage6.node.globals import SQUID_IMAGE, PACKAGE_FOLDER
@@ -45,6 +47,7 @@ class Squid(DockerBaseManager):
         node_name: str,
         config_volume: str,
         squid_image: str | None = None,
+        docker_client: DockerClient | None = None,
     ) -> None:
         """
         Create a tunnel from the isolated network to a remote machine and
@@ -63,6 +66,8 @@ class Squid(DockerBaseManager):
             Name of the ssh config volume (or local path)
         squid_image : str | None, optional
             User defined image to use for the tunnel, by default None
+        docker_client : DockerClient | None, optional
+            Docker client to use, by default None (creates new client)
 
         Raises
         ------
@@ -70,7 +75,7 @@ class Squid(DockerBaseManager):
             Missing key in the configuration
         """
 
-        super().__init__(isolated_network_mgr)
+        super().__init__(isolated_network_mgr, docker_client=docker_client)
 
         # reference to the squid container
         self.container = None

--- a/vantage6-node/vantage6/node/docker/ssh_tunnel.py
+++ b/vantage6-node/vantage6/node/docker/ssh_tunnel.py
@@ -22,6 +22,7 @@ from vantage6.common.docker.addons import (
     running_in_docker,
     remove_container_if_exists,
 )
+from docker import DockerClient
 from vantage6.node.docker.docker_base import DockerBaseManager
 from vantage6.node.docker.docker_manager import NetworkManager
 from vantage6.node.globals import SSH_TUNNEL_IMAGE, PACKAGE_FOLDER
@@ -88,6 +89,7 @@ class SSHTunnel(DockerBaseManager):
         node_name: str,
         config_volume: str,
         tunnel_image: str | None = None,
+        docker_client: DockerClient | None = None,
     ) -> None:
         """
         Create a tunnel from the isolated network to a remote machine and
@@ -106,6 +108,8 @@ class SSHTunnel(DockerBaseManager):
             Name of the ssh config volume (or local path)
         tunnel_image : str | None, optional
             User defined image to use for the tunnel, by default None
+        docker_client : DockerClient | None, optional
+            Docker client to use, by default None (creates new client)
 
         Raises
         ------
@@ -113,7 +117,7 @@ class SSHTunnel(DockerBaseManager):
             Missing key in the configuration
         """
 
-        super().__init__(isolated_network_mgr)
+        super().__init__(isolated_network_mgr, docker_client=docker_client)
 
         # reference to the SSH tunnel container
         self.container = None

--- a/vantage6-node/vantage6/node/docker/task_manager.py
+++ b/vantage6-node/vantage6/node/docker/task_manager.py
@@ -45,7 +45,7 @@ class DockerTaskManager(DockerBaseManager):
         self,
         image: str,
         docker_client: DockerClient,
-        vpn_manager: VPNManager,
+        vpn_manager: VPNManager | None,
         node_name: str,
         node_id: int,
         run_id: int,
@@ -72,8 +72,8 @@ class DockerTaskManager(DockerBaseManager):
             Name of docker image to be run
         docker_client: DockerClient
             Docker client instance to use
-        vpn_manager: VPNManager
-            VPN manager required to set up traffic forwarding via VPN
+        vpn_manager: VPNManager | None
+            VPN manager required to set up traffic forwarding via VPN, or None
         node_name: str
             Name of the node, to track running algorithms
         node_id: int
@@ -566,7 +566,7 @@ class DockerTaskManager(DockerBaseManager):
             environment_variables["https_proxy"] = self.proxy.address
 
             no_proxy = []
-            if self.__vpn_manager.subnet:
+            if self.__vpn_manager and self.__vpn_manager.subnet:
                 # Computing all ips in the vpn network is not feasible as the
                 # no_proxy environment variable will be too long for the
                 # container to start. So we only add the net + mask. For some

--- a/vantage6-node/vantage6/node/docker/utils.py
+++ b/vantage6-node/vantage6/node/docker/utils.py
@@ -1,0 +1,44 @@
+import logging
+
+import docker
+
+from vantage6.common import logger_name
+
+log = logging.getLogger(logger_name(__name__))
+
+
+def login_to_registries(
+    registries: list, docker_client: docker.DockerClient | None = None
+) -> docker.DockerClient:
+    """
+    Login to docker registries.
+
+    This is a module-level function so it can be called early in node
+    initialization, before DockerManager is instantiated.
+
+    Parameters
+    ----------
+    registries : list
+        List of registry dicts with 'username', 'password', 'registry' keys
+    docker_client : docker.DockerClient | None
+        Docker client to use. If None, a new client will be created.
+
+    Returns
+    -------
+    docker.DockerClient
+        The authenticated docker client
+    """
+    if docker_client is None:
+        docker_client = docker.from_env()
+    for registry in registries:
+        try:
+            docker_client.login(
+                username=registry.get("username"),
+                password=registry.get("password"),
+                registry=registry.get("registry"),
+            )
+            log.info(f"Logged in to {registry.get('registry')}")
+        except docker.errors.APIError as e:
+            log.warning(f"Could not login to {registry.get('registry')}")
+            log.warning(e)
+    return docker_client

--- a/vantage6-node/vantage6/node/docker/vpn_manager.py
+++ b/vantage6-node/vantage6/node/docker/vpn_manager.py
@@ -95,15 +95,14 @@ class VPNManager(DockerBaseManager):
             else network_config_image
         )
 
-        self.log.debug("Used VPN images:")
-        self.log.debug(f"  Alpine: {self.alpine_image}")
-        self.log.debug(f"  Client: {self.vpn_client_image}")
-        self.log.debug(f"  Config: {self.network_config_image}")
-
         self.has_vpn = False
 
     def _update_images(self) -> None:
         """Pulls the latest version of the VPN images"""
+        self.log.debug("Used VPN images:")
+        self.log.debug(f"  Alpine: {self.alpine_image}")
+        self.log.debug(f"  Client: {self.vpn_client_image}")
+        self.log.debug(f"  Config: {self.network_config_image}")
         self.log.info("Updating VPN images...")
         self.log.debug("Pulling Alpine image")
         pull_image(self.docker, self.alpine_image)

--- a/vantage6-node/vantage6/node/docker/vpn_manager.py
+++ b/vantage6-node/vantage6/node/docker/vpn_manager.py
@@ -5,6 +5,7 @@ import time
 import ipaddress
 
 from json.decoder import JSONDecodeError
+from docker import DockerClient
 from docker.models.containers import Container
 
 from vantage6.common import logger_name
@@ -47,6 +48,7 @@ class VPNManager(DockerBaseManager):
         vpn_client_image: str | None = None,
         network_config_image: str | None = None,
         extra_hosts: dict[str, str] | None = None,
+        docker_client: DockerClient | None = None,
     ) -> None:
         """
         Initializes a VPN manager instance
@@ -67,8 +69,10 @@ class VPNManager(DockerBaseManager):
             Name of alternative VPN client image to be used
         network_config_image: str | None
             Name of alternative network config image to be used
+        docker_client: DockerClient | None
+            Docker client to use. If None, a new client will be created.
         """
-        super().__init__(isolated_network_mgr)
+        super().__init__(isolated_network_mgr, docker_client=docker_client)
 
         self.vpn_client_container_name = f"{APPNAME}-{node_name}-vpn-client"
         self.vpn_volume_name = vpn_volume_name
@@ -90,8 +94,6 @@ class VPNManager(DockerBaseManager):
             if not network_config_image
             else network_config_image
         )
-
-        self._update_images()
 
         self.log.debug("Used VPN images:")
         self.log.debug(f"  Alpine: {self.alpine_image}")
@@ -125,9 +127,12 @@ class VPNManager(DockerBaseManager):
             return
         elif not self._is_ipv4_subnet(self.subnet):
             self.log.error(
-                f"VPN subnet {self.subnet} is not a valid subnet! " "Disabling VPN..."
+                f"VPN subnet {self.subnet} is not a valid subnet! Disabling VPN..."
             )
             return
+
+        # Pull VPN images only when we actually need them
+        self._update_images()
 
         self.log.debug("Mounting VPN configuration file")
         # add volume containing OVPN config file
@@ -395,9 +400,7 @@ class VPNManager(DockerBaseManager):
 
         # Find ports on VPN container that are already occupied
         cmd = (
-            "sh -c "
-            '"iptables -t nat -L PREROUTING -n | '
-            "awk '{print $7}' | cut -c 5-\""
+            "sh -c \"iptables -t nat -L PREROUTING -n | awk '{print $7}' | cut -c 5-\""
         )
         occupied_ports = self.vpn_client_container.exec_run(cmd=cmd)
 
@@ -424,15 +427,15 @@ class VPNManager(DockerBaseManager):
             # Rule for directing external vpn traffic to algorithms
             command += (
                 "iptables -t nat -A PREROUTING -i tun0 -p tcp "
-                f'--dport {port["port"]} -j DNAT '
-                f'--to {algo_ip}:{port["algo_port"]};'
+                f"--dport {port['port']} -j DNAT "
+                f"--to {algo_ip}:{port['algo_port']};"
             )
 
             # Rule for directing internal vpn traffic to algorithms
             command += (
                 f"iptables -t nat -A PREROUTING -d {vpn_ip}/32 -p tcp "
-                f'--dport {port["port"]} -j DNAT '
-                f'--to {algo_ip}:{port["algo_port"]};'
+                f"--dport {port['port']} -j DNAT "
+                f"--to {algo_ip}:{port['algo_port']};"
             )
 
             # remove the algorithm ports from the dictionaries as these are no

--- a/vantage6/vantage6/cli/node/start.py
+++ b/vantage6/vantage6/cli/node/start.py
@@ -155,7 +155,7 @@ def cli_node_start(
         ("/mnt/vpn", vpn_volume.name, "rw"),
         ("/mnt/ssh", ssh_volume.name, "rw"),
         ("/mnt/squid", squid_volume.name, "rw"),
-        ("/mnt/config", str(ctx.config_dir), "ro"),
+        (f"/mnt/config/{name}.yaml", str(ctx.config_file), "ro"),
         ("/var/run/docker.sock", "/var/run/docker.sock", "rw"),
     ]
 


### PR DESCRIPTION
This pull request introduces several improvements to Docker image building, container initialization, and resource cleanup for the vantage6 infrastructure. The main themes are enhanced Docker registry flexibility, improved Dockerfile hygiene, and early authentication for pulling infrastructure images. Additionally, a new Docker Compose template for node deployment is added.

**Docker registry flexibility and image build improvements:**

* Added support for a configurable `REGISTRY` build argument across all relevant Dockerfiles and `Makefile` targets, allowing images to be built from custom registries instead of hardcoding the default. (`docker/node-and-server.Dockerfile`, `docker/algorithm-store.Dockerfile`, `Makefile`, [[1]](diffhunk://#diff-2698a5af323828b743362f1fc3ef9330a5b7bf44f7ad3688ea28ef8d75d85accL10-R19) [[2]](diffhunk://#diff-37d507c9c83d6a5d19204eaa022579c4b3b61c290b2d675d5c95f1cb960a7333L9-R17) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R131) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R200) [[5]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R212)
* Updated Dockerfiles to use `apt-get` consistently, combine update/upgrade/install commands, and clean up `apt` lists to reduce image size and improve build reliability. (`docker/node-and-server.Dockerfile`, `docker/algorithm-store.Dockerfile`, `docker/infrastructure-base.Dockerfile`, `docker/squid.Dockerfile`, `docker/ssh-tunnel.Dockerfile`, `docker/vpn-configurator.Dockerfile`, [[1]](diffhunk://#diff-2698a5af323828b743362f1fc3ef9330a5b7bf44f7ad3688ea28ef8d75d85accL10-R19) [[2]](diffhunk://#diff-37d507c9c83d6a5d19204eaa022579c4b3b61c290b2d675d5c95f1cb960a7333L9-R17) [[3]](diffhunk://#diff-f28a3e6d0a2c51a4d5b04d8ff002ac3ea3a70a5d0d85032f34652183338a144eL9-R10) [[4]](diffhunk://#diff-e1f72645033ed606c5b74b10eb34aa05f65340eda628749866ad8cfd471f496dL3-R6) [[5]](diffhunk://#diff-b448dd80bba3344258abd5243dd0dfb327015a0fe1d9876ff864759254544bc8L3-R6) [[6]](diffhunk://#diff-423b5a78f4b7c066135e2e8cc64d7f1a095abc58a7052a8226a0aefe92d52d93L3-R5)

**Node initialization and infrastructure image pulling:**

* The node now logs in to all configured Docker registries early in the startup process, ensuring credentials are available when pulling infrastructure images (VPN, Squid, SSH tunnel). This involves passing an authenticated Docker client to all relevant setup methods. (`vantage6-node/vantage6/node/__init__.py`, [[1]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R67) [[2]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R157-R178) [[3]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R189) [[4]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489L766-R783) [[5]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R806-R807) [[6]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489L816-R840) [[7]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489L826-R850) [[8]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R862-R863) [[9]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R905) [[10]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489L890-R921) [[11]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R931-R942) [[12]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R978-R981)

**Deployment and configuration enhancements:**

* Added a new `docker-compose.node.yml` template for running a vantage6 node via Docker Compose, with detailed instructions and placeholders for easier setup in various environments.
* Cleaned up and modernized the main `docker-compose.yml`, switching to a more explicit command array for the server and removing deprecated build fields.

**Minor improvements and fixes:**

* Improved log messages, error handling, and code comments for clarity and maintainability. (`vantage6-node/vantage6/node/__init__.py`, [[1]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489L585-R601) [[2]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489L1070-R1105) [[3]](diffhunk://#diff-641c734edf099ce15a8911efbbe8f0e1b3ff8365531efe558694de1b65b5f489R1271)
* Small Dockerfile style fixes, such as consistent use of `AS` in multi-stage builds. (`docker/ui.Dockerfile`, [docker/ui.DockerfileL3-R5](diffhunk://#diff-d1018bc16ce1071bfae48cfafd616eb01e04be3628b1c52a54e6594d1cf670afL3-R5))