### PR TITLE
Change/ghcr add back infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,24 +294,24 @@ jobs:
 
       - name: Pull docker images
         run: |
-          docker pull ghcr.io/${{ github.repository }}/server:${version}
-          docker pull ghcr.io/${{ github.repository }}/node:${version}
-          docker pull ghcr.io/${{ github.repository }}/algorithm-store:${version}
-          docker pull ghcr.io/${{ github.repository }}/ui:${version}
-          docker pull ghcr.io/${{ github.repository }}/alpine:${version}
-          docker pull ghcr.io/${{ github.repository }}/vpn-client:${version}
-          docker pull ghcr.io/${{ github.repository }}/vpn-configurator:${version}
-          docker pull ghcr.io/${{ github.repository }}/ssh-tunnel:${version}
-          docker pull ghcr.io/${{ github.repository }}/squid:${version}
+          docker pull ghcr.io/vantage6/infrastructure/server:${version}
+          docker pull ghcr.io/vantage6/infrastructure/node:${version}
+          docker pull ghcr.io/vantage6/infrastructure/algorithm-store:${version}
+          docker pull ghcr.io/vantage6/infrastructure/ui:${version}
+          docker pull ghcr.io/vantage6/infrastructure/alpine:${version}
+          docker pull ghcr.io/vantage6/infrastructure/vpn-client:${version}
+          docker pull ghcr.io/vantage6/infrastructure/vpn-configurator:${version}
+          docker pull ghcr.io/vantage6/infrastructure/ssh-tunnel:${version}
+          docker pull ghcr.io/vantage6/infrastructure/squid:${version}
 
       - name: Tag docker images
         if: ${{  env.stage == ''  &&  env.major_name != '' }}
         run: |
-          docker tag ghcr.io/${{ github.repository }}/server:${version} ghcr.io/${{ github.repository }}/server:${major_name}
-          docker tag ghcr.io/${{ github.repository }}/server:${version} ghcr.io/${{ github.repository }}/server:${major_name}-live
-          docker tag ghcr.io/${{ github.repository }}/node:${version} ghcr.io/${{ github.repository }}/node:${major_name}
-          docker tag ghcr.io/${{ github.repository }}/algorithm-store:${version} ghcr.io/${{ github.repository }}/algorithm-store:${major_name}
-          docker tag ghcr.io/${{ github.repository }}/ui:${version} ghcr.io/${{ github.repository }}/ui:${major_name}
+          docker tag ghcr.io/vantage6/infrastructure/server:${version} ghcr.io/vantage6/infrastructure/server:${major_name}
+          docker tag ghcr.io/vantage6/infrastructure/server:${version} ghcr.io/vantage6/infrastructure/server:${major_name}-live
+          docker tag ghcr.io/vantage6/infrastructure/node:${version} ghcr.io/vantage6/infrastructure/node:${major_name}
+          docker tag ghcr.io/vantage6/infrastructure/algorithm-store:${version} ghcr.io/vantage6/infrastructure/algorithm-store:${major_name}
+          docker tag ghcr.io/vantage6/infrastructure/ui:${version} ghcr.io/vantage6/infrastructure/ui:${major_name}
 
       # Release a node image for major.minor. This is released for any
       # non-candidate release or if no non-candidate release has been made yet
@@ -319,17 +319,17 @@ jobs:
       - name: Build latest node minor image
         if: ${{ env.stage == '' || env.patch == 0 }}
         run: |
-          docker tag ghcr.io/${{ github.repository }}/node:${version} ghcr.io/${{ github.repository }}/node:${major}.${minor}
-          docker push ghcr.io/${{ github.repository }}/node:${major}.${minor}
+          docker tag ghcr.io/vantage6/infrastructure/node:${version} ghcr.io/vantage6/infrastructure/node:${major}.${minor}
+          docker push ghcr.io/vantage6/infrastructure/node:${major}.${minor}
 
       - name: Push docker images
         if: ${{  env.stage == ''  &&  env.major_name != '' }}
         run: |
-          docker push ghcr.io/${{ github.repository }}/server:${major_name}
-          docker push ghcr.io/${{ github.repository }}/server:${major_name}-live
-          docker push ghcr.io/${{ github.repository }}/node:${major_name}
-          docker push ghcr.io/${{ github.repository }}/algorithm-store:${major_name}
-          docker push ghcr.io/${{ github.repository }}/ui:${major_name}
+          docker push ghcr.io/vantage6/infrastructure/server:${major_name}
+          docker push ghcr.io/vantage6/infrastructure/server:${major_name}-live
+          docker push ghcr.io/vantage6/infrastructure/node:${major_name}
+          docker push ghcr.io/vantage6/infrastructure/algorithm-store:${major_name}
+          docker push ghcr.io/vantage6/infrastructure/ui:${major_name}
 
       # Release matching support images for major.minor. This is released for any
       # non-candidate release or if no non-candidate release has been made yet
@@ -337,20 +337,20 @@ jobs:
       - name: Build latest minor version support images
         if: ${{ env.stage == '' || env.patch == 0 }}
         run: |
-          docker tag ghcr.io/${{ github.repository }}/alpine:${version} ghcr.io/${{ github.repository }}/alpine:${major}.${minor}
-          docker push ghcr.io/${{ github.repository }}/alpine:${major}.${minor}
+          docker tag ghcr.io/vantage6/infrastructure/alpine:${version} ghcr.io/vantage6/infrastructure/alpine:${major}.${minor}
+          docker push ghcr.io/vantage6/infrastructure/alpine:${major}.${minor}
 
-          docker tag ghcr.io/${{ github.repository }}/vpn-client:${version} ghcr.io/${{ github.repository }}/vpn-client:${major}.${minor}
-          docker push ghcr.io/${{ github.repository }}/vpn-client:${major}.${minor}
+          docker tag ghcr.io/vantage6/infrastructure/vpn-client:${version} ghcr.io/vantage6/infrastructure/vpn-client:${major}.${minor}
+          docker push ghcr.io/vantage6/infrastructure/vpn-client:${major}.${minor}
 
-          docker tag ghcr.io/${{ github.repository }}/vpn-configurator:${version} ghcr.io/${{ github.repository }}/vpn-configurator:${major}.${minor}
-          docker push ghcr.io/${{ github.repository }}/vpn-configurator:${major}.${minor}
+          docker tag ghcr.io/vantage6/infrastructure/vpn-configurator:${version} ghcr.io/vantage6/infrastructure/vpn-configurator:${major}.${minor}
+          docker push ghcr.io/vantage6/infrastructure/vpn-configurator:${major}.${minor}
 
-          docker tag ghcr.io/${{ github.repository }}/ssh-tunnel:${version} ghcr.io/${{ github.repository }}/ssh-tunnel:${major}.${minor}
-          docker push ghcr.io/${{ github.repository }}/ssh-tunnel:${major}.${minor}
+          docker tag ghcr.io/vantage6/infrastructure/ssh-tunnel:${version} ghcr.io/vantage6/infrastructure/ssh-tunnel:${major}.${minor}
+          docker push ghcr.io/vantage6/infrastructure/ssh-tunnel:${major}.${minor}
 
-          docker tag ghcr.io/${{ github.repository }}/squid:${version} ghcr.io/${{ github.repository }}/squid:${major}.${minor}
-          docker push ghcr.io/${{ github.repository }}/squid:${major}.${minor}
+          docker tag ghcr.io/vantage6/infrastructure/squid:${version} ghcr.io/vantage6/infrastructure/squid:${major}.${minor}
+          docker push ghcr.io/vantage6/infrastructure/squid:${major}.${minor}
 
   # Build an release all the vantage6 infrastructure packages. For all
   # the packages it will (1) update the version as specified in the tag,

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # docker image tag
 TAG ?= cotopaxi
-REGISTRY ?= ghcr.io/vantage6
+REGISTRY ?= ghcr.io/vantage6/infrastructure
 PLATFORMS ?= linux/arm64,linux/amd64
 # Example for local development
 # TAG ?= local

--- a/README.md
+++ b/README.md
@@ -146,10 +146,10 @@ easily.
 The vantage6 infrastructure is delivered in Docker images. All Docker images are stored
 in the vantage6 GitHub Container Registry. The most important images are:
 
-- `ghcr.io/vantage6/node:VERSION` -> _Node application Docker image_
-- `ghcr.io/vantage6/server:VERSION` -> _Server application Docker image_
-- `ghcr.io/vantage6/ui:VERSION` -> _User interface Docker image_
-- `ghcr.io/vantage6/algorithm-store:VERSION` -> _Algorithm store Docker image_
+- `ghcr.io/vantage6/infrastructure/node:VERSION` -> _Node application Docker image_
+- `ghcr.io/vantage6/infrastructure/server:VERSION` -> _Server application Docker image_
+- `ghcr.io/vantage6/infrastructure/ui:VERSION` -> _User interface Docker image_
+- `ghcr.io/vantage6/infrastructure/algorithm-store:VERSION` -> _Algorithm store Docker image_
 
 with `VERSION` being the full semantic version of the vantage6 infrastructure, e.g.
 `4.0.0` or `4.1.0rc0`.
@@ -157,16 +157,16 @@ with `VERSION` being the full semantic version of the vantage6 infrastructure, e
 Several other images are used to support the infrastructure:
 
 - `ghcr.io/vantage6/infrastructure-base:VERSION` -> _Base image for the infrastructure_
-- `ghcr.io/vantage6/squid:VERSION` -> _Squid proxy image used for the whitelisting service_
-- `ghcr.io/vantage6/alpine` -> _Alpine image used for vpn traffic forwarding_
-- `ghcr.io/vantage6/vpn-client` -> _VPN image used to connect to the VPN_
-- `ghcr.io/vantage6/vpn-configurator` -> _VPN image used for initialization_
-- `ghcr.io/vantage6/ssh-tunnel` -> _SSH tunnel image used for connecting algorithms to external services_
+- `ghcr.io/vantage6/infrastructure/squid:VERSION` -> _Squid proxy image used for the whitelisting service_
+- `ghcr.io/vantage6/infrastructure/alpine` -> _Alpine image used for vpn traffic forwarding_
+- `ghcr.io/vantage6/infrastructure/vpn-client` -> _VPN image used to connect to the VPN_
+- `ghcr.io/vantage6/infrastructure/vpn-configurator` -> _VPN image used for initialization_
+- `ghcr.io/vantage6/infrastructure/ssh-tunnel` -> _SSH tunnel image used for connecting algorithms to external services_
 
 And finally there are some images released for algorithm development:
 
-- `ghcr.io/vantage6/algorithm-base:MAJOR.MINOR` -> _Base image for algorithm development_
-- `ghcr.io/vantage6/algorithm-ohdsi-base:MAJOR.MINOR` -> _Extended algorithm base image for OHDSI algorithm development_
+- `ghcr.io/vantage6/infrastructure/algorithm-base:MAJOR.MINOR` -> _Base image for algorithm development_
+- `ghcr.io/vantage6/infrastructure/algorithm-ohdsi-base:MAJOR.MINOR` -> _Extended algorithm base image for OHDSI algorithm development_
 
 ## :gift_heart: Join the community!
 

--- a/docker-compose.node.yml
+++ b/docker-compose.node.yml
@@ -23,7 +23,7 @@
 
 services:
   node:
-    image: ghcr.io/vantage6/node:cotopaxi
+    image: ghcr.io/vantage6/infrastructure/node:cotopaxi
     container_name: vantage6-<NODE_NAME>-user
     restart: unless-stopped
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vantage6-server:
-    image: ghcr.io/vantage6/server:latest
+    image: ghcr.io/vantage6/infrastructure/server:latest
     ports:
       - "7601:7601"
     depends_on:

--- a/docker/algorithm-ohdsi-base.Dockerfile
+++ b/docker/algorithm-ohdsi-base.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE=4.0
 # We could do this by supplying an environment var or store a requirements.txt
 # file in the repo.however for now lets always use the latest in a build.
 # ARG OHDSI_VERSION=0.3.2
-ARG REGISTRY=ghcr.io/vantage6
+ARG REGISTRY=ghcr.io/vantage6/infrastructure
 FROM ${REGISTRY}/algorithm-base:${BASE}
 
 LABEL version=${TAG}

--- a/docker/algorithm-store.Dockerfile
+++ b/docker/algorithm-store.Dockerfile
@@ -2,10 +2,10 @@
 #
 # IMAGE
 # -----
-# * ghcr.io/vantage6/algorithm-store:x.x.x
+# * ghcr.io/vantage6/infrastructure/algorithm-store:x.x.x
 #
 ARG BASE=4.15
-ARG REGISTRY=ghcr.io/vantage6
+ARG REGISTRY=ghcr.io/vantage6/infrastructure
 FROM ${REGISTRY}/infrastructure-base:${BASE}
 
 ARG TAG=latest

--- a/docker/node-and-server.Dockerfile
+++ b/docker/node-and-server.Dockerfile
@@ -2,11 +2,11 @@
 #
 # IMAGES
 # ------
-# * ghcr.io/vantage6/node:x.x.x
-# * ghcr.io/vantage6/server:x.x.x
+# * ghcr.io/vantage6/infrastructure/node:x.x.x
+# * ghcr.io/vantage6/infrastructure/server:x.x.x
 #
 ARG BASE=4.15
-ARG REGISTRY=ghcr.io/vantage6
+ARG REGISTRY=ghcr.io/vantage6/infrastructure
 FROM ${REGISTRY}/infrastructure-base:${BASE}
 
 ARG TAG=latest

--- a/docs/algorithm_store/deploy.rst
+++ b/docs/algorithm_store/deploy.rst
@@ -37,7 +37,7 @@ of a docker-compose file that can be used to deploy the algorithm store.
 
     services:
       vantage6-algorithm-store:
-        image: ghcr.io/vantage6/algorithm-store:cotopaxi
+        image: ghcr.io/vantage6/infrastructure/algorithm-store:cotopaxi
         ports:
         - "8000:5000"
         volumes:

--- a/docs/algorithm_store/install.rst
+++ b/docs/algorithm_store/install.rst
@@ -2,8 +2,8 @@
 
 .. |instance-type| replace:: algorithm store
 .. |requirements-link| replace:: :ref:`requirements <algorithm-store-requirements>`
-.. |image| replace:: ``ghcr.io/vantage6/algorithm-store``
-.. |image-old| replace:: ``ghcr.io/vantage6/algorithm-store:<VERSION>``
+.. |image| replace:: ``ghcr.io/vantage6/infrastructure/algorithm-store``
+.. |image-old| replace:: ``ghcr.io/vantage6/infrastructure/algorithm-store:<VERSION>``
 .. |deployment-link| replace:: :ref:`deployment <algorithm-store-deployment>`
 
 .. include:: ../common/install.rst

--- a/docs/algorithms/develop.rst
+++ b/docs/algorithms/develop.rst
@@ -266,8 +266,8 @@ Here are a few examples of how to build and upload your image:
     # Build and upload to private registry (GCR as example). Here you don't need to
     # provide a username but you should write out the full image URL. Also, again you
     # need to be logged in with ``docker login``.
-    docker build -t ghcr.io/vantage6/algorithm-example:latest .
-    docker push ghcr.io/vantage6/algorithm-example:latest
+    docker build -t ghcr.io/vantage6/algorithm/example:latest .
+    docker push ghcr.io/vantage6/algorithm/example:latest
 
 Now that your algorithm has been uploaded it is available for nodes to retrieve
 when they need it.
@@ -330,7 +330,7 @@ execution result. For example, to test the average algorithm, the script could l
             collaboration=1,
             organizations=[1],
             name="test_average_task",
-            image="ghcr.io/vantage6/algorithm-average:latest",
+            image="ghcr.io/vantage6/algorithm/average:latest",
             description="",
             input_=input_,
             databases=[{"label": "olympic_athletes"}],

--- a/docs/devops/release.rst
+++ b/docs/devops/release.rst
@@ -67,13 +67,13 @@ the following steps to test a release:
   .. code:: bash
 
     v6 dev create-demo-network \
-        -i ghcr.io/vantage6/server:<version> \
-        --ui-image ghcr.io/vantage6/ui:<version>
+        -i ghcr.io/vantage6/infrastructure/server:<version> \
+        --ui-image ghcr.io/vantage6/infrastructure/ui:<version>
 
     v6 dev start-demo-network \
-        --server-image ghcr.io/vantage6/server:<version> \
-        --node-image ghcr.io/vantage6/node:<version> \
-        --store-image ghcr.io/vantage6/algorithm-store:<version>
+        --server-image ghcr.io/vantage6/infrastructure/server:<version> \
+        --node-image ghcr.io/vantage6/infrastructure/node:<version> \
+        --store-image ghcr.io/vantage6/infrastructure/algorithm-store:<version>
 
 4. *Test code changes*. Go through all issues that are part of the new release
    and test if they work as intended.
@@ -149,8 +149,7 @@ The release pipeline executes the following steps:
    tag and commit this back to the main branch.
 3. Install the dependencies and build the Python package.
 4. Upload the package to PyPi.
-5. Build and push the Docker image to `ghcr.io/vantage6
-   <https://ghcr.io/vantage6>`_.
+5. Build and push the Docker image to ``ghcr.io/vantage6/infrastructure``.
 6. Post a message in Discord to alert the community of the new release. This
    is not done if the version is a pre-release (e.g. version/x.y.0rc1).
 
@@ -181,7 +180,7 @@ in the table below.
      - Token from coveralls to post the test coverage stats.
    * - ``DOCKER_TOKEN``
      - Token used together ``DOCKER_USERNAME`` to upload the container images
-       to `<https://ghcr.io/vantage6>`_.
+       to ``ghcr.io/vantage6/infrastructure``.
    * - ``DOCKER_USERNAME``
      - See ``DOCKER_TOKEN``.
    * - ``PYPI_TOKEN``
@@ -218,8 +217,8 @@ Docker images can be pulled manually with e.g.
 
 ::
 
-  docker pull ghcr.io/vantage6/server:cotopaxi
-  docker pull ghcr.io/vantage6/node:3.1.0
+  docker pull ghcr.io/vantage6/infrastructure/server:cotopaxi
+  docker pull ghcr.io/vantage6/infrastructure/node:3.1.0
 
 User Interface release
 ----------------------
@@ -239,7 +238,7 @@ The release pipeline for the UI executes the following steps:
 1. Version tag is verified (same as infrastructure).
 2. Version is updated in the code (same as infrastructure).
 3. Application is built.
-4. Docker images are built and released to ghcr.io/vantage6.
+4. Docker images are built and released to ``ghcr.io/vantage6/infrastructure``.
 5. Application is pushed to our UI deployment slot (an Azure app service).
 
 

--- a/docs/features/server/api_structure.rst
+++ b/docs/features/server/api_structure.rst
@@ -11,7 +11,7 @@ same way, loosely following HATEOAS rules. An example is detailed below:
       "id": 1,
       "name": "test",
       "results": "/api/result?task_id=1",
-      "image": "ghcr.io/vantage6/algorithm-test:latest",
+      "image": "ghcr.io/vantage6/algorithm/test:latest",
       ...
   }
 

--- a/docs/node/configure.rst
+++ b/docs/node/configure.rst
@@ -111,18 +111,18 @@ There are two important steps to be taken to accomplish this:
 
       policies:
          allowed_algorithms:
-            - ^ghcr\.io/vantage6/[a-zA-Z]+/[a-zA-Z]+
-            - ^ghcr\.io/vantage6/algorithm-glm$
-            - ^ghcr\.io/vantage6/algorithm-glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$
+            - ^ghcr\.io/vantage6/algorithm/[a-zA-Z]+/[a-zA-Z]+
+            - ^ghcr\.io/vantage6/algorithm/glm$
+            - ^ghcr\.io/vantage6/algorithm/glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$
          allowed_algorithm_stores:
             - https://store.cotopaxi.vantage6.ai
 
    These four examples lead to the following restrictions:
-   1. ``^ghcr\.io/vantage6/[a-zA-Z]+/[a-zA-Z]+``: allow all images
-      from the ghcr.io/vantage6 registry
-   2. ``^ghcr\.io/vantage6/algorithm-glm$``: only allow the GLM image, but
+   1. ``^ghcr\.io/vantage6/algorithm/[a-zA-Z]+/[a-zA-Z]+``: allow all images
+      from the ghcr.io/vantage6 registry that start with ``algorithm/``
+   2. ``^ghcr\.io/vantage6/algorithm/glm$``: only allow the GLM image, but
       all builds of this image
-   3. ``^ghcr\.io/vantage6/algorithm-glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$``
+   3. ``^ghcr\.io/vantage6/algorithm/glm@sha256:82becede498899ec668628e7cb0ad87b6e1c371cb8a1e597d83a47fac21d6af3$``
       ``a1e597d83a47fac21d6af3$``: allows only this specific build from the GLM
       image to run on your data
    4. ``https://store.cotopaxi.vantage6.ai``: allow all algorithms from the

--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -56,12 +56,12 @@ node_extra_hosts:
 # components.
 # OPTIONAL
 images:
-  node: ghcr.io/vantage6/node:cotopaxi
-  alpine: ghcr.io/vantage6/alpine
-  vpn_client: ghcr.io/vantage6/vpn-client
-  network_config: ghcr.io/vantage6/vpn-configurator
-  ssh_tunnel: ghcr.io/vantage6/ssh-tunnel
-  squid: ghcr.io/vantage6/squid
+  node: ghcr.io/vantage6/infrastructure/node:cotopaxi
+  alpine: ghcr.io/vantage6/infrastructure/alpine
+  vpn_client: ghcr.io/vantage6/infrastructure/vpn-client
+  network_config: ghcr.io/vantage6/infrastructure/vpn-configurator
+  ssh_tunnel: ghcr.io/vantage6/infrastructure/ssh-tunnel
+  squid: ghcr.io/vantage6/infrastructure/squid
 
 # path or endpoint to the local data source. The client can request a
 # certain database by using its label. The type is used by the
@@ -132,8 +132,8 @@ policies:
   # expected to be a valid regular expression. If you don't specify this, all algorithm
   # images are allowed to run on this node (unless other policies restrict this).
   allowed_algorithms:
-    - ^ghcr\.io/vantage6/[a-zA-Z]+/[a-zA-Z]+$
-    - ^ghcr\.io/vantage6/algorithm-glm$
+    - ^ghcr\.io/vantage6/algorithm/[a-zA-Z]+/[a-zA-Z]+$
+    - ^ghcr\.io/vantage6/algorithm/glm$
 
   # It is also possible to allow all algorithms from particular algorithm stores. Set
   # these stores here. They may be strings or regular expressions. If you don't specify
@@ -160,7 +160,7 @@ policies:
     - 6
     - root
 
-  # The basics algorithm (ghcr.io/vantage6/algorithm-basics:latest) is whitelisted
+  # The basics algorithm (ghcr.io/vantage6/algorithm/basics:latest) is whitelisted
   # by default. It is used to collect column names in the User Interface to
   # facilitate task creation. Set to false to disable this.
   allow_basics_algorithm: true

--- a/docs/server/deploy.rst
+++ b/docs/server/deploy.rst
@@ -129,7 +129,7 @@ may want to use a different image tag, or you may want to use a different port.
 
     services:
       vantage6-server:
-        image: ghcr.io/vantage6/server:cotopaxi
+        image: ghcr.io/vantage6/infrastructure/server:cotopaxi
         ports:
         - "8000:80"
         volumes:
@@ -147,7 +147,7 @@ look something like this if you want to use `secrets in docker compose
 
     services:
       vantage6-server:
-        image: ghcr.io/vantage6/server:cotopaxi
+        image: ghcr.io/vantage6/infrastructure/server:cotopaxi
         ports:
         - "8000:80"
         environment:

--- a/docs/server/install.rst
+++ b/docs/server/install.rst
@@ -2,8 +2,8 @@
 
 .. |instance-type| replace:: server
 .. |requirements-link| replace:: :ref:`requirements <server-requirements>`
-.. |image| replace:: ``ghcr.io/vantage6/server``
-.. |image-old| replace:: ``ghcr.io/vantage6/server:<VERSION>``
+.. |image| replace:: ``ghcr.io/vantage6/infrastructure/server``
+.. |image-old| replace:: ``ghcr.io/vantage6/infrastructure/server:<VERSION>``
 .. |deployment-link| replace:: :ref:`deployment <server-deployment>`
 
 .. include:: ../common/install.rst

--- a/docs/server/optional.rst
+++ b/docs/server/optional.rst
@@ -56,7 +56,7 @@ to your own environment.
     name: run-ui
     services:
       ui:
-        image: ghcr.io/vantage6/ui:cotopaxi
+        image: ghcr.io/vantage6/infrastructure/ui:cotopaxi
         ports:
           - "8000:80"
         environment:

--- a/docs/server/yaml/server_config.yaml
+++ b/docs/server/yaml/server_config.yaml
@@ -161,8 +161,8 @@ vpn_server:
 # components.
 # OPTIONAL
 images:
-  server: ghcr.io/vantage6/server:cotopaxi
-  ui: ghcr.io/vantage6/ui:cotopaxi
+  server: ghcr.io/vantage6/infrastructure/server:cotopaxi
+  ui: ghcr.io/vantage6/infrastructure/ui:cotopaxi
 
 # options for starting the User Interface when starting the server
 ui:

--- a/docs/user/pyclient.rst
+++ b/docs/user/pyclient.rst
@@ -316,7 +316,7 @@ Here we assume that
 -  the nodes are configured to look at the right database
 
 In this manual, we'll use the averaging algorithm from
-``ghcr.io/vantage6/algorithm-average:latest``, so the second requirement is met.
+``ghcr.io/vantage6/algorithm/average:latest``, so the second requirement is met.
 We'll assume the nodes in your collaboration have been configured to look as
 something like:
 
@@ -396,7 +396,7 @@ us create a task that runs the central part of the
       collaboration=1,
       organizations=[2],
       name="an-awesome-task",
-      image="ghcr.io/vantage6/algorithm-average:latest",
+      image="ghcr.io/vantage6/algorithm/average:latest",
       description='',
       input_=input_,
       databases=[
@@ -449,7 +449,7 @@ central part of the algorithm will normally do:
       collaboration=1,
       organizations=[2,3],
       name="an-awesome-task",
-      image="ghcr.io/vantage6/algorithm-average:latest",
+      image="ghcr.io/vantage6/algorithm/average:latest",
       description='',
       input_=input_
    )

--- a/tools/update-discord.py
+++ b/tools/update-discord.py
@@ -110,7 +110,6 @@ class PostUpdates(commands.Cog):
         )
 
         links = (
-            "[Github Container Registry](https://ghcr.io/vantage6)\n"
             "[Project website](https://vantage6.ai)\n"
             "[Build status](https://github.com/vantage6/vantage6/actions)"
         )
@@ -137,7 +136,7 @@ class PostUpdates(commands.Cog):
         embed.add_field(
             name="Docker Images",
             value=(
-                f"ghcr.io/vantage6/node:{version} \n ghcr.io/vantage6/server:{version}"
+                f"ghcr.io/vantage6/infrastructure/node:{version} \n ghcr.io/vantage6/infrastructure/server:{version}"
             ),
             inline=False,
         )

--- a/vantage6-common/tests/vantage6/common/docker/test_addons.py
+++ b/vantage6-common/tests/vantage6/common/docker/test_addons.py
@@ -113,37 +113,37 @@ class TestParseImageName(TestCase):
 
     def test_parse_image_name_ghcr_average(self):
         self.assertEqual(
-            parse_image_name("ghcr.io/vantage6/algorithm-average:latest"),
-            ("ghcr.io", "vantage6/algorithm-average", "latest"),
+            parse_image_name("ghcr.io/vantage6/algorithm/average:latest"),
+            ("ghcr.io", "vantage6/algorithm/average", "latest"),
         )
 
     def test_parse_image_name_ghcr_average_tag_latest(self):
         self.assertEqual(
-            parse_image_name("ghcr.io/vantage6/algorithm-average:latest"),
-            ("ghcr.io", "vantage6/algorithm-average", "latest"),
+            parse_image_name("ghcr.io/vantage6/algorithm/average:latest"),
+            ("ghcr.io", "vantage6/algorithm/average", "latest"),
         )
 
     def test_parse_image_name_ghcr_average_tag_4(self):
         self.assertEqual(
-            parse_image_name("ghcr.io/vantage6/algorithm-average:4"),
-            ("ghcr.io", "vantage6/algorithm-average", "4"),
+            parse_image_name("ghcr.io/vantage6/algorithm/average:4"),
+            ("ghcr.io", "vantage6/algorithm/average", "4"),
         )
 
     def test_parse_image_name_with_sha(self):
         self.assertEqual(
-            parse_image_name("ghcr.io/vantage6/algorithm-average@sha256:1234"),
-            ("ghcr.io", "vantage6/algorithm-average", "sha256:1234"),
+            parse_image_name("ghcr.io/vantage6/algorithm/average@sha256:1234"),
+            ("ghcr.io", "vantage6/algorithm/average", "sha256:1234"),
         )
 
     def test_parse_image_name_with_sha_and_tag(self):
         self.assertEqual(
             parse_image_name(
-                "ghcr.io/vantage6/node:4.5@sha256:1234567890abcdef"
+                "ghcr.io/vantage6/infrastructure/node:4.5@sha256:1234567890abcdef"
                 "1234567890abcdef1234567890abcdef1234567890abcdef"
             ),
             (
                 "ghcr.io",
-                "vantage6/node",
+                "vantage6/infrastructure/node",
                 "4.5",
             ),
         )

--- a/vantage6-common/vantage6/common/docker/addons.py
+++ b/vantage6-common/vantage6/common/docker/addons.py
@@ -319,7 +319,7 @@ def parse_image_name(image: str) -> tuple[str, str, str]:
     Parameters
     ----------
     image: str
-        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest" or
+        Image name. E.g. "ghcr.io/vantage6/algorithm/average:latest" or
         "library/hello-world"
 
     Returns
@@ -349,12 +349,12 @@ def get_image_name_wo_tag(image: str) -> str:
     Parameters
     ----------
     image: str
-        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm/average:latest"
 
     Returns
     -------
     str
-        Image name without tag. E.g. "ghcr.io/vantage6/algorithm-average"
+        Image name without tag. E.g. "ghcr.io/vantage6/algorithm/average"
     """
     registry, repository, _ = parse_image_name(image)
     if registry == "docker.io":
@@ -377,7 +377,7 @@ def _get_manifest(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm/average:latest"
     registry_user: str | None
         Docker username to authenticate with at the registry. Required if the image is
         private
@@ -469,7 +469,7 @@ def _get_digest_via_docker(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm/average:latest"
     client: DockerClient
         Docker client.
     docker_username: str | None
@@ -516,7 +516,7 @@ def _get_digest_via_manifest(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm/average:latest"
     docker_username: str | None
         Docker username to authenticate with at the registry. Required if the image is
         private
@@ -553,7 +553,7 @@ def get_digest(
     Parameters
     ----------
     full_image: str
-        Image name. E.g. "ghcr.io/vantage6/algorithm-average:latest"
+        Image name. E.g. "ghcr.io/vantage6/algorithm/average:latest"
     client: DockerClient | None
         Docker client to use. If not provided, a new client will be created. An existing
         client could be useful to provide if it has already been authenticated with one

--- a/vantage6-node/vantage6/node/globals.py
+++ b/vantage6-node/vantage6/node/globals.py
@@ -30,9 +30,9 @@ TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET = 60
 #    VPN CONFIGURATION RELATED CONSTANTS
 #
 # TODO move part of these constants elsewhere?! Or make context?
-VPN_CLIENT_IMAGE = "ghcr.io/vantage6/vpn-client"
-NETWORK_CONFIG_IMAGE = "ghcr.io/vantage6/vpn-configurator"
-ALPINE_IMAGE = "ghcr.io/vantage6/alpine"
+VPN_CLIENT_IMAGE = "ghcr.io/vantage6/infrastructure/vpn-client"
+NETWORK_CONFIG_IMAGE = "ghcr.io/vantage6/infrastructure/vpn-configurator"
+ALPINE_IMAGE = "ghcr.io/vantage6/infrastructure/alpine"
 MAX_CHECK_VPN_ATTEMPTS = 60  # max attempts to obtain VPN IP (1 second apart)
 FREE_PORT_RANGE = range(49152, 65535)
 DEFAULT_ALGO_VPN_PORT = "8888"  # default VPN port for algorithm container
@@ -40,12 +40,12 @@ DEFAULT_ALGO_VPN_PORT = "8888"  # default VPN port for algorithm container
 #
 #   SSH TUNNEL RELATED CONSTANTS
 #
-SSH_TUNNEL_IMAGE = "ghcr.io/vantage6/ssh-tunnel"
+SSH_TUNNEL_IMAGE = "ghcr.io/vantage6/infrastructure/ssh-tunnel"
 
 #
 #   SQUID RELATED CONSTANTS
 #
-SQUID_IMAGE = "ghcr.io/vantage6/squid"
+SQUID_IMAGE = "ghcr.io/vantage6/infrastructure/squid"
 
 # Environment variables that should be set in the Dockerfile and that may not
 # be overwritten by the user.

--- a/vantage6-ui/README.md
+++ b/vantage6-ui/README.md
@@ -59,11 +59,11 @@ Angular production servers can be deployed in many ways. Angular's
 [deployment documentation](https://angular.io/guide/deployment) offers a number
 of options.
 
-Alternatively, we provide the Docker image `ghcr.io/vantage6/ui`
+Alternatively, we provide the Docker image `ghcr.io/vantage6/infrastructure/ui`
 to help you deploy your own UI. In that case, run
 
 ```
-docker run --env SERVER_URL="<your_url>" --env API_PATH="<your_path>" -p 8080:80 ghcr.io/vantage6/ui:latest
+docker run --env SERVER_URL="<your_url>" --env API_PATH="<your_path>" -p 8080:80 ghcr.io/vantage6/infrastructure/ui:latest
 ```
 
 to run a UI on port 8080 that communicates with your own server. For instance,

--- a/vantage6-ui/src/app/pages/analyze/template-task/create/mock.ts
+++ b/vantage6-ui/src/app/pages/analyze/template-task/create/mock.ts
@@ -1,6 +1,6 @@
 export const mockDataQualityTemplateTask = {
   name: 'Quality check',
-  image: 'ghcr.io/vantage6/algorithm-starter-utils:latest',
+  image: 'ghcr.io/vantage6/algorithm/starter-utils:latest',
   function: 'fetch_static_file',
   collaboration: 2,
   fixed: { name: 'Quality check', databases: [] },
@@ -18,7 +18,7 @@ export const mockDataQualityTemplateTask = {
 
 export const mockDataCrossTabTemplateTask = {
   name: 'Cross tabulation',
-  image: 'ghcr.io/vantage6/algorithm-starter-crosstab:latest',
+  image: 'ghcr.io/vantage6/algorithm/starter-crosstab:latest',
   function: 'dct',
   collaboration: 2,
   fixed: {

--- a/vantage6/vantage6/cli/configuration_wizard.py
+++ b/vantage6/vantage6/cli/configuration_wizard.py
@@ -221,14 +221,14 @@ def _get_allowed_algorithms() -> list[str]:
     )
     info("Examples:")
     info(
-        r"^ghcr\.io/vantage6/algorithm-average:latest$    Allow the demo average algorithm"
+        r"^ghcr\.io/vantage6/algorithm/average:latest$    Allow the demo average algorithm"
     )
     info(
-        r"^ghcr\.io/vantage6/algorithm-*.   Allow all algorithms from "
-        "ghcr.io/vantage6"
+        r"^ghcr\.io/vantage6/algorithm/*.   Allow all algorithms from "
+        "ghcr.io/vantage6/algorithm/"
     )
     info(
-        r"^ghcr\.io/vantage6/algorithm-average@sha256:82becede...$    Allow a "
+        r"^ghcr\.io/vantage6/algorithm/average@sha256:82becede...$    Allow a "
         "specific hash of average algorithm"
     )
     allowed_algorithms = []

--- a/vantage6/vantage6/cli/globals.py
+++ b/vantage6/vantage6/cli/globals.py
@@ -37,7 +37,7 @@ RABBIT_TIMEOUT = 300
 ALGORITHM_TEMPLATE_REPO = "gh:vantage6/v6-algorithm-template.git"
 
 # image to use for diagnostics in `v6 test` commands
-DIAGNOSTICS_IMAGE = "ghcr.io/vantage6/algorithm-diagnostic:latest"
+DIAGNOSTICS_IMAGE = "ghcr.io/vantage6/algorithm/diagnostic:latest"
 
 # Address of community algorithm store
 COMMUNITY_STORE = "https://store.cotopaxi.vantage6.ai/api"

--- a/vantage6/vantage6/cli/rabbitmq/queue_manager.py
+++ b/vantage6/vantage6/cli/rabbitmq/queue_manager.py
@@ -17,7 +17,7 @@ from vantage6.cli.context.server import ServerContext
 from vantage6.cli.rabbitmq.definitions import RABBITMQ_DEFINITIONS
 from vantage6.cli.globals import RABBIT_TIMEOUT
 
-DEFAULT_RABBIT_IMAGE = "ghcr.io/vantage6/rabbitmq"
+DEFAULT_RABBIT_IMAGE = "ghcr.io/vantage6/infrastructure/rabbitmq"
 RABBIT_CONFIG = "rabbitmq.config"
 RABBIT_DIR = "rabbitmq"
 
@@ -34,7 +34,7 @@ class RabbitMQManager:
         Network manager for network in which server container resides
     image: str
         Docker image to use for RabbitMQ container. By default, the image
-        ghcr.io/vantage6/rabbitmq is used.
+        ghcr.io/vantage6/infrastructure/rabbitmq is used.
     """
 
     def __init__(
@@ -161,8 +161,7 @@ class RabbitMQManager:
                 "bind": "/etc/rabbitmq/definitions.json",
                 "mode": "ro",
             },
-            self.ctx.data_dir
-            / RABBIT_CONFIG: {
+            self.ctx.data_dir / RABBIT_CONFIG: {
                 "bind": "/etc/rabbitmq/rabbitmq.config",
                 "mode": "ro",
             },

--- a/vantage6/vantage6/cli/rabbitmq/queue_manager.py
+++ b/vantage6/vantage6/cli/rabbitmq/queue_manager.py
@@ -161,7 +161,8 @@ class RabbitMQManager:
                 "bind": "/etc/rabbitmq/definitions.json",
                 "mode": "ro",
             },
-            self.ctx.data_dir / RABBIT_CONFIG: {
+            self.ctx.data_dir
+            / RABBIT_CONFIG: {
                 "bind": "/etc/rabbitmq/rabbitmq.config",
                 "mode": "ro",
             },

--- a/vantage6/vantage6/cli/test/algo_test_scripts/algo_test_arguments.py
+++ b/vantage6/vantage6/cli/test/algo_test_scripts/algo_test_arguments.py
@@ -2,7 +2,7 @@ average = {
     "collaboration": 1,
     "organizations": [1],
     "name": "test_average_task",
-    "image": "ghcr.io/vantage6/algorithm-average:latest",
+    "image": "ghcr.io/vantage6/algorithm/average:latest",
     "description": "",
     "input_": {
         "method": "central_average",
@@ -16,7 +16,7 @@ kaplan_meier = {
     "collaboration": 1,
     "organizations": [1],
     "name": "test_average_task",
-    "image": "ghcr.io/vantage6/algorithm-kaplan-meier:latest",
+    "image": "ghcr.io/vantage6/algorithm/kaplan-meier:latest",
     "description": "",
     "input_": {
         "method": "kaplan_meier_central",


### PR DESCRIPTION
Undoes some of the changes in #2591 as keeping the 'project' part of the image is deemed useful to easily separate algorithms from infrastructure images etc