### PR TITLE
Change/prevent doubles config list wsl

### DIFF
--- a/vantage6-common/vantage6/common/context.py
+++ b/vantage6-common/vantage6/common/context.py
@@ -353,7 +353,7 @@ class AppContext(metaclass=Singleton):
             return {
                 "log": mount_path / "log",
                 "data": mount_path / "data",
-                "config": mount_path / "config",
+                "config": mount_path / "config" / instance_type,
                 "dev": mount_path / "dev",
             }
         elif system_folders:

--- a/vantage6/tests_cli/test_node_cli.py
+++ b/vantage6/tests_cli/test_node_cli.py
@@ -25,9 +25,12 @@ class NodeCLITest(unittest.TestCase):
     def setUpClass(cls):
         return super().setUpClass()
 
+    @patch("vantage6.cli.common.list.running_in_wsl", return_value=False)
     @patch("vantage6.cli.context.node.NodeContext.available_configurations")
     @patch("vantage6.cli.common.list.find_running_service_names")
-    def test_list(self, find_running_service_names, available_configurations):
+    def test_list(
+        self, find_running_service_names, available_configurations, _running_in_wsl
+    ):
         """A container list and their current status."""
         # https://docs.python.org/3/library/unittest.mock.html#mock-names-and-the-name-attribute
 

--- a/vantage6/vantage6/cli/common/list.py
+++ b/vantage6/vantage6/cli/common/list.py
@@ -2,11 +2,13 @@ import click
 from colorama import Fore, Style
 
 from vantage6.common import warning
+from vantage6.common.context import AppContext
 from vantage6.common.globals import (
     APPNAME,
     SANDBOX_SUFFIX,
     InstanceType,
 )
+from vantage6.common.kubernetes.utils import running_in_wsl
 
 from vantage6.cli.common.utils import find_running_service_names
 from vantage6.cli.context import select_context_class
@@ -29,40 +31,59 @@ def get_configuration_list(instance_type: InstanceType) -> None:
     click.echo(header)
     click.echo("-" * len(header))
 
+    # system folders
+    if running_in_wsl():
+        # for WSL, there is no distinction between user and system folders, so we
+        # only print the user folders
+        failed_imports = _print_configs(
+            ctx_class=ctx_class,
+            system_folders=False,
+            running_service_names=running_service_names,
+            instance_type=instance_type,
+        )
+    else:
+        failed_imports_system = _print_configs(
+            ctx_class=ctx_class,
+            system_folders=True,
+            running_service_names=running_service_names,
+            instance_type=instance_type,
+        )
+        failed_imports_user = _print_configs(
+            ctx_class=ctx_class,
+            system_folders=False,
+            running_service_names=running_service_names,
+            instance_type=instance_type,
+        )
+        failed_imports = failed_imports_system + failed_imports_user
+    if failed_imports:
+        warning(f"{Fore.RED}Failed imports: {len(failed_imports)}{Style.RESET_ALL}")
+
+
+def _print_configs(
+    ctx_class: AppContext,
+    system_folders: bool,
+    running_service_names: list[str],
+    instance_type: InstanceType,
+) -> int:
+
     running = Fore.GREEN + "Running" + Style.RESET_ALL
     stopped = Fore.RED + "Not running" + Style.RESET_ALL
 
-    # system folders
-    configs, failed_imports_system = ctx_class.available_configurations(
-        system_folders=True
+    configs, failed_imports = ctx_class.available_configurations(
+        system_folders=system_folders
     )
+
+    system_or_user = "System" if system_folders else "User  "
+    system_or_user_lower = "system" if system_folders else "user"
+
     for config in configs:
         config.name = config.name.replace(SANDBOX_SUFFIX, "")
         status = (
             running
-            if f"{APPNAME}-{config.name}-system-{instance_type.value}"
+            if f"{APPNAME}-{config.name}-{system_or_user_lower}-{instance_type.value}"
             in running_service_names
             else stopped
         )
-        click.echo(f"{config.name:25}{status:25}System ")
+        click.echo(f"{config.name:25}{status:25}{system_or_user} ")
 
-    # user folders
-    configs, failed_imports_user = ctx_class.available_configurations(
-        system_folders=False
-    )
-    for config in configs:
-        config.name = config.name.replace(SANDBOX_SUFFIX, "")
-        status = (
-            running
-            if f"{APPNAME}-{config.name}-user-{instance_type.value}"
-            in running_service_names
-            else stopped
-        )
-        click.echo(f"{config.name:25}{status:25}User   ")
-
-    click.echo("-" * len(header))
-    if len(failed_imports_system) + len(failed_imports_user):
-        warning(
-            f"{Fore.RED}Failed imports: "
-            f"{len(failed_imports_system) + len(failed_imports_user)}{Style.RESET_ALL}"
-        )
+    return failed_imports

--- a/vantage6/vantage6/cli/common/list.py
+++ b/vantage6/vantage6/cli/common/list.py
@@ -55,6 +55,8 @@ def get_configuration_list(instance_type: InstanceType) -> None:
             instance_type=instance_type,
         )
         failed_imports = failed_imports_system + failed_imports_user
+
+    click.echo("-" * len(header))
     if failed_imports:
         warning(f"{Fore.RED}Failed imports: {len(failed_imports)}{Style.RESET_ALL}")
 

--- a/vantage6/vantage6/cli/context/__init__.py
+++ b/vantage6/vantage6/cli/context/__init__.py
@@ -23,7 +23,7 @@ from vantage6.cli.context.node import NodeContext
 
 def select_context_class(
     type_: InstanceType,
-) -> HQContext | NodeContext | AlgorithmStoreContext | AuthContext:
+) -> HQContext | NodeContext | AlgorithmStoreContext | AuthContext | HubContext:
     """
     Select the context class based on the type of instance.
 

--- a/vantage6/vantage6/cli/hub/list.py
+++ b/vantage6/vantage6/cli/hub/list.py
@@ -8,6 +8,6 @@ from vantage6.cli.common.list import get_configuration_list
 @click.command()
 def cli_hub_configuration_list() -> None:
     """
-    Print the available algorithm store configurations.
+    Print the available hub configurations.
     """
     get_configuration_list(InstanceType.HUB)


### PR DESCRIPTION
`v6 hub/node/... list` commands in v5 showed duplicates if run from within WSL. Also, `v6 hub list` showed also nodes and vice versa. This PR addresses both those issues