### PR TITLE
Algorithm tools were accidentally dependent on the node, which should…

### DIFF
--- a/vantage6-algorithm-tools/vantage6/algorithm/mock/client.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/mock/client.py
@@ -3,13 +3,13 @@ import traceback
 from typing import TYPE_CHECKING, Any
 
 from vantage6.algorithm.tools.exceptions import (
+    DataFrameNotFound,
     MethodNotFoundError,
     SessionActionMismatchError,
 )
 from vantage6.algorithm.tools.util import error, warn
 
 from vantage6.algorithm.mock.globals import MockDatabase
-from vantage6.node.k8s.exceptions import DataFrameNotFound
 
 if TYPE_CHECKING:
     from vantage6.algorithm.mock.network import MockNetwork

--- a/vantage6-algorithm-tools/vantage6/algorithm/mock/node.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/mock/node.py
@@ -9,6 +9,7 @@ from vantage6.common.globals import ContainerEnvNames
 
 from vantage6.algorithm.tools.exceptions import (
     AlgorithmModuleNotFoundError,
+    DataFrameNotFound,
     MethodNotFoundError,
     SessionActionMismatchError,
 )
@@ -16,7 +17,6 @@ from vantage6.algorithm.tools.exceptions import (
 from vantage6.algorithm.mock.client import MockAlgorithmClient
 from vantage6.algorithm.mock.globals import MockDatabase
 from vantage6.algorithm.mock.util import env_vars
-from vantage6.node.k8s.exceptions import DataFrameNotFound
 
 if TYPE_CHECKING:
     from vantage6.algorithm.mock.network import MockNetwork

--- a/vantage6-algorithm-tools/vantage6/algorithm/tools/exceptions.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/tools/exceptions.py
@@ -170,3 +170,12 @@ class SessionActionMismatchError(AlgorithmError):
     - The function is e.g. a data extraction function but the user requests to start
       a preprocessing task using that function.
     """
+
+
+class DataFrameNotFound(AlgorithmError):
+    """
+    Raised when a dataframe is not found.
+
+    Example usage:
+    - The dataframe is not found in the node.
+    """


### PR DESCRIPTION
…n't be the case. This commit removes that, by creating a similar error within the algorithm tools (just like similar use cases in mock network), that may later also be used for real algorithms