### PR TITLE
Fix DetachedInstanceError at socket-emit sites in HQ

### DIFF
--- a/vantage6-hq/tests_hq/resources/test_run.py
+++ b/vantage6-hq/tests_hq/resources/test_run.py
@@ -2,6 +2,9 @@ import datetime
 import logging
 import uuid
 from http import HTTPStatus
+from unittest.mock import patch
+
+from flask_socketio import SocketIO
 
 from vantage6.common import logger_name
 from vantage6.common.enum import AlgorithmStepType, RunStatus
@@ -12,6 +15,7 @@ from vantage6.hq.model import (
     Run,
     Task,
 )
+from vantage6.hq.model.base import DatabaseSessionManager
 
 from .test_resource_base import TestResourceBase
 
@@ -136,3 +140,47 @@ class TestResources(TestResourceBase):
             col.delete()
             org1.delete()
             org2.delete()
+
+    def test_run_patch_survives_session_clear_during_emit(self):
+        """
+        A socket emit yields the greenlet, after which the database session may have
+        been cleared by another handler's cleanup, detaching the run. The endpoint
+        should still be able to serialize its response.
+
+        See https://github.com/vantage6/vantage6/issues/2656.
+        """
+        org = Organization(name=str(uuid.uuid1()))
+        col = Collaboration(name=str(uuid.uuid1()), organizations=[org])
+        col.save()
+        node = self.create_node(organization=org, collaboration=col)
+        task = Task(
+            image="localhost/algorithms/test:local", collaboration=col, init_org=org
+        )
+        task.save()
+        run = Run(task=task, organization=org, status=RunStatus.PENDING.value)
+        run.save()
+
+        try:
+            headers = self.login_node(node)
+
+            # Clear the session on emit, which is what a concurrent handler's
+            # __cleanup() does while the emit has yielded the greenlet.
+            with patch.object(
+                SocketIO,
+                "emit",
+                side_effect=lambda *a, **kw: DatabaseSessionManager.clear_session(),
+            ):
+                response = self.app.patch(
+                    f"/api/run/{run.id}",
+                    headers=headers,
+                    json={"status": RunStatus.COMPLETED.value},
+                )
+
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            self.assertEqual(response.json["status"], RunStatus.COMPLETED.value)
+        finally:
+            run.delete()
+            task.delete()
+            node.delete()
+            col.delete()
+            org.delete()

--- a/vantage6-hq/tests_hq/resources/test_task.py
+++ b/vantage6-hq/tests_hq/resources/test_task.py
@@ -1,6 +1,8 @@
 import logging
 from http import HTTPStatus
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+from flask_socketio import SocketIO
 
 from vantage6.common import logger_name
 from vantage6.common.enum import AlgorithmStepType, RunStatus, TaskStatus
@@ -15,6 +17,7 @@ from vantage6.hq.model import (
     Study,
     Task,
 )
+from vantage6.hq.model.base import DatabaseSessionManager
 from vantage6.hq.model.rule import Operation, Scope
 from vantage6.hq.resource.event import kill_task
 
@@ -744,3 +747,102 @@ class TestResources(TestResourceBase):
         self.assertEqual(child_run_1.status, RunStatus.KILLED.value)
         self.assertEqual(child_run_2.status, RunStatus.KILLED.value)
         self.assertEqual(child_run_done.status, RunStatus.COMPLETED.value)
+
+    def test_kill_task_marks_runs_killed_when_session_cleared_on_emit(self):
+        """
+        The emit yields the greenlet, after which the session may have been cleared.
+        The runs must still end up marked as killed rather than silently staying
+        active while the nodes have already been told to kill them.
+
+        See https://github.com/vantage6/vantage6/issues/2656.
+        """
+        org = Organization(name="kill-session-clear-org")
+        collaboration = Collaboration(
+            name="kill-session-clear-collaboration", organizations=[org]
+        )
+        collaboration.save()
+        task = Task(
+            name="kill-session-clear-task",
+            image="some-image",
+            collaboration=collaboration,
+            job_id=90002,
+        )
+        task.save()
+        run = Run(organization=org, task=task, status=RunStatus.ACTIVE.value)
+        run.save()
+
+        # Hold on to the ids: clearing the session below detaches these objects.
+        run_id = run.id
+        task_id = task.id
+        collaboration_id = collaboration.id
+        org_id = org.id
+
+        try:
+            socket = MagicMock()
+            socket.emit.side_effect = lambda *a, **kw: (
+                DatabaseSessionManager.clear_session()
+            )
+
+            # kill_task is called from a Flask endpoint, so run it in a request
+            # context: that is also what makes the cleared session the request-scoped
+            # one rather than the session shared by the rest of the test suite.
+            with self.server.app.test_request_context():
+                DatabaseSessionManager.get_session()
+                kill_task(Task.get(task_id), socket)
+
+            self.assertEqual(Run.get(run_id).status, RunStatus.KILLED.value)
+        finally:
+            Run.get(run_id).delete()
+            Task.get(task_id).delete()
+            Collaboration.get(collaboration_id).delete()
+            Organization.get(org_id).delete()
+
+    def test_task_post_survives_session_clear_during_emit(self):
+        """
+        The new-task emit yields the greenlet, after which the session may have been
+        cleared and the task detached before it is serialized into the response.
+
+        See https://github.com/vantage6/vantage6/issues/2656.
+        """
+        org = Organization()
+        org.save()
+        col = Collaboration(organizations=[org], encrypted=False)
+        col.save()
+        node = Node(organization=org, collaboration=col)
+        node.save()
+
+        rule_create = Rule.get_by_("task", Scope.COLLABORATION, Operation.CREATE)
+        user = self.create_user(organization=org, rules=[rule_create])
+        session = Session(
+            name="session-clear-session", user_id=user.id, collaboration=col
+        )
+        session.save()
+
+        try:
+            headers = self.login(user)
+            task_json = {
+                "method": "dummy",
+                "image": "some-image",
+                "action": AlgorithmStepType.FEDERATED_COMPUTE.value,
+                "organizations": [{"id": org.id}],
+                "collaboration_id": col.id,
+                "session_id": session.id,
+            }
+
+            with patch.object(
+                SocketIO,
+                "emit",
+                side_effect=lambda *a, **kw: DatabaseSessionManager.clear_session(),
+            ):
+                results = self.app.post("/api/task", headers=headers, json=task_json)
+
+            self.assertEqual(results.status_code, HTTPStatus.CREATED)
+            self.assertEqual(results.json["image"], "some-image")
+        finally:
+            for created_task in Task.get():
+                if created_task.collaboration_id == col.id:
+                    created_task.delete()
+            session.delete()
+            node.delete()
+            col.delete()
+            org.delete()

--- a/vantage6-hq/tests_hq/resources/test_websockets.py
+++ b/vantage6-hq/tests_hq/resources/test_websockets.py
@@ -1,0 +1,62 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+from vantage6.common import logger_name
+
+from vantage6.hq.websockets import DefaultSocketNamespace
+
+from .test_resource_base import TestResourceBase
+
+logger = logger_name(__name__)
+log = logging.getLogger(logger)
+
+
+class TestSocketNamespaceCleanup(TestResourceBase):
+    """
+    Socket handlers must always release their database session, including when the
+    handler body raises. A leaked session keeps a connection checked out for the
+    lifetime of the greenlet.
+
+    See https://github.com/vantage6/vantage6/issues/2656.
+    """
+
+    # Handlers that clean up their own session, with an argument set to call them by.
+    HANDLERS_WITH_ARGS = {
+        "on_algorithm_status_change": ({"run_id": 1},),
+        "on_algorithm_log": ({"run_id": 1, "log": "boom"},),
+        "on_node_info_update": ({"some_key": "some_value"},),
+        "on_node_metrics_update": ({"cpu": 1},),
+        "on_dataframe_deleted": ({"df_name": "df", "session_id": 1, "node_id": 1},),
+        "on_ping": (),
+    }
+
+    def setUp(self):
+        super().setUp()
+        self.namespace = DefaultSocketNamespace("/tasks", MagicMock(), MagicMock())
+
+    def test_cleanup_runs_when_handler_raises(self):
+        for handler_name, args in self.HANDLERS_WITH_ARGS.items():
+            with self.subTest(handler=handler_name):
+                # `session` is a werkzeug LocalProxy, so it must be replaced with
+                # `new=` rather than autospecced - patch() would try to resolve the
+                # proxy, which fails outside a request context.
+                with (
+                    patch(
+                        "vantage6.hq.websockets.DatabaseSessionManager"
+                    ) as mock_session_manager,
+                    patch.object(DefaultSocketNamespace, "_is_node", return_value=True),
+                    patch("vantage6.hq.websockets.db") as mock_db,
+                    patch("vantage6.hq.websockets.session", new=MagicMock()),
+                ):
+                    # Make the handler body blow up part-way through.
+                    mock_db.Run.get.side_effect = RuntimeError("boom")
+                    mock_db.Node.get_by_keycloak_id.side_effect = RuntimeError("boom")
+                    mock_db.Authenticatable.get_by_keycloak_id.side_effect = (
+                        RuntimeError("boom")
+                    )
+
+                    handler = getattr(self.namespace, handler_name)
+                    with self.assertRaises(Exception):
+                        handler(*args)
+
+                    mock_session_manager.clear_session.assert_called_once()

--- a/vantage6-hq/vantage6/hq/resource/common/task_post_base.py
+++ b/vantage6-hq/vantage6/hq/resource/common/task_post_base.py
@@ -151,10 +151,14 @@ class TaskPostBase(ServicesResources):
         self._create_task_databases(task, data.get("databases", [[]]))
         self._create_runs(task, organizations_json_list, action)
 
-        # alerting and logging
-        self._notify_nodes_of_new_task(task)
+        # alerting and logging. Log before emitting: the emit yields the greenlet,
+        # after which the session may have been cleared and `task` detached.
         self._new_task_logging(task)
+        task_id = task.id
+        self._notify_nodes_of_new_task(task)
 
+        # Re-attach the task before serializing it, in case the emit detached it.
+        task = db.Task.get(task_id)
         return task_schema.dump(task, many=False), HTTPStatus.CREATED
 
     def _validate_request_body(self, data: dict) -> dict:

--- a/vantage6-hq/vantage6/hq/resource/event.py
+++ b/vantage6-hq/vantage6/hq/resource/event.py
@@ -278,15 +278,20 @@ class KillNodeTasks(ServicesResources):
                     "msg": "You lack the permission to do that!"
                 }, HTTPStatus.UNAUTHORIZED
 
+        # Read the node's attributes before emitting: the emit yields the greenlet,
+        # after which the session may have been cleared and `node` detached.
+        node_id = node.id
+        collaboration_id = node.collaboration_id
+
         self.socketio.emit(
             "kill_containers",
-            {"node_id": node.id, "collaboration_id": node.collaboration_id},
+            {"node_id": node_id, "collaboration_id": collaboration_id},
             namespace="/tasks",
-            room=f"collaboration_{node.collaboration_id}",
+            room=f"collaboration_{collaboration_id}",
         )
 
         return {
-            "msg": f"Node {node.id} has been instructed to kill all containers"
+            "msg": f"Node {node_id} has been instructed to kill all containers"
             " running on it."
         }, HTTPStatus.OK
 
@@ -313,14 +318,7 @@ def kill_task(task: db.Task, socket: SocketIO) -> None:
         for run in task_to_kill.runs
         if not RunStatus.has_finished(run.status)
     ]
-
-    # emit socket event to the node to execute the container kills
-    socket.emit(
-        "kill_containers",
-        {"kill_list": kill_list, "collaboration_id": task.collaboration.id},
-        namespace="/tasks",
-        room=f"collaboration_{task.collaboration_id}",
-    )
+    collaboration_id = task.collaboration.id
 
     # set tasks and subtasks status to killed
     def set_killed(task: db.Task):
@@ -331,6 +329,16 @@ def kill_task(task: db.Task, socket: SocketIO) -> None:
             run.finished_at = dt.datetime.now(dt.timezone.utc)
             run.save()
 
-    set_killed(task)
-    for subtask in task.children:
-        set_killed(subtask)
+    # Update the runs before emitting: the emit yields the greenlet, after which the
+    # session may have been cleared and these runs detached - leaving them silently
+    # unkilled in the database while the nodes have already been told to kill them.
+    for task_to_kill in tasks_to_kill:
+        set_killed(task_to_kill)
+
+    # emit socket event to the node to execute the container kills
+    socket.emit(
+        "kill_containers",
+        {"kill_list": kill_list, "collaboration_id": collaboration_id},
+        namespace="/tasks",
+        room=f"collaboration_{collaboration_id}",
+    )

--- a/vantage6-hq/vantage6/hq/resource/run.py
+++ b/vantage6-hq/vantage6/hq/resource/run.py
@@ -752,31 +752,40 @@ class Run(SingleRunBase):
                     dependent_run.finished_at = run.finished_at
                     dependent_run.save()
 
+        # Read everything we need off the ORM objects while the session is
+        # guaranteed to be alive. `socketio.emit` yields the greenlet, after which
+        # the session may have been cleared and `run` detached.
+        collaboration_id = run.task.collaboration.id
+        status_change_data = {
+            "run_id": run.id,
+            "status": run.status,
+            "task_id": run.task.id,
+            "job_id": run.task.job_id,
+            "collaboration_id": collaboration_id,
+            "node_id": run.node.id,
+            "organization_id": run.organization.id,
+            "parent_id": run.task.parent_id,
+        }
+
         # notify collaboration nodes/users that the task has an update
         # TODO refactor it shouldn't be necessary to send two events.
         self.socketio.emit(
             "status_update",
             {"run_id": id},
             namespace="/tasks",
-            room=f"collaboration_{run.task.collaboration.id}",
+            room=f"collaboration_{collaboration_id}",
         )
 
         self.socketio.emit(
             "algorithm_status_change",
-            {
-                "run_id": run.id,
-                "status": run.status,
-                "task_id": run.task.id,
-                "job_id": run.task.job_id,
-                "collaboration_id": run.task.collaboration.id,
-                "node_id": run.node.id,
-                "organization_id": run.organization.id,
-                "parent_id": run.task.parent_id,
-            },
+            status_change_data,
             namespace="/tasks",
-            room=f"collaboration_{run.task.collaboration.id}",
+            room=f"collaboration_{collaboration_id}",
         )
 
+        # Re-attach the run before serializing it: the save() above expired it, so
+        # the dump would hit the database anyway, and the emits may have detached it.
+        run = db_Run.get(id)
         return run_schema.dump(run, many=False), HTTPStatus.OK
 
     def _add_dependent_tasks(self, dependent_tasks: list[db.Task]) -> list[db.Task]:

--- a/vantage6-hq/vantage6/hq/websockets.py
+++ b/vantage6-hq/vantage6/hq/websockets.py
@@ -93,29 +93,30 @@ class DefaultSocketNamespace(Namespace):
             self.log.exception(exc)
             return
 
-        # get identity from token.
-        session.auth_id = get_jwt_identity()
-        auth = db.Authenticatable.get_by_keycloak_id(session.auth_id)
-        auth.status = AuthStatus.ONLINE.value
-        auth.save()
+        try:
+            # get identity from token.
+            session.auth_id = get_jwt_identity()
+            auth = db.Authenticatable.get_by_keycloak_id(session.auth_id)
+            auth.status = AuthStatus.ONLINE.value
+            auth.save()
 
-        # define socket-session variables.
-        session.type = auth.type
-        session.name = auth.username if session.type == "user" else auth.name
-        self.log.info("Client identified as <%s>: <%s>", session.type, session.name)
+            # define socket-session variables.
+            session.type = auth.type
+            session.name = auth.username if session.type == "user" else auth.name
+            self.log.info("Client identified as <%s>: <%s>", session.type, session.name)
 
-        # join appropiate rooms
-        session.rooms = []
-        if session.type == "node":
-            self._handle_node_connection(auth)
-        elif session.type == "user":
-            self._add_user_to_rooms(auth)
+            # join appropiate rooms
+            session.rooms = []
+            if session.type == "node":
+                self._handle_node_connection(auth)
+            elif session.type == "user":
+                self._add_user_to_rooms(auth)
 
-        for room in session.rooms:
-            self.__join_room_and_notify(room)
-
-        # cleanup (e.g. database session)
-        self.__cleanup()
+            for room in session.rooms:
+                self.__join_room_and_notify(room)
+        finally:
+            # cleanup (e.g. database session)
+            self.__cleanup()
 
     def _handle_node_connection(self, node: Authenticatable) -> None:
         """
@@ -127,6 +128,16 @@ class DefaultSocketNamespace(Namespace):
         node: Authenticatable
             Node that is to be connected
         """
+        # Read the node's attributes before emitting: the emits below yield the
+        # greenlet, after which the session may have been cleared and `node` detached.
+        node_id = node.id
+        node_name = node.name
+        org_id = node.organization.id
+        collaboration_id = node.collaboration_id
+
+        # Add node to rooms before emitting, as the emits rely on `session.rooms`
+        self._add_node_to_rooms(node)
+
         # It appears to be necessary to use the root socketio instance
         # otherwise events cannot be sent outside the current namespace.
         # In this case, only events to '/tasks' can be emitted otherwise.
@@ -135,12 +146,13 @@ class DefaultSocketNamespace(Namespace):
         # Ensure that node syncs on initial connection
         emit("sync", room=request.sid)
 
-        # Add node to rooms and alert other clients of that
-        self._add_node_to_rooms(node)
-        self.__alert_node_status(online=True, node=node)
+        # Alert other clients that the node came online
+        self.__alert_node_status(
+            online=True, node_id=node_id, node_name=node_name, org_id=org_id
+        )
 
         # send dataframe deletion instructions to node
-        self._send_dataframe_deletion_instructions(node)
+        self._send_dataframe_deletion_instructions(node_id, collaboration_id)
 
     @staticmethod
     def _add_node_to_rooms(node: Authenticatable) -> None:
@@ -189,16 +201,28 @@ class DefaultSocketNamespace(Namespace):
                     f"collaboration_{collab.id}_organization_{user.organization.id}"
                 )
 
-    def _send_dataframe_deletion_instructions(self, node: Authenticatable) -> None:
+    def _send_dataframe_deletion_instructions(
+        self, node_id: int, collaboration_id: int
+    ) -> None:
         """
         Send dataframe deletion instructions to a node.
+
+        Parameters
+        ----------
+        node_id: int
+            ID of the node that should delete its dataframes
+        collaboration_id: int
+            ID of the collaboration the node belongs to
         """
-        for dataframe_to_delete in DataframeToBeDeletedAtNode.get_by_node_id(node.id):
+        # Read the dataframe attributes before emitting, as each emit yields the
+        # greenlet and may leave the remaining dataframes detached.
+        dataframes_to_delete = [
+            (dataframe.dataframe_name, dataframe.session_id)
+            for dataframe in DataframeToBeDeletedAtNode.get_by_node_id(node_id)
+        ]
+        for dataframe_name, session_id in dataframes_to_delete:
             send_delete_dataframe_event(
-                self.socketio,
-                dataframe_to_delete.dataframe_name,
-                dataframe_to_delete.session_id,
-                node.collaboration_id,
+                self.socketio, dataframe_name, session_id, collaboration_id
             )
 
     def on_disconnect(self) -> None:
@@ -213,29 +237,41 @@ class DefaultSocketNamespace(Namespace):
             self.log.debug("Client disconnected before identification")
             return
 
-        for room in session.rooms:
-            # self.__leave_room_and_notify(room)
-            self.__leave_room_and_notify(room)
+        try:
+            for room in session.rooms:
+                # self.__leave_room_and_notify(room)
+                self.__leave_room_and_notify(room)
 
-        auth = db.Authenticatable.get_by_keycloak_id(session.auth_id)
-        auth.status = AuthStatus.OFFLINE.value
-        auth.save()
+            auth = db.Authenticatable.get_by_keycloak_id(session.auth_id)
+            auth.status = AuthStatus.OFFLINE.value
+            auth.save()
 
-        # It appears to be necessary to use the root socketio instance
-        # otherwise events cannot be sent outside the current namespace.
-        # In this case, only events to '/tasks' can be emitted otherwise.
-        if session.type == "node":
-            self.log.warning("emitting to /admin")
-            self.socketio.emit("node-status-changed", namespace="/admin")
-            self.__alert_node_status(online=False, node=auth)
+            # It appears to be necessary to use the root socketio instance
+            # otherwise events cannot be sent outside the current namespace.
+            # In this case, only events to '/tasks' can be emitted otherwise.
+            if session.type == "node":
+                # Read the node's attributes before emitting: the emits below yield
+                # the greenlet, after which `auth` may have been detached.
+                node_id = auth.id
+                node_name = auth.name
+                org_id = auth.organization.id
 
-            # delete any data on the node stored on HQ (e.g. configuration data)
-            self.__clean_node_data(auth)
+                self.log.warning("emitting to /admin")
+                self.socketio.emit("node-status-changed", namespace="/admin")
+                self.__alert_node_status(
+                    online=False, node_id=node_id, node_name=node_name, org_id=org_id
+                )
 
-        self.log.info(f"{session.name} disconnected")
+                # delete any data on the node stored on HQ (e.g. configuration data).
+                # Re-fetch the node, as the emits above may have detached it.
+                node = db.Node.get(node_id)
+                if node:
+                    self.__clean_node_data(node)
 
-        # cleanup (e.g. database session)
-        self.__cleanup()
+            self.log.info(f"{session.name} disconnected")
+        finally:
+            # cleanup (e.g. database session)
+            self.__cleanup()
 
     def on_message(self, message: str) -> None:
         """
@@ -295,51 +331,63 @@ class DefaultSocketNamespace(Namespace):
         organization_id = data.get("organization_id")
         parent_id = data.get("parent_id")
 
-        run: db.Run = db.Run.get(run_id)
-        job_id = run.task.job_id
+        try:
+            run: db.Run = db.Run.get(run_id)
+            job_id = run.task.job_id
 
-        # log event in HQ logs
-        msg = (
-            f"A container for job_id={job_id} and run_id={run_id} "
-            f"in collaboration_id={collaboration_id} on node_id={node_id}"
-        )
-        if RunStatus.has_failed(status):
-            self.log.critical(f"{msg} exited with status={status}.")
-        else:
-            self.log.info(f"{msg} has a new status={status}.")
+            # Read the dependent tasks' attributes before emitting, as each emit
+            # yields the greenlet and may leave the remaining tasks detached.
+            dependent_task_updates = [
+                (task.id, task.parent_id, task.collaboration_id)
+                for task in run.task.required_by
+            ]
 
-        # notify nodes that there is a new task available if there are tasks dependent
-        # on this one
-        dependent_tasks = run.task.required_by
-        if status == RunStatus.COMPLETED and dependent_tasks:
-            self.log.debug(
-                f"{len(dependent_tasks)} dependent tasks ready to be executed"
+            # log event in HQ logs
+            msg = (
+                f"A container for job_id={job_id} and run_id={run_id} "
+                f"in collaboration_id={collaboration_id} on node_id={node_id}"
             )
-            for task in dependent_tasks:
-                emit(
-                    "new_task_update",
-                    {"id": task.id, "parent_id": task.parent_id},
-                    room=f"collaboration_{task.collaboration_id}",
+            if RunStatus.has_failed(status):
+                self.log.critical(f"{msg} exited with status={status}.")
+            else:
+                self.log.info(f"{msg} has a new status={status}.")
+
+            # notify nodes that there is a new task available if there are tasks
+            # dependent on this one
+            if status == RunStatus.COMPLETED and dependent_task_updates:
+                self.log.debug(
+                    f"{len(dependent_task_updates)} dependent tasks ready to be "
+                    "executed"
                 )
+                for (
+                    dependent_id,
+                    parent_task_id,
+                    dependent_collab_id,
+                ) in dependent_task_updates:
+                    emit(
+                        "new_task_update",
+                        {"id": dependent_id, "parent_id": parent_task_id},
+                        room=f"collaboration_{dependent_collab_id}",
+                    )
 
-        # emit task status change to other nodes/users in the collaboration
-        emit(
-            "algorithm_status_change",
-            {
-                "status": status,
-                "run_id": run_id,
-                "task_id": task_id,
-                "job_id": job_id,
-                "collaboration_id": collaboration_id,
-                "node_id": node_id,
-                "organization_id": organization_id,
-                "parent_id": parent_id,
-            },
-            room=f"collaboration_{collaboration_id}",
-        )
-
-        # cleanup (e.g. database session)
-        self.__cleanup()
+            # emit task status change to other nodes/users in the collaboration
+            emit(
+                "algorithm_status_change",
+                {
+                    "status": status,
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "job_id": job_id,
+                    "collaboration_id": collaboration_id,
+                    "node_id": node_id,
+                    "organization_id": organization_id,
+                    "parent_id": parent_id,
+                },
+                room=f"collaboration_{collaboration_id}",
+            )
+        finally:
+            # cleanup (e.g. database session)
+            self.__cleanup()
 
     def on_node_info_update(self, node_config: dict) -> None:
         """
@@ -355,68 +403,77 @@ class DefaultSocketNamespace(Namespace):
         if not self._is_node():
             return
 
-        node = db.Node.get_by_keycloak_id(session.auth_id)
+        try:
+            node = db.Node.get_by_keycloak_id(session.auth_id)
 
-        # delete any old data that may be present (if cleanup on disconnect
-        # failed)
-        self.__clean_node_data(node=node)
+            # delete any old data that may be present (if cleanup on disconnect
+            # failed)
+            self.__clean_node_data(node=node)
 
-        # store (new) node config
-        to_store = []
-        for k, v in node_config.items():
-            # add single item or list of items
-            if isinstance(v, list):
-                to_store.extend(
-                    [db.NodeConfig(node_id=node.id, key=k, value=i) for i in v]
-                )
-            elif isinstance(v, dict):
-                for inner_key, inner_val in v.items():
-                    if isinstance(inner_val, list):
-                        to_store.extend(
-                            [
-                                db.NodeConfig(node_id=node.id, key=inner_key, value=val)
-                                for val in inner_val
-                            ]
-                        )
-                    else:
-                        to_store.append(
-                            db.NodeConfig(
-                                node_id=node.id, key=inner_key, value=inner_val
+            # store (new) node config
+            to_store = []
+            for k, v in node_config.items():
+                # add single item or list of items
+                if isinstance(v, list):
+                    to_store.extend(
+                        [db.NodeConfig(node_id=node.id, key=k, value=i) for i in v]
+                    )
+                elif isinstance(v, dict):
+                    for inner_key, inner_val in v.items():
+                        if isinstance(inner_val, list):
+                            to_store.extend(
+                                [
+                                    db.NodeConfig(
+                                        node_id=node.id, key=inner_key, value=val
+                                    )
+                                    for val in inner_val
+                                ]
                             )
-                        )
-            else:
-                to_store.append(db.NodeConfig(node_id=node.id, key=k, value=v))
+                        else:
+                            to_store.append(
+                                db.NodeConfig(
+                                    node_id=node.id, key=inner_key, value=inner_val
+                                )
+                            )
+                else:
+                    to_store.append(db.NodeConfig(node_id=node.id, key=k, value=v))
 
-        node.config = to_store
-        node.save()
-
-        # cleanup (e.g. database session)
-        self.__cleanup()
+            node.config = to_store
+            node.save()
+        finally:
+            # cleanup (e.g. database session)
+            self.__cleanup()
 
     def on_ping(self) -> None:
         """
         A client sends a ping to HQ, which detects who sent the ping and sets them as
         online.
         """
-        auth = db.Authenticatable.get_by_keycloak_id(session.auth_id)
+        try:
+            auth = db.Authenticatable.get_by_keycloak_id(session.auth_id)
 
-        # There is a bug https://github.com/vantage6/vantage6/issues/2386 where the node
-        # disconnects on the HQ side but the node is still connected to HQ.
-        # This is a last resort to recover the connection. It should be considered to
-        # remove the setting of the `status` field in this method when the bug is fixed.
-        if auth.status != AuthStatus.ONLINE.value:
-            self._handle_node_connection(auth)
-            for room in session.rooms:
-                self.__join_room_and_notify(room)
-            self.log.info(
-                f"Node {session.name} websocket session recovered through ping"
-            )
+            # There is a bug https://github.com/vantage6/vantage6/issues/2386 where
+            # the node disconnects on the HQ side but the node is still connected to
+            # HQ. This is a last resort to recover the connection. It should be
+            # considered to remove the setting of the `status` field in this method
+            # when the bug is fixed.
+            was_offline = auth.status != AuthStatus.ONLINE.value
 
-        auth.status = AuthStatus.ONLINE.value
-        auth.last_seen = dt.datetime.now(dt.timezone.utc)
-        auth.save()
+            # Persist the status before recovering the connection: the recovery emits,
+            # which yields the greenlet and may leave `auth` detached.
+            auth.status = AuthStatus.ONLINE.value
+            auth.last_seen = dt.datetime.now(dt.timezone.utc)
+            auth.save()
 
-        self.__cleanup()
+            if was_offline:
+                self._handle_node_connection(auth)
+                for room in session.rooms:
+                    self.__join_room_and_notify(room)
+                self.log.info(
+                    f"Node {session.name} websocket session recovered through ping"
+                )
+        finally:
+            self.__cleanup()
 
     def on_dataframe_deleted(self, data: dict) -> None:
         """
@@ -427,12 +484,13 @@ class DefaultSocketNamespace(Namespace):
             data["df_name"],
             data["node_id"],
         )
-        df_to_be_deleted = DataframeToBeDeletedAtNode.get_by_multiple_keys(
-            data["df_name"], data["session_id"], data["node_id"]
-        )
-        df_to_be_deleted.delete()
-
-        self.__cleanup()
+        try:
+            df_to_be_deleted = DataframeToBeDeletedAtNode.get_by_multiple_keys(
+                data["df_name"], data["session_id"], data["node_id"]
+            )
+            df_to_be_deleted.delete()
+        finally:
+            self.__cleanup()
 
     def __join_room_and_notify(self, room: str) -> None:
         """
@@ -475,22 +533,31 @@ class DefaultSocketNamespace(Namespace):
         if room != ALL_NODES_ROOM:
             emit("message", msg, room=room)
 
-    def __alert_node_status(self, online: bool, node: Authenticatable) -> None:
+    def __alert_node_status(
+        self, online: bool, node_id: int, node_name: str, org_id: int
+    ) -> None:
         """
         Send status update of nodes when they change on/offline status
+
+        Takes plain values rather than the node object: this method emits in a loop,
+        and each emit yields the greenlet, which may detach the node.
 
         Parameters
         ----------
         online: bool
             Whether node is coming online or not
-        node: Authenticatable
-            The node SQLALchemy object
+        node_id: int
+            ID of the node
+        node_name: str
+            Name of the node
+        org_id: int
+            ID of the organization the node belongs to
         """
         event = "node-online" if online else "node-offline"
         for room in session.rooms:
             self.socketio.emit(
                 event,
-                {"id": node.id, "name": node.name, "org_id": node.organization.id},
+                {"id": node_id, "name": node_name, "org_id": org_id},
                 namespace="/tasks",
                 room=room,
             )
@@ -522,18 +589,19 @@ class DefaultSocketNamespace(Namespace):
         task_id = data.get("task_id")
         log_message = data.get("log")
 
-        run = db.Run.get(run_id)
-        self._append_log(log_message, run)
-        run.save()
+        try:
+            run = db.Run.get(run_id)
+            self._append_log(log_message, run)
+            run.save()
 
-        # emit the log to the collaboration room so that the UI can display it
-        emit(
-            "algorithm_log",
-            {"run_id": run_id, "task_id": task_id, "log": log_message},
-            room=f"collaboration_{collaboration_id}",
-        )
-
-        self.__cleanup()
+            # emit the log to the collaboration room so that the UI can display it
+            emit(
+                "algorithm_log",
+                {"run_id": run_id, "task_id": task_id, "log": log_message},
+                room=f"collaboration_{collaboration_id}",
+            )
+        finally:
+            self.__cleanup()
 
     def _append_log(self, log_message, run):
         if run.log:
@@ -555,29 +623,30 @@ class DefaultSocketNamespace(Namespace):
         if not self._is_node():
             return
 
-        node = db.Node.get_by_keycloak_id(session.auth_id)
+        try:
+            node_id = db.Node.get_by_keycloak_id(session.auth_id).id
 
-        os_label = data.pop("os", "unknown")
-        platform_label = data.pop("platform", "unknown")
-        for metric_name, value in data.items():
-            try:
-                self.metrics.set_metric(
-                    metric_name=metric_name,
-                    value=value,
-                    labels={
-                        "node_id": node.id,
-                        "os": os_label,
-                        "platform": platform_label,
-                    },
-                )
-            except ValueError as e:
-                self.log.warning(f"Invalid metric data: {e}")
-            except Exception as e:
-                self.log.error(f"Failed to process metric '{metric_name}': {e}")
+            os_label = data.pop("os", "unknown")
+            platform_label = data.pop("platform", "unknown")
+            for metric_name, value in data.items():
+                try:
+                    self.metrics.set_metric(
+                        metric_name=metric_name,
+                        value=value,
+                        labels={
+                            "node_id": node_id,
+                            "os": os_label,
+                            "platform": platform_label,
+                        },
+                    )
+                except ValueError as e:
+                    self.log.warning(f"Invalid metric data: {e}")
+                except Exception as e:
+                    self.log.error(f"Failed to process metric '{metric_name}': {e}")
 
-        self.log.info(f"Updated metrics for node {node.id}")
-
-        self.__cleanup()
+            self.log.info(f"Updated metrics for node {node_id}")
+        finally:
+            self.__cleanup()
 
     @staticmethod
     def __is_identified_client() -> bool:


### PR DESCRIPTION
## Summary

Nodes and users occasionally saw a 500 (`DetachedInstanceError`) on things like run
status updates and task creation, because `socketio.emit()` yields the greenlet under
gevent and a concurrent handler's session cleanup could detach the ORM object the
current request still needed to read from. This PR fixes five such sites — three from
the linked issue, two more found by auditing `event.py` — by hoisting needed attributes
into locals before emitting, re-fetching before serialization, or reordering writes
ahead of the emit. A broader root-cause fix (`expire_on_commit=False` on both
sessionmakers) was considered and deliberately deferred; see the note below for why.

Closes #2656

## A note on an alternative, more root-cause fix

Before reading the rest of this PR: there is a broader alternative fix we considered and
deliberately did not implement here — `expire_on_commit=False` on the two sessionmakers
in `vantage6-backend-common/vantage6/backend/common/base.py`
(`session_flask_requests` and `session_outside_flask_requests`).

Right now both are built with autocommit/autoflush settings only, so `expire_on_commit`
defaults to SQLAlchemy's `True`. That means every `.save()` (i.e. every commit) expires
*all* loaded ORM instances, turning every later attribute access into a fresh query.
That's the dominant trigger behind this whole bug class: it's what makes a `run` or
`task` object fragile the moment a session is cleared after a commit, anywhere in the
codebase, not just at the sites fixed here.

Setting `expire_on_commit=False` would remove that trigger globally in one change,
instead of requiring every future `emit()`/lazy-relationship call site to be fixed one
at a time (as this PR does). We chose **not** to make that change in this PR because:

- It's a global behavioral change affecting every session in HQ and the algorithm
  store, not scoped to the bug being fixed.
- There is close to no existing test coverage for the websocket layer, so a regression
  from stale in-memory attribute values (e.g. any column with `server_default` or
  `onupdate` computed by the DB) would not be reliably caught. We checked and found no
  such columns in the current HQ/algorithm-store models, but that's a point-in-time
  fact, not a guarantee against future models introducing one.
- Given the stability risk of a global session-behavior change with thin test
  coverage backing it up, we preferred the narrower, reviewable, site-by-site fix in
  this PR for now.

**We should consider `expire_on_commit=False` as a deliberate follow-up**, ideally paired
with expanded websocket test coverage so a regression would actually be caught.

## What this does

Fixes `DetachedInstanceError` at several socket-emit sites in HQ. All are the same
shape: HQ commits a change, then calls `socketio.emit()`/`emit()` before reading
attributes off the same ORM objects for logging or serialization. Because HQ runs on
`gevent_uwsgi` with a Redis message queue, `emit()` performs network I/O and yields the
greenlet — during which a concurrent handler's `__cleanup()` can clear the shared
database session, detaching the objects the current handler is still holding.

Fixed in three complementary ways, applied per call site as appropriate:

- **Hoist**: read every ORM attribute needed after an emit into a local variable
  *before* the first emit in that code path.
- **Re-fetch**: re-load an object from the database immediately before it is
  serialized into a response, since it may have been detached in the interim.
- **Reorder**: where safe, do database writes / side-effect-free reads before emitting
  rather than after, removing the hazard rather than working around it.

Sites fixed:
- `resource/run.py` — `SingleRun.patch`: hoist before the two status-update emits,
  re-fetch before the response is serialized.
- `websockets.py` — `_handle_node_connection`, `on_disconnect`, `on_ping`,
  `__alert_node_status`, `_send_dataframe_deletion_instructions`,
  `on_algorithm_status_change`: hoisted node/task attributes; `__alert_node_status`
  and `_send_dataframe_deletion_instructions` now take plain ids/names rather than ORM
  objects, since they emit inside a loop.
- `resource/common/task_post_base.py` — `post_task`: log before emitting rather than
  after (keeps `task.collaboration.name` in the log line), re-fetch before the response
  is serialized.
- `resource/event.py` — two sites not covered by the original bug report:
  `KillNodeTasks.post` (hoist before emit) and `kill_task()` (mark runs killed
  *before* emitting the kill instruction, so the DB is consistent even if the runs are
  detached afterward — this one previously risked leaving runs silently un-killed).

Additionally, every socket handler body in `websockets.py` is now wrapped in
`try/finally` so `DatabaseSessionManager.clear_session()` always runs, even if the
handler raises partway through. Previously an exception mid-handler would leak the
session for the lifetime of the greenlet.

## Approach

Considered making the fix global via `expire_on_commit=False` on both sessionmakers in
`vantage6-backend-common`, which would remove the dominant trigger (every `.save()`
currently expires all loaded instances) across the whole codebase in one change. Decided
against it for this PR — it's a broader behavioral change than this bug warrants, and
there is close to no test coverage for the websocket layer to catch a regression if the
assumption about safety (no `server_default`/`onupdate` columns in these models) turns
out to be wrong somewhere I didn't check. Left as a candidate for a follow-up.

Also considered mirroring an existing fix for the same bug on an older branch. Diverged
from it in a few places: it introduces dual old/new calling conventions on private
methods with no old callers to support, and wraps some emits in broad
`except Exception` that logs and swallows the failure. Neither seemed worth carrying
forward — the private-method shims are dead weight, and silently losing a websocket
message seems worse than letting the failure surface.

## Deviations from the plan

- `on_algorithm_status_change` needed one more hoist than planned: `run.task.required_by`
  is read in a loop that emits on each iteration, the same hazard as
  `__alert_node_status`. Same technique as planned, just one more site than originally
  scoped.
- `on_ping` needed a small reorder in addition to the planned `try/finally`: the status
  write is now persisted before the reconnection-recovery branch runs (which itself
  emits), so the write isn't left stranded against an session that recovery already
  cleared.
- Two bugs surfaced in the new tests themselves during verification, not in the fix:
  one read a detached attribute after the simulated session clear (fixed by capturing
  ids upfront and running inside a request context, matching how `kill_task` runs in
  production); the other initially skipped this repo's DB test lifecycle and broke five
  unrelated tests in `test_cleanup.py` (fixed by inheriting `TestResourceBase`).
- `black` isn't installed in this environment; used `ruff format` (its black-compatible
  formatter) instead.

## Testing

- `test_run.py::test_run_patch_survives_session_clear_during_emit` — patches
  `SocketIO.emit` to clear the session as a side effect, reproducing the race
  deterministically. Confirmed this fails with `500 != 200` against the pre-fix code
  and passes after.
- `test_task.py::test_task_post_survives_session_clear_during_emit` — same technique for
  task creation.
- `test_task.py::test_kill_task_marks_runs_killed_when_session_cleared_on_emit` — asserts
  runs actually end up `KILLED` in the database even when the session clears mid-emit.
- `test_websockets.py::test_cleanup_runs_when_handler_raises` (new file) — asserts
  `clear_session()` is still called for six handlers when the handler body raises.
- Full HQ suite: 143/143 passing (`uv run python utest.py --hq`).
- `ruff format --check` and `ruff check` clean on all changed files.
