### PR TITLE
Fix gevent monkey-patch import order in HQ

### DIFF
--- a/vantage6-hq/vantage6/hq/__init__.py
+++ b/vantage6-hq/vantage6/hq/__init__.py
@@ -9,8 +9,6 @@ import os
 
 from gevent import monkey
 
-from vantage6.backend.common.globals import RequiredBackendEnvVars
-
 # This is a workaround for readthedocs
 if not os.environ.get("READTHEDOCS"):
     # flake8: noqa: E402 (ignore import error)
@@ -42,6 +40,7 @@ from vantage6.common.globals import (
 from vantage6.cli.context.hq import HQContext
 
 from vantage6.backend.common import Vantage6App
+from vantage6.backend.common.globals import RequiredBackendEnvVars
 from vantage6.backend.common.metrics import Metrics, start_prometheus_exporter
 from vantage6.backend.common.permission import RuleNeed
 


### PR DESCRIPTION
This was a side effect from me debugging #2656 

---

Commit ec565060a (2026-03-16) added `from vantage6.backend.common.globals import RequiredBackendEnvVars` between `from gevent import monkey` and `monkey.patch_all()`. That import executes the whole `vantage6.backend.common` package (Flask, requests/urllib3, PyJWT), which pulls in `ssl`/`socket` before they are patched. gevent then warns:

    MonkeyPatchWarning: Monkey-patching ssl after ssl has already been imported
    ... Modules that had direct imports (NOT patched): ['jwt.jwks_client',
    'urllib3.util', 'urllib3.util.ssl_']

Those unpatched modules perform blocking SSL I/O (e.g. Keycloak HTTPS calls), stalling the entire gevent event loop instead of yielding. This is a re-introduction of the class of bug fixed historically in #1311 / PR#1320.

Move the import below `patch_all()` so the standard library is patched before any ssl-importing module loads. Verified: importing `vantage6.hq` no longer emits the MonkeyPatchWarning, and the full HQ test suite (139 tests) passes.

Note: this is unrelated to the DetachedInstanceError reports in #2656 — that bug was reproduced on the 5.0.0b1 lineage, which predates this misordering and had correct patch ordering.