### PR TITLE
Fix DetachedInstanceError by scoping request session per request context (#2656)

### DIFF
--- a/vantage6-backend-common/vantage6/backend/common/base.py
+++ b/vantage6-backend-common/vantage6/backend/common/base.py
@@ -4,7 +4,7 @@ import os
 from time import sleep
 from typing import Any
 
-from flask.globals import g
+from flask.globals import app_ctx, g, request_ctx
 from sqlalchemy import (
     Column,
     Integer,
@@ -33,6 +33,44 @@ from vantage6.backend.common.globals import (
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
+
+# Fallback scope key for `_flask_request_scope` when there is no Flask context
+# at all (e.g. `scoped_session.configure()` at connect time).
+_NO_FLASK_CONTEXT = object()
+
+
+def _flask_request_scope():
+    """
+    Scope key for the per-request database session.
+
+    Returns one session per Flask *request* context instead of the default
+    ``threading.local()`` (which, under gevent, is one session per greenlet).
+
+    Flask-SocketIO dispatches every socket-event handler inside a fresh request
+    context (``with app.request_context(environ)``). Under gevent a socket
+    handler can run *synchronously inside* a ``socketio.emit()`` - e.g. a node
+    disconnect triggered by delivering to a half-open client - which nests it in
+    the greenlet that is still handling an HTTP request. With greenlet scoping
+    the two share one session, so the nested handler's ``clear_session()``
+    detaches the ORM objects the outer request is still using
+    (``DetachedInstanceError``). Scoping per request context gives them separate
+    sessions. See https://github.com/vantage6/vantage6/issues/2656.
+
+    The scope must be the request context, not the app context: Flask reuses a
+    single app context across nested same-app request contexts, so app-context
+    scoping would not separate the two handlers.
+    """
+    try:
+        return id(request_ctx._get_current_object())
+    except RuntimeError:
+        pass
+    try:
+        # No request context (e.g. a bare app context pushed by a CLI command).
+        # There is no nested-handler hazard here; fall back to the app context.
+        return id(app_ctx._get_current_object())
+    except RuntimeError:
+        # No Flask context at all (e.g. `configure()` during connect).
+        return id(_NO_FLASK_CONTEXT)
 
 
 class BaseDatabase:
@@ -127,8 +165,13 @@ class BaseDatabase:
 
                 # Create a session for flask requests. If a session already
                 # exists it will return the same session (!).
+                # Scoped per Flask request context (see `_flask_request_scope`)
+                # rather than the default per-greenlet, so a socket handler that
+                # runs nested inside a request's `socketio.emit()` cannot clear
+                # the request's session out from under it (issue #2656).
                 self.session_flask_requests = scoped_session(
-                    sessionmaker(autocommit=False, autoflush=False)
+                    sessionmaker(autocommit=False, autoflush=False),
+                    scopefunc=_flask_request_scope,
                 )
                 self.session_flask_requests.configure(bind=self.engine)
 

--- a/vantage6-hq/tests_hq/model/test_session_scope.py
+++ b/vantage6-hq/tests_hq/model/test_session_scope.py
@@ -1,0 +1,54 @@
+"""
+Regression test for issue #2656 (DetachedInstanceError).
+
+The per-request database session is scoped to the Flask *request context*
+rather than to the greenlet/thread. This guards against a socket-event handler
+that runs synchronously inside a request's ``socketio.emit()`` (e.g. a node
+disconnect triggered by delivering to a half-open client): such a handler runs
+in a nested request context but the same greenlet, and its ``clear_session()``
+must not detach the ORM objects the outer request is still holding.
+
+Without the fix (session scoped per greenlet) the assertion below raises
+``DetachedInstanceError``; with it the outer request keeps its own session.
+"""
+
+from unittest import TestCase
+
+from flask import Flask
+
+from vantage6.hq.model import Organization
+from vantage6.hq.model.base import Database, DatabaseSessionManager
+
+
+class TestSessionScopePerRequestContext(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        Database().connect("sqlite://", allow_drop_all=True)
+        cls.app = Flask(__name__)
+
+    @classmethod
+    def tearDownClass(cls):
+        Database().clear_data()
+        Database().close()
+
+    def test_nested_request_context_clear_does_not_detach_outer_session(self):
+        # Outer request context (the HTTP PATCH handler).
+        with self.app.test_request_context():
+            org = Organization(name="outer-request-org")
+            org.save()  # commit expires all attributes (expire_on_commit=True)
+
+            # A socket handler dispatched inside socketio.emit() runs in its own
+            # request context (Flask-SocketIO: `with app.request_context(...)`)
+            # but the same greenlet. It does unrelated DB work and clears the
+            # session in its cleanup.
+            with self.app.test_request_context():
+                DatabaseSessionManager.new_session()
+                unrelated = Organization(name="disconnect-handler-org")
+                unrelated.save()
+                DatabaseSessionManager.clear_session()
+
+            # Back in the outer request: reading an expired attribute must still
+            # work. This is the exact operation that failed at run.py:743.
+            self.assertEqual(org.name, "outer-request-org")
+
+            DatabaseSessionManager.clear_session()


### PR DESCRIPTION
The fix turned out to be quite different, this should resolve the root cause rather than patches (like the PR: Super seeds: https://github.com/vantage6/vantage6/pull/2665).

AI report bellow. I also updated the original issue with the MWE to demonstrate the issue and the fix.

---

## Summary

Fixes the intermittent `DetachedInstanceError` 500s (issue #2656) at their root, replacing the site-by-site defensive patches with a single change to how the per-request database session is scoped.

## The bug

The per-request session (`session_flask_requests`) is a SQLAlchemy `scoped_session` whose default scope is `threading.local()` — under the production gevent stack, **one session per greenlet**.

Flask-SocketIO dispatches every socket-event handler inside a **fresh Flask request context**. Under gevent, a socket handler can run **synchronously inside** a request's `socketio.emit()`:

1. A node `PATCH`es `/api/run/<id>`; the handler runs in greenlet **G**, request context **RC1**. `run.save()` commits, and `expire_on_commit=True` expires every loaded attribute, so `run` now needs a live session to read anything back.
2. `socketio.emit(...)` — in the python-socketio version the image installs — delivers to local room members **inline, in greenlet G**.
3. One room member is a **half-open client** (common with the long-polling transport behind sticky-session load balancing). Delivering to it trips engine.io's `check_ping_timeout()` → `close(run_async=False)` → `_trigger_event('disconnect')`, **synchronously**, still in G.
4. Flask-SocketIO runs that disconnect handler in a fresh request context **RC2** (still greenlet G). Its cleanup calls `clear_session()` → `scoped_session.remove()`. Because the session is scoped to the **greenlet**, RC1 and RC2 share one session, so `remove()` detaches `run`.
5. Back in the PATCH handler, reading `run.id` to serialize the response raises `DetachedInstanceError` (run.py:743).

The detacher is a **nested handler in the same greenlet but a different request context** — the session scope (greenlet) is coarser than the unit of work (request context).

## The fix

Scope `session_flask_requests` to the Flask **request context** instead of the greenlet. Nested request contexts get separate sessions, so a nested handler's cleanup can no longer detach the outer request's objects. This removes the implicit "read every attribute before emitting" ordering dependency that the earlier defensive patches relied on.

It must be the **request** context, not the app context: Flask reuses one app context across nested same-app request contexts, so app-context scoping would not separate the handlers. `session_outside_flask_requests` is left greenlet-scoped — background workers legitimately want one session per greenlet.

## Testing

- A self-contained minimal reproduction (Flask + SQLAlchemy only, no vantage6/gevent/Redis/websockets) is posted on the issue — it reproduces the 500 on the current scope and shows the fix: https://github.com/vantage6/vantage6/issues/2656#issuecomment-5059154646

- Added `tests_hq/model/test_session_scope.py`, which reproduces the nested-disconnect-during-emit scenario. It **fails with `DetachedInstanceError` without the scopefunc** and passes with it.
- Full HQ suite green (140 tests).
