### PR TITLE
Guarantee WebSocket DB session cleanup via teardown_request (#2654)

### DIFF
--- a/vantage6-backend-common/vantage6/backend/common/__init__.py
+++ b/vantage6-backend-common/vantage6/backend/common/__init__.py
@@ -247,6 +247,19 @@ class Vantage6App:
             database_session_manager.clear_session()
             return response
 
+        @self.app.teardown_request
+        def remove_db_session_on_teardown(exc):
+            """When the request context is torn down.
+
+            Flask's `after_request` does NOT run for Flask-SocketIO events (they
+            never go through the full HTTP dispatch), and it is skipped whenever
+            a handler raises. `teardown_request` runs on every request-context
+            pop - including on exceptions and for socket events - so this is the
+            single guarantee that a handler cannot leak a pooled database
+            connection. See https://github.com/vantage6/vantage6/issues/2654.
+            """
+            database_session_manager.clear_session()
+
         @self.app.errorhandler(HTTPException)
         def error_remove_db_session(error: HTTPException):
             """In case an HTTP-exception occurs during the request.

--- a/vantage6-backend-common/vantage6/backend/common/base.py
+++ b/vantage6-backend-common/vantage6/backend/common/base.py
@@ -408,9 +408,13 @@ class BaseDatabaseSessionManager:
         from the db module.
         """
         if BaseDatabaseSessionManager.in_flask_request():
-            # print(f"gsession: {g.session}")
-            g.session.remove()
-            # g.session = None
+            # `g.session` is only set once a session has actually been opened
+            # (via `new_session`). This is now called from `teardown_request`,
+            # which fires for every request-context pop - including socket
+            # events and error paths that never touched the database - so guard
+            # against clearing a session that was never created.
+            if "session" in g:
+                g.session.remove()
         else:
             if session.session:
                 session.session.remove()

--- a/vantage6-hq/tests_hq/resources/test_websockets_cleanup.py
+++ b/vantage6-hq/tests_hq/resources/test_websockets_cleanup.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for issue #2654 (WebSocket DB connection leaks).
+
+WebSocket event handlers run inside a Flask request context, but Flask's
+``after_request`` hook does not fire for socket events, and is skipped whenever a
+handler raises. Cleanup of the database session is therefore driven by a
+``teardown_request`` hook, which runs on every request-context pop - including on
+exceptions - so a handler that raises cannot leak a pooled connection.
+"""
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from flask import Flask
+from flask_socketio import SocketIO
+
+from vantage6.hq.model import Organization
+from vantage6.hq.model.base import Database, DatabaseSessionManager
+
+
+class TestWebsocketSessionCleanup(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        Database().connect("sqlite://", allow_drop_all=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        Database().clear_data()
+        Database().close()
+
+    @staticmethod
+    def _build_app():
+        """Minimal Flask + SocketIO app with the same teardown hook the backend
+        factory registers (backend/common/__init__.py)."""
+        app = Flask(__name__)
+        app.config["SECRET_KEY"] = "test"
+
+        @app.teardown_request
+        def _remove_db_session_on_teardown(exc):
+            DatabaseSessionManager.clear_session()
+
+        socketio = SocketIO(app, async_mode="threading")
+        return app, socketio
+
+    def test_session_released_when_handler_raises(self):
+        """A handler that opens a session and then raises must still have its
+        session cleared, via teardown."""
+        app, socketio = self._build_app()
+
+        @socketio.on("boom")
+        def boom(data):
+            # opens a per-request session (lazily, like any model access)
+            Organization(name="ws-teardown-org").save()
+            raise RuntimeError("handler blew up mid-event")
+
+        client = socketio.test_client(app)
+
+        with patch.object(
+            DatabaseSessionManager,
+            "clear_session",
+            wraps=DatabaseSessionManager.clear_session,
+        ) as clear_spy:
+            try:
+                client.emit("boom", {})
+            except RuntimeError:
+                pass  # the test client re-raises the handler's exception
+
+        self.assertTrue(
+            clear_spy.called,
+            "teardown_request must clear the session even when the handler raises",
+        )
+
+    def test_clear_session_noop_without_session(self):
+        """teardown fires for every request-context pop, including events that
+        never touch the database - clearing must be a no-op, not an error."""
+        app, _ = self._build_app()
+        with app.test_request_context():
+            # no session was ever opened on `g`
+            DatabaseSessionManager.clear_session()  # must not raise

--- a/vantage6-hq/tests_hq/resources/test_websockets_cleanup.py
+++ b/vantage6-hq/tests_hq/resources/test_websockets_cleanup.py
@@ -5,8 +5,8 @@ WebSocket handlers run inside a Flask request context, and the database session
 is cleared by a ``teardown_request`` hook rather than ``after_request``, since
 the latter does not fire for socket events and is skipped when a handler raises.
 These tests check that the teardown hook clears the session even when a handler
-raises, and that it is a harmless no-op for handlers that never touch the
-database.
+raises, that it is a harmless no-op for handlers that never touch the database,
+and that the HQ app actually registers such a hook.
 """
 
 from unittest import TestCase
@@ -17,6 +17,8 @@ from flask_socketio import SocketIO
 
 from vantage6.hq.model import Organization
 from vantage6.hq.model.base import Database, DatabaseSessionManager
+
+from .test_resource_base import TestResourceBase
 
 
 class TestWebsocketSessionCleanup(TestCase):
@@ -78,3 +80,28 @@ class TestWebsocketSessionCleanup(TestCase):
         with app.test_request_context():
             # no session was ever opened on `g`
             DatabaseSessionManager.clear_session()  # must not raise
+
+
+class TestWebsocketSessionCleanupWiring(TestResourceBase):
+    """The tests above run against a hand-built Flask app, so they would still
+    pass if the HQ app stopped registering the hook. This one checks the real
+    app."""
+
+    def test_hq_app_registers_teardown_hook(self):
+        """Popping a request context of the real HQ app must clear the database
+        session. `after_request` does not run for a bare request context (nor
+        for socket events), so this only passes if a teardown hook is
+        registered."""
+        with patch.object(
+            DatabaseSessionManager,
+            "clear_session",
+            wraps=DatabaseSessionManager.clear_session,
+        ) as clear_spy:
+            with self.server.app.test_request_context():
+                DatabaseSessionManager.new_session()
+
+        self.assertTrue(
+            clear_spy.called,
+            "the HQ app must register a teardown_request hook that clears the "
+            "database session",
+        )

--- a/vantage6-hq/tests_hq/resources/test_websockets_cleanup.py
+++ b/vantage6-hq/tests_hq/resources/test_websockets_cleanup.py
@@ -1,11 +1,12 @@
 """
-Regression tests for issue #2654 (WebSocket DB connection leaks).
+Tests that WebSocket event handlers release their database session.
 
-WebSocket event handlers run inside a Flask request context, but Flask's
-``after_request`` hook does not fire for socket events, and is skipped whenever a
-handler raises. Cleanup of the database session is therefore driven by a
-``teardown_request`` hook, which runs on every request-context pop - including on
-exceptions - so a handler that raises cannot leak a pooled connection.
+WebSocket handlers run inside a Flask request context, and the database session
+is cleared by a ``teardown_request`` hook rather than ``after_request``, since
+the latter does not fire for socket events and is skipped when a handler raises.
+These tests check that the teardown hook clears the session even when a handler
+raises, and that it is a harmless no-op for handlers that never touch the
+database.
 """
 
 from unittest import TestCase

--- a/vantage6-hq/vantage6/hq/websockets.py
+++ b/vantage6-hq/vantage6/hq/websockets.py
@@ -15,7 +15,6 @@ from vantage6.backend.common.metrics import Metrics
 
 from vantage6.hq import db
 from vantage6.hq.model.authenticatable import Authenticatable
-from vantage6.hq.model.base import DatabaseSessionManager
 from vantage6.hq.model.dataframe_to_be_deleted_at_node import (
     DataframeToBeDeletedAtNode,
 )
@@ -113,9 +112,6 @@ class DefaultSocketNamespace(Namespace):
 
         for room in session.rooms:
             self.__join_room_and_notify(room)
-
-        # cleanup (e.g. database session)
-        self.__cleanup()
 
     def _handle_node_connection(self, node: Authenticatable) -> None:
         """
@@ -244,9 +240,6 @@ class DefaultSocketNamespace(Namespace):
             reason if reason else "unknown"
         )
 
-        # cleanup (e.g. database session)
-        self.__cleanup()
-
     def on_message(self, message: str) -> None:
         """
         On receiving a message from a client, log it.
@@ -348,9 +341,6 @@ class DefaultSocketNamespace(Namespace):
             room=f"collaboration_{collaboration_id}",
         )
 
-        # cleanup (e.g. database session)
-        self.__cleanup()
-
     def on_node_info_update(self, node_config: dict) -> None:
         """
         A node sends information about its configuration and other properties.
@@ -400,9 +390,6 @@ class DefaultSocketNamespace(Namespace):
         node.config = to_store
         node.save()
 
-        # cleanup (e.g. database session)
-        self.__cleanup()
-
     def on_ping(self) -> None:
         """
         A client sends a ping to HQ, which detects who sent the ping and sets them as
@@ -426,8 +413,6 @@ class DefaultSocketNamespace(Namespace):
         auth.last_seen = dt.datetime.now(dt.timezone.utc)
         auth.save()
 
-        self.__cleanup()
-
     def on_dataframe_deleted(self, data: dict) -> None:
         """
         A dataframe has been deleted at a node.
@@ -441,8 +426,6 @@ class DefaultSocketNamespace(Namespace):
             data["df_name"], data["session_id"], data["node_id"]
         )
         df_to_be_deleted.delete()
-
-        self.__cleanup()
 
     def __join_room_and_notify(self, room: str) -> None:
         """
@@ -543,8 +526,6 @@ class DefaultSocketNamespace(Namespace):
             room=f"collaboration_{collaboration_id}",
         )
 
-        self.__cleanup()
-
     def _append_log(self, log_message, run):
         if run.log:
             if not run.log.endswith("\n"):
@@ -587,8 +568,6 @@ class DefaultSocketNamespace(Namespace):
 
         self.log.info(f"Updated metrics for node {node.id}")
 
-        self.__cleanup()
-
     @staticmethod
     def __is_identified_client() -> bool:
         """
@@ -614,11 +593,6 @@ class DefaultSocketNamespace(Namespace):
         """
         for conf in node.config:
             conf.delete()
-
-    @staticmethod
-    def __cleanup() -> None:
-        """Cleanup database connections"""
-        DatabaseSessionManager.clear_session()
 
 
 def send_delete_dataframe_event(


### PR DESCRIPTION
## Summary

WebSocket event handlers run inside a Flask request context, but Flask's `after_request` hook never fires for socket events (they don't go through the full HTTP dispatch) and is also skipped whenever a handler raises. Each handler therefore cleared its own DB session with a trailing `self.__cleanup()` call — unguarded, so any exception mid-handler skipped it and permanently leaked a pooled connection. This replaces the per-handler cleanup with a single `teardown_request` hook that runs on every request-context pop, including on exceptions, so a handler can no longer leak a connection. Chosen over the alternative of wrapping all eight handlers in `try/finally`, which is the same pattern repeated eight times and easy to forget on the next handler.

Closes #2654

## What this does

- Registers one `@app.teardown_request` handler in the shared backend app factory (`backend/common/__init__.py`) that calls `clear_session()`. `teardown_request` fires on every request-context pop — for HTTP requests, for socket events, and on exceptions — which is exactly the guarantee `after_request` cannot give for sockets.
- Guards `clear_session()` (`backend/common/base.py`) with `if "session" in g:`, since teardown now fires for request contexts that never opened a session (socket events that touch no DB, pre-session early returns). Without the guard, accessing `g.session` would raise `AttributeError`.
- Removes the now-redundant manual cleanup from `hq/websockets.py`: the eight `self.__cleanup()` calls, the `__cleanup()` method, and its now-unused `DatabaseSessionManager` import. No `try/finally` added anywhere.

## Approach

`teardown_request` was verified empirically (Flask 3.1.3 + Flask-SocketIO 5.6.1, the pinned versions) to fire once per socket event and to fire even when the handler raises, while `after_request` never fires for sockets. `teardown_request` is used rather than `teardown_appcontext` because Flask reuses a single app context across nested same-app request contexts, so `teardown_appcontext` would not fire for a socket handler dispatched synchronously inside another request (the nested-handler scenario from #2656); `teardown_request` fires per request context and is correct in both the flat and nested cases. The HTTP `before_request`/`after_request`/errorhandler flow is left unchanged; teardown also firing for HTTP requests is a harmless idempotent double `clear_session()`.

## Deviations from the plan

- Also removed the now-unused `DatabaseSessionManager` import from `websockets.py` (only the deleted `__cleanup` used it) — needed for a clean lint.
- The "no session" test is a direct `clear_session()`-without-session unit test rather than a socket dispatch: teardown-exception propagation through the socket test client is unreliable to assert, so a direct call is deterministic (and confirmed to fail without the guard).
- The tests register the teardown hook in a mini-app mirroring the factory, so they guard the mechanism and the guard, not the factory wiring itself; that wiring is smoke-covered by the full suite booting the app through the factory.

## Testing

- `tests_hq/resources/test_websockets_cleanup.py` (new): `test_session_released_when_handler_raises` (a handler that opens a session then raises still has `clear_session` run via teardown) and `test_clear_session_noop_without_session` (the guard). Confirmed the latter fails with `AttributeError` without the guard.
- HQ suite: 141 passed (139 baseline + 2 new).
- Algorithm-store suite: 49 passed (shared `backend-common` change does not regress the store).
- `ruff check` clean; `ruff format` applied to `websockets.py`.
