### PR TITLE
fix(node-chart): quote policy list entries in ConfigMap

### DIFF
--- a/charts/node/templates/node-configmap.yml
+++ b/charts/node/templates/node-configmap.yml
@@ -37,25 +37,25 @@ data:
       {{- if .Values.node.policies.allowed_algorithms }}
       allowed_algorithms:
         {{- range .Values.node.policies.allowed_algorithms }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
       {{- end }}
       {{- if .Values.node.policies.allowed_algorithm_stores }}
       allowed_algorithm_stores:
         {{- range .Values.node.policies.allowed_algorithm_stores }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
       {{- end }}
       {{- if .Values.node.policies.allowed_users }}
       allowed_users:
         {{- range .Values.node.policies.allowed_users }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
       {{- end }}
       {{- if .Values.node.policies.allowed_organizations }}
       allowed_organizations:
         {{- range .Values.node.policies.allowed_organizations }}
-        - {{ . }}
+        - {{ . | quote }}
         {{- end }}
       {{- end }}
       require_algorithm_pull: {{ .Values.node.policies.require_algorithm_pull }}


### PR DESCRIPTION
## Summary
The Node Helm chart's ConfigMap rendered `policies.allowed_users`,
`allowed_organizations`, `allowed_algorithms`, and `allowed_algorithm_stores` list
entries as bare `- {{ . }}`, so numeric IDs (e.g. a user/org ID of `1`) were re-parsed
as YAML **integers** in the node's `config.yml`. The node-side allow-list check compares
them as strings (`str(init_user_id) == entry`), so numeric entries never matched and
execution fell through to a fallback path that raised
`AttributeError: 'str' object has no attribute 'get'`. This adds `| quote` to the four
policy list fields so entries keep their string type. Note: quoting the IDs in
`values.yaml` alone does not help — Go templates emit `{{ . }}` unquoted regardless, so
the fix has to live in the template.

Closes #2644

## What this does
Changes the four `range` bodies in `charts/node/templates/node-configmap.yml` that emit
policy list entries from `- {{ . }}` to `- {{ . | quote }}`. Rendered output now reads
`- "1"`, `- "root"`, etc. `allowed_algorithms`/`allowed_algorithm_stores` are included
for consistency (same latent gap; regex/URL strings are unambiguously strings and
unaffected in meaning).

## Approach
`| quote` is already the convention in this same file for every other scalar whose
string type matters (`logging.datefmt`, `logging.format`,
`private_docker_registries[].password`). The unquoted policy lists were an inconsistency,
not a deliberate choice, so this brings them in line. The fix is confined to the chart —
the node-side Python comparison is left unchanged, as fixing the rendered config is the
correct minimal fix and Python-side hardening is a separable concern. `algorithm_env`
(which holds `KEY=value` strings, not policy IDs) is intentionally left as-is.

## Deviations from the plan
None — implemented as planned.

## Testing
No unit-test harness exists for this chart. Verified with Helm directly:
- `helm template` with numeric and string IDs — before the change entries rendered as
  bare `- 1` / `- root`; after the change they render quoted as `- "1"` / `- "root"`
  across all four fields.
- `helm lint` with values supplied — passes clean (only the cosmetic "icon is
  recommended" INFO). The unrelated `node-secrets.yml` b64enc lint error only appears
  when linting with empty default values and reproduces identically on `main`.
