### PR TITLE
Reject algorithms when no allow-list is configured

### DIFF
--- a/docs/node/configure.rst
+++ b/docs/node/configure.rst
@@ -155,6 +155,10 @@ hash (i.e. version) of the trusted algorithm. Note that this process requires ma
 updates to the data station configuration, as well as a data station restart,
 each time that a new algorithm is approved or an existing algorithm is updated.
 
+If neither ``allowed_algorithms`` nor ``allowed_algorithm_stores`` is configured,
+the node rejects all algorithm images. To allow all images explicitly, configure
+``.*`` as an allowed algorithm pattern, but only if you really know what you are doing!
+
 It is also possible to allow a set of algorithms at once by providing a pattern, i.e.
 a regular expression. This makes it e.g. possible to allow a certain
 directory with algorithms. The disadvantage of this approach is that if an

--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -128,16 +128,17 @@ encryption:
 
 # Define who is allowed to run which algorithms on this node.
 policies:
+  # At least one of `allowed_algorithms` or `allowed_algorithm_stores` must be
+  # configured. If neither is configured, no algorithm images are allowed.
+
   # Control which algorithm images are allowed to run on this node. This is
-  # expected to be a valid regular expression. If you don't specify this, all algorithm
-  # images are allowed to run on this node (unless other policies restrict this).
+  # expected to be a valid regular expression.
   allowed_algorithms:
     - ^ghcr\.io/vantage6/algorithm/[a-zA-Z]+/[a-zA-Z]+$
     - ^ghcr\.io/vantage6/algorithm/glm$
 
   # It is also possible to allow all algorithms from particular algorithm stores. Set
-  # these stores here. They may be strings or regular expressions. If you don't specify
-  # this, algorithms from any store are allowed (unless other policies prevent this).
+  # these stores here. They may be strings or regular expressions.
   allowed_algorithm_stores:
     # allow all algorithms from the vantage6 community store
     - https://store.cotopaxi.vantage6.ai
@@ -160,9 +161,9 @@ policies:
     - 6
     - root
 
-  # The basics algorithm (ghcr.io/vantage6/algorithm/basics:latest) is whitelisted
-  # by default. It is used to collect column names in the User Interface to
-  # facilitate task creation. Set to false to disable this.
+  # The basics algorithm (ghcr.io/vantage6/algorithm/basics:latest) is used to collect
+  # column names in the User Interface. Set this to false to always reject it. When
+  # true, it must still satisfy the allowed algorithm and algorithm-store policies.
   allow_basics_algorithm: true
 
   # Set to true to always require that the algorithm image is successfully pulled. This

--- a/utest.py
+++ b/utest.py
@@ -20,6 +20,12 @@ def run():
     cli_test_suites = find_tests(str(Path(__file__).parent / "vantage6"))
     success_cli = run_tests(cli_test_suites)
 
+    # run node tests
+    node_test_suites = find_tests(
+        str(Path(__file__).parent / "vantage6-node" / "tests_node")
+    )
+    success_node = run_tests(node_test_suites)
+
     # run server tests
     server_test_suites = find_tests(str(Path(__file__).parent / "vantage6-server"))
     success_server = run_tests(server_test_suites)
@@ -40,6 +46,7 @@ def run():
         not (
             success_server
             and success_cli
+            and success_node
             and success_common
             and success_algorithm_store
             and success_algorithm_tools

--- a/vantage6-node/tests_node/__init__.py
+++ b/vantage6-node/tests_node/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the vantage6 node package."""

--- a/vantage6-node/tests_node/test_docker_manager.py
+++ b/vantage6-node/tests_node/test_docker_manager.py
@@ -1,0 +1,130 @@
+import unittest
+
+from unittest.mock import MagicMock
+
+from vantage6.common.globals import BASIC_PROCESSING_IMAGE, NodePolicy
+from vantage6.node.docker.docker_manager import DockerManager
+
+ALLOWED_IMAGE = "ghcr.io/example/allowed:latest"
+OTHER_IMAGE = "ghcr.io/example/other:latest"
+ALLOWED_IMAGE_PATTERN = r"^ghcr\.io/example/allowed:.*$"
+ALLOWED_STORE = "https://store.example.org"
+OTHER_STORE = "https://other.example.org"
+
+
+class AlgorithmPolicyTest(unittest.TestCase):
+    """Test policy evaluation in DockerManager.is_docker_image_allowed()."""
+
+    def setUp(self):
+        # We bypass DockerManager.__init__ because these checks do not need a
+        # running Docker daemon. The mocked clients cover the few attributes used.
+        self.manager = DockerManager.__new__(DockerManager)
+        self.manager.log = MagicMock()
+        self.manager.client = MagicMock()
+        self.manager.docker = MagicMock()
+
+    def is_allowed(
+        self,
+        policies: dict,
+        image: str = ALLOWED_IMAGE,
+        store_url: str | None = None,
+    ) -> bool:
+        # `policies` contains only the node configuration's `policies:` section,
+        # not the complete node configuration. For example:
+        # {"allowed_algorithms": [ALLOWED_IMAGE_PATTERN]}
+        # The policy check expects the task's user and organization identifiers.
+        # They are not relevant unless user or organization policies are configured.
+        self.manager._policies = policies
+        task_info = {
+            "init_org": {"id": 1},
+            "init_user": {"id": 1},
+        }
+        if store_url:
+            # In normal operation the node retrieves the store URL from the server.
+            task_info["algorithm_store"] = {"id": 1}
+            self.manager.client.algorithm_store.get.return_value = {"url": store_url}
+        return self.manager.is_docker_image_allowed(image, task_info)
+
+    def test_no_algorithm_or_store_policy_rejects_all_images(self):
+        # A missing `policies:` section is represented by an empty dictionary.
+        self.assertFalse(self.is_allowed({}))
+
+        # Explicitly configured but empty policy lists must behave the same way.
+        self.assertFalse(
+            self.is_allowed(
+                {
+                    NodePolicy.ALLOWED_ALGORITHMS: [],
+                    NodePolicy.ALLOWED_ALGORITHM_STORES: [],
+                }
+            )
+        )
+
+    def test_algorithm_policy_can_be_used_on_its_own(self):
+        # We do not require a store policy when an algorithm policy is configured.
+        policies = {
+            NodePolicy.ALLOWED_ALGORITHMS: [ALLOWED_IMAGE_PATTERN],
+        }
+        self.assertTrue(self.is_allowed(policies))
+        self.assertFalse(self.is_allowed(policies, image=OTHER_IMAGE))
+
+    def test_all_images_can_be_allowed_explicitly(self):
+        # We retain allow-all behavior when the administrator explicitly requests it.
+        policies = {
+            NodePolicy.ALLOWED_ALGORITHMS: [".*"],
+        }
+        self.assertTrue(self.is_allowed(policies, image=OTHER_IMAGE))
+
+    def test_store_policy_can_be_used_on_its_own(self):
+        # We do not require an algorithm policy when a store policy is configured.
+        policies = {
+            NodePolicy.ALLOWED_ALGORITHM_STORES: [ALLOWED_STORE],
+        }
+        self.assertTrue(self.is_allowed(policies, store_url=ALLOWED_STORE))
+        self.assertFalse(self.is_allowed(policies, store_url=OTHER_STORE))
+
+    def test_both_policies_must_match_by_default(self):
+        # With both policies configured, the default behavior requires both to match.
+        policies = {
+            NodePolicy.ALLOWED_ALGORITHMS: [ALLOWED_IMAGE_PATTERN],
+            NodePolicy.ALLOWED_ALGORITHM_STORES: [ALLOWED_STORE],
+        }
+        self.assertTrue(self.is_allowed(policies, store_url=ALLOWED_STORE))
+        self.assertFalse(
+            self.is_allowed(policies, image=OTHER_IMAGE, store_url=ALLOWED_STORE)
+        )
+        self.assertFalse(self.is_allowed(policies, store_url=OTHER_STORE))
+
+    def test_either_policy_can_match_when_enabled(self):
+        # The opt-in setting changes the two-policy check from AND to OR.
+        policies = {
+            NodePolicy.ALLOWED_ALGORITHMS: [ALLOWED_IMAGE_PATTERN],
+            NodePolicy.ALLOWED_ALGORITHM_STORES: [ALLOWED_STORE],
+            "allow_either_whitelist_or_store": True,
+        }
+        self.assertTrue(
+            self.is_allowed(policies, image=OTHER_IMAGE, store_url=ALLOWED_STORE)
+        )
+        self.assertTrue(self.is_allowed(policies, store_url=OTHER_STORE))
+        self.assertFalse(
+            self.is_allowed(policies, image=OTHER_IMAGE, store_url=OTHER_STORE)
+        )
+
+    def test_either_setting_does_not_bypass_a_single_policy(self):
+        # A missing policy must not count as a match when OR behavior is enabled.
+        algorithm_policies = {
+            NodePolicy.ALLOWED_ALGORITHMS: [ALLOWED_IMAGE_PATTERN],
+            "allow_either_whitelist_or_store": True,
+        }
+        self.assertTrue(self.is_allowed(algorithm_policies))
+        self.assertFalse(self.is_allowed(algorithm_policies, image=OTHER_IMAGE))
+
+        store_policies = {
+            NodePolicy.ALLOWED_ALGORITHM_STORES: [ALLOWED_STORE],
+            "allow_either_whitelist_or_store": True,
+        }
+        self.assertTrue(self.is_allowed(store_policies, store_url=ALLOWED_STORE))
+        self.assertFalse(self.is_allowed(store_policies, store_url=OTHER_STORE))
+
+    def test_basics_algorithm_is_rejected_without_an_allowed_image_policy(self):
+        # The basics setting is an extra veto, not an independent allow-list.
+        self.assertFalse(self.is_allowed({}, image=BASIC_PROCESSING_IMAGE))

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -361,7 +361,7 @@ class DockerManager(DockerBaseManager):
                 "No policies on allowed algorithms have been set for this node!"
             )
             self.log.warning(
-                "This means that all algorithms are allowed to run on this node."
+                "This means that all algorithms will be rejected by this node."
             )
         return policies
 
@@ -391,7 +391,8 @@ class DockerManager(DockerBaseManager):
         Checks the docker image name.
 
         Against a list of regular expressions as defined in the configuration
-        file. If no expressions are defined, all docker images are accepted.
+        file. If no algorithm or algorithm-store policy is defined, all Docker
+        images are rejected.
 
         Parameters
         ----------
@@ -419,7 +420,8 @@ class DockerManager(DockerBaseManager):
                     "this node does not allow to run."
                 )
                 return False
-            # else: basics are allowed, so we don't need to check the regex
+            # The basics setting is an additional check. If it is enabled, the
+            # algorithm must still pass the policies below.
 
         # check if user or their organization is allowed
         allowed_users = self._policies.get(NodePolicy.ALLOWED_USERS, [])
@@ -530,16 +532,20 @@ class DockerManager(DockerBaseManager):
                         if expr_.match(store_from_task):
                             store_whitelisted = True
 
-        allowed_from_whitelist = not allowed_algorithms or algorithm_whitelisted
-        allowed_from_store = not allowed_stores or store_whitelisted
-        if allow_either_whitelist_or_store:
+        algorithm_policy_set = bool(allowed_algorithms)
+        store_policy_set = bool(allowed_stores)
+        if not algorithm_policy_set and not store_policy_set:
+            allowed = False
+        elif allow_either_whitelist_or_store:
             # if we allow an algorithm if it is defined in the whitelist or the store,
             # we return True if either the algorithm or the store is whitelisted
-            allowed = allowed_from_whitelist or allowed_from_store
+            allowed = algorithm_whitelisted or store_whitelisted
         else:
-            # only allow algorithm if it is allowed for both the allowed_algorithms and
-            # the allowed_algorithm_stores
-            allowed = allowed_from_whitelist and allowed_from_store
+            # We require the algorithm to pass each configured policy. Policies that
+            # have not been configured do not restrict the algorithm.
+            allowed = (not algorithm_policy_set or algorithm_whitelisted) and (
+                not store_policy_set or store_whitelisted
+            )
 
         if not allowed:
             self.log.warning(

--- a/vantage6/vantage6/cli/configuration_wizard.py
+++ b/vantage6/vantage6/cli/configuration_wizard.py
@@ -111,8 +111,9 @@ def node_configuration_questionaire(dirs: dict, instance_name: str) -> dict:
         ).unsafe_ask()
 
     is_policies = q.confirm(
-        "Do you want to limit the algorithms allowed to run on your node? This "
-        "should always be done for production scenarios.",
+        "Do you want to configure which algorithms are allowed to run on your node? "
+        "If no algorithms or algorithm stores are allowed, the node will reject every "
+        "algorithm image.",
         default=True,
     ).unsafe_ask()
     policies = {}
@@ -145,6 +146,11 @@ def node_configuration_questionaire(dirs: dict, instance_name: str) -> dict:
             policies["allow_either_whitelist_or_store"] = not require_both_whitelists
     if policies:
         config["policies"] = policies
+    else:
+        warning(
+            "No allowed algorithm policy was configured. This node will reject "
+            "all algorithm images."
+        )
 
     res = q.select(
         "Which level of logging would you like?",

--- a/vantage6/vantage6/cli/dev/create.py
+++ b/vantage6/vantage6/cli/dev/create.py
@@ -8,7 +8,13 @@ from jinja2 import Environment, FileSystemLoader
 from colorama import Fore, Style
 
 from vantage6.common.globals import APPNAME, InstanceType, Ports
-from vantage6.common import ensure_config_dir_writable, info, error, generate_apikey
+from vantage6.common import (
+    ensure_config_dir_writable,
+    info,
+    warning,
+    error,
+    generate_apikey,
+)
 
 import vantage6.cli.dev.data as data_dir
 from vantage6.cli.context.algorithm_store import AlgorithmStoreContext
@@ -633,6 +639,11 @@ def create_demo_network(
     """
     server_name = prompt_config_name(name)
     if not ServerContext.config_exists(server_name, False):
+        warning(
+            "Nodes reject all algorithm images when no algorithm policy is configured. "
+            "To allow algorithms in this development network, review and uncomment the "
+            "policies section in each generated node configuration."
+        )
         demo = demo_network(
             num_nodes,
             server_url,

--- a/vantage6/vantage6/cli/template/node_config.j2
+++ b/vantage6/vantage6/cli/template/node_config.j2
@@ -31,6 +31,12 @@ logging:
   - level: warning
     name: docker.auth
 port: {{ port }}
+# Nodes reject all algorithm images by default. Uncomment the lines below and
+# include an algorithm image pattern to allow it. Using `.*` will allow every
+# algorithm image. Use it with care.
+# policies:
+#   allowed_algorithms:
+#     - your-algorithm-image-pattern
 server_url: {{ server_url }}
 task_dir: {{ task_dir}}
 {{- user_provided_config -}}


### PR DESCRIPTION
See: https://github.com/vantage6/vantage6/issues/2676

This PR might no longer apply – as Bart points out, they are working towards a `production: false/true` toggle. I'd favor defaulting to deny all, perhaps production = true by default? Are there other production/dev settings?

This PR is a starting point. Needs discussion, careful review, and testing. Tim or someone else at MDW will continue work on this PR / proposal.