### PR TITLE
Make column names and allowed algos sharing opt-in [lite-01]

### DIFF
--- a/docs/node/node_config.yaml
+++ b/docs/node/node_config.yaml
@@ -296,11 +296,19 @@ debug:
 # directory where local task files (input/output) are stored
 task_dir: C:\Users\<your-user>\AppData\Local\vantage6\node\mydir
 
-# Whether or not your node shares some configuration (e.g. which images are
-# allowed to run on your node) with the central server. This can be useful
-# for other organizations in your collaboration to understand why a task
-# is not completed. Obviously, no sensitive data is shared. Default true
+# Whether or not we share the encryption setting, allowed users and organizations,
+# and database labels and types with the central server. Default is true. Setting
+# this to false also disables the optional sharing settings below.
 share_config: true
+
+# Whether or not we share the allowed algorithm names and regular expressions with
+# the central server. The node enforces these locally even when we do not share them.
+# Default is false.
+share_allowed_algorithms: false
+
+# Column-name sharing is currently unsupported. Enabling this setting logs an error
+# and does not share any column names. Default is false.
+share_column_names: false
 
 
 # Whether or not to share algorithm logs with the server. Otherwise they will

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -1211,8 +1211,8 @@ class Node:
         """
         Share part of the node's configuration with the server.
 
-        This helps the other parties in a collaboration to see e.g. which
-        algorithms they are allowed to run on this node.
+        This lets the other parties in a collaboration see the node details
+        that we have chosen to share.
         """
         # check if node allows to share node details, otherwise return
         if not self.config.get("share_config", True):
@@ -1229,11 +1229,12 @@ class Node:
             if encryption_config.get("enabled") is not None:
                 config_to_share["encryption"] = encryption_config.get("enabled")
 
-        # share node policies (e.g. who can run which algorithms)
+        # We only share the algorithm allow-list when this is explicitly enabled
         policies = self.config.get("policies", {})
-        config_to_share["allowed_algorithms"] = policies.get(
-            NodePolicy.ALLOWED_ALGORITHMS, "all"
-        )
+        if self.config.get("share_allowed_algorithms", False):
+            config_to_share["allowed_algorithms"] = policies.get(
+                NodePolicy.ALLOWED_ALGORITHMS, "all"
+            )
         if policies.get(NodePolicy.ALLOWED_USERS) is not None:
             config_to_share["allowed_users"] = policies.get(NodePolicy.ALLOWED_USERS)
         if policies.get(NodePolicy.ALLOWED_ORGANIZATIONS) is not None:
@@ -1241,17 +1242,17 @@ class Node:
                 NodePolicy.ALLOWED_ORGANIZATIONS
             )
 
-        # share node database labels, types, and column names (if they are
-        # fixed as e.g. for csv file)
+        # We always share database labels and types. Column-name should be opt-in.
         labels = []
         types = {}
         col_names = {}
+        share_column_names = self.config.get("share_column_names", False)
         for db in self.config.get("databases", []):
             label = db.get("label")
             type_ = db.get("type")
             labels.append(label)
             types[f"db_type_{label}"] = type_
-            if type_ in ("csv", "parquet"):
+            if share_column_names and type_ in ("csv", "parquet"):
                 col_names[f"columns_{label}"] = self.__docker.get_column_names(
                     label, type_
                 )

--- a/vantage6-node/vantage6/node/docker/docker_manager.py
+++ b/vantage6-node/vantage6/node/docker/docker_manager.py
@@ -34,7 +34,6 @@ from vantage6.common.globals import (
 )
 from vantage6.common.task_status import TaskStatus, has_task_failed
 from vantage6.common.docker.network_manager import NetworkManager
-from vantage6.algorithm.tools.wrappers import get_column_names
 from vantage6.cli.context.node import NodeContext
 from vantage6.node.context import DockerNodeContext
 from vantage6.node.docker.docker_base import DockerBaseManager
@@ -958,6 +957,8 @@ class DockerManager(DockerBaseManager):
         """
         Get column names from a node database
 
+        Column-name discovery is currently unsupported, so this returns no names.
+
         Parameters
         ----------
         label: str
@@ -970,27 +971,13 @@ class DockerManager(DockerBaseManager):
         list[str]
             List of column names
         """
-        db = self.databases.get(label)
-        if not db:
-            self.log.error("Database with label %s not found", label)
-            return []
-        if not db["is_file"]:
-            self.log.error(
-                "Database with label %s is not a file. Cannot"
-                " determine columns without query",
-                label,
-            )
-            return []
-        if db["type"] == "excel":
-            self.log.error(
-                "Cannot determine columns for excel database without a worksheet"
-            )
-            return []
-        if type_ not in ("csv", "sparql"):
-            self.log.error(
-                "Cannot determine columns for database of type %s."
-                "Only csv and sparql are supported",
-                type_,
-            )
-            return []
-        return get_column_names(db["uri"], type_)
+        # If we restore sharing column names through node configuration for the
+        # server's /column endpoint and UI column selectors, we can consider a simple
+        # standard-library implementation that does not require pandas.
+        # For now, its low usage does not justify the pandas dependency or the
+        # risk that incorrectly parsed data is exposed as column names.
+        self.log.error(
+            "Column-name discovery is currently unsupported; no column names "
+            "will be returned."
+        )
+        return []


### PR DESCRIPTION
Sharing the allowed algorithm patterns makes it easier to take advantage of a mistake in one of the administrator's regular expressions. Hiding them does not make a bad rule safe, but we do not need to publish them by default. Ultimately, it would be better to _not_ do regexes for allowed algorithms.
https://github.com/vantage6/vantage6/issues/2675

Column discovery currently uses pandas to load local data just to get the headers. We want to remove pandas, and a malformed or headerless CSV could result in actual data being sent as column names. For now, column sharing is deliberately not implemented.

This PR is a starting point. Needs discussion, careful review, and testing. Tim or someone else at MDW will continue work on this PR / proposal.