### PR TITLE
Copy node test datasets to the dev mount path automatically

### DIFF
--- a/dev/copy_test_data.py
+++ b/dev/copy_test_data.py
@@ -1,0 +1,60 @@
+"""
+Development script to copy the node test datasets from this repository to the
+directory on the host that is mounted into the node containers.
+
+On WSL the mount path points outside of the repository (see DEV_MOUNT_BASE_PATH
+in devspace.yaml), and /mnt/wsl is wiped whenever WSL restarts. The datasets
+therefore have to be copied there again before every deployment. On other
+systems the mount path is the repository's dev folder, so nothing is copied.
+"""
+
+import argparse
+import shutil
+from pathlib import Path
+
+from vantage6.cli.sandbox.populate.helpers.utils import replace_wsl_path
+
+from create_mount_directory import create_mount_directory
+
+SOURCE_DIR = Path(__file__).parent
+
+
+def copy_test_data(dest_dir: Path, file_names: list[str]):
+    """
+    Copy the test datasets to the directory that is mounted into the node
+    containers.
+
+    Files that are already present in the destination are left untouched, so
+    that custom datasets are never overwritten.
+    """
+    dest_dir = replace_wsl_path(dest_dir)
+    create_mount_directory(dest_dir)
+
+    for file_name in file_names:
+        source = SOURCE_DIR / file_name
+        destination = dest_dir / file_name
+
+        if not source.exists():
+            print(f"  Warning: '{source}' does not exist, skipping it")
+            continue
+
+        if destination.exists():
+            print(f"  '{destination}' already exists, skipping it")
+            continue
+
+        shutil.copy2(source, destination)
+        print(f"  Copied '{source}' to '{destination}'")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Copy the node test datasets")
+    parser.add_argument(
+        "dest_dir", type=Path, help="The directory to copy the datasets to"
+    )
+    parser.add_argument("file_names", nargs="+", help="The datasets to copy")
+    args = parser.parse_args()
+    copy_test_data(args.dest_dir, args.file_names)
+
+
+if __name__ == "__main__":
+    main()

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -217,6 +217,14 @@ hooks:
     command: |
       dev/check_microk8s_storage_enabled.sh
     events: ["before:deploy:vantage6-auth"]
+  # Note: new hooks must be appended at the end of this list, as the
+  # 'with-prometheus' profile patches a hook by its index in dev/pipeline/profiles.yaml
+  - name: "copy-node-test-data"
+    command: |
+      echo "Copying node test data to ${NODE_TEST_DATABASE_MOUNT_PATH}"
+      python dev/copy_test_data.py ${NODE_TEST_DATABASE_MOUNT_PATH} \
+        ${NODE_TEST_DATABASE_NAME} km_dataset.csv
+    events: ["before:deploy:vantage6-node"]
 
 # This is a list of `images` that DevSpace can build for this project. These can be
 # build with `devspace build` or when running `devspace dev -b`.

--- a/docs/community/develop_env.rst
+++ b/docs/community/develop_env.rst
@@ -80,6 +80,14 @@ up the following variables:
     for the file paths. Note also that these files may be deleted when you restart
     WSL or your machine itself.
 
+.. note::
+
+    Because the mount path is located outside of the repository on WSL, the test datasets
+    that are shipped in the ``dev`` folder are copied to ``NODE_TEST_DATABASE_MOUNT_PATH``
+    automatically every time you start the development environment. This also restores them
+    after a WSL restart. If a dataset with the same name is already present at that
+    location, it is left untouched, so you can safely put your own test data there.
+
 Running the development environment
 ----------------------------------
 


### PR DESCRIPTION

* Solves the problem that WSL needs to have the database files of the dev environment copied to the `/mnt/wsl/` dir.

Tested this in my environment and this seems to work.

----

## Problem

On WSL with Docker Desktop, hostPath mounts have to go through `/run/desktop/mnt/host/wsl/...`, so `DEV_MOUNT_BASE_PATH` — and with it `NODE_TEST_DATABASE_MOUNT_PATH` — points at `/mnt/wsl/vantage6/dev` rather than the repository's `dev` folder.

The node chart turns every `databases.fileBased` entry into a `PersistentVolume` with `local.path` set to that directory and mounts it with `subPath: <originalName>`, so `olympic_athletes_2016.csv` and `km_dataset.csv` have to physically exist there on the host.

Nothing put them there. The existing hooks only create the tasks, database and log directories. And because `/mnt/wsl` is a tmpfs that is wiped whenever WSL restarts, the datasets have to be restored on every start — until now by hand, typically with a couple of `cp` lines in `.bashrc`.

## Change

- **`dev/copy_test_data.py`** (new) — copies the named datasets from the repository's `dev` folder to a destination directory. Reuses `replace_wsl_path` and `create_mount_directory()` rather than reimplementing either.
- **`devspace.yaml`** — new `copy-node-test-data` hook on `before:deploy:vantage6-node`.
- **`docs/community/develop_env.rst`** — note next to the existing WSL warning.

Two deliberate choices:

- **A file already present at the destination is left untouched**, so a user who points `NODE_TEST_DATABASE_MOUNT_PATH` at their own data directory never gets it overwritten. A missing source file warns and exits 0, since `NODE_TEST_DATABASE_NAME` is overridable.
- **No WSL check.** On other systems the mount path defaults to the repository's `dev` folder, which makes source and destination the same file and turns the copy into a no-op. This also fixes the same problem for a custom mount path on Linux and Mac, which an explicit WSL check would miss.

The hook is appended at the end of the list because the `with-prometheus` profile patches a hook by its index; a comment in `devspace.yaml` now records that constraint.

## Verification

| Check | Result |
| --- | --- |
| Fresh copy after wiping `/mnt/wsl/vantage6/dev/*.csv` | Both CSVs copied, md5 identical to the repository copies |
| Re-run | Both skipped, no writes |
| `$PWD/dev` as destination (non-WSL case) | Both skipped, no self-copy |
| Missing source file | Warns, exit 0 |
| `devspace print` | Hook renders with the correct resolved path |
| Hook indices | New hook is index 7; the index patched by `with-prometheus` is unchanged |

A full `v6 dev start` was not run.

## Noticed separately

`dev/pipeline/profiles.yaml` patches `hooks/2/command`, but index 2 is `create-hq-database-folder` while the replacement value is the `create-log-folder` command (index 4). The `with-prometheus` profile looks broken independently of this change. Not touched here.