### PR TITLE
Fix crash on task page when a parameter is a long list

### DIFF
--- a/vantage6-ui/src/app/components/forms/compute-form/task-steps/parameter-step/parameter-step.component.ts
+++ b/vantage6-ui/src/app/components/forms/compute-form/task-steps/parameter-step/parameter-step.component.ts
@@ -95,8 +95,9 @@ export class ParameterStepComponent implements OnInit, OnDestroy {
         argument.type == ArgumentType.StringList
       ) {
         const controls = this.getFormArrayControls(argument);
+        const values = Array.isArray(parameter.value) ? parameter.value : [parameter.value];
         let isFirst = true;
-        for (const value of parameter.value) {
+        for (const value of values) {
           if (!isFirst) controls.push(this.getNewControlForArgumentList(argument));
           controls[controls.length - 1].setValue(value);
           isFirst = false;

--- a/vantage6-ui/src/app/models/api/task.models.ts
+++ b/vantage6-ui/src/app/models/api/task.models.ts
@@ -130,7 +130,7 @@ export interface RunNode {
 
 export interface TaskParameter {
   label: string;
-  value: string;
+  value: unknown;
 }
 
 export interface TaskResult {

--- a/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.ts
+++ b/vantage6-ui/src/app/pages/analyze/task/read/task-read.component.ts
@@ -434,8 +434,9 @@ export class TaskReadComponent implements OnInit, OnDestroy {
   }
 
   getParameterValueAsString(parameter: TaskParameter): string {
+    if (parameter.value === null || parameter.value === undefined) return '';
     const argument: Argument | undefined = this.function?.arguments.find((_) => _.name === parameter.label);
-    let parameter_str = argument?.type !== ArgumentType.Json ? parameter.value : JSON.stringify(parameter.value);
+    let parameter_str = argument?.type !== ArgumentType.Json ? String(parameter.value) : JSON.stringify(parameter.value);
     if (parameter_str.length > THRESHOLD_LONG_PARAMETER_TEXT) {
       const len_not_displayed = parameter_str.length - THRESHOLD_LONG_PARAMETER_TEXT;
       parameter_str = parameter_str.substring(0, THRESHOLD_LONG_PARAMETER_TEXT) + '... (' + len_not_displayed + ' more characters)';

--- a/vantage6-ui/src/app/services/task.service.ts
+++ b/vantage6-ui/src/app/services/task.service.ts
@@ -46,7 +46,7 @@ export class TaskService {
           ? Object.keys(arguments_).map((key: string) => {
               return {
                 label: key,
-                value: arguments_[key] || ''
+                value: arguments_[key] ?? ''
               };
             })
           : [];


### PR DESCRIPTION
## Summary
Viewing a task whose argument contained a list of more than 500 elements threw
`TypeError: substring is not a function` inside Angular change detection, which aborted
rendering of the entire task page — the reported symptom was that the algorithm status
no longer appeared. The value is decoded JSON and can be a list, number or boolean, but
`TaskParameter.value` was typed as `string`, so `.length` measured the element count
rather than the character count and `.substring()` was called on an array. The value is
now coerced with `String()` before being measured, and the model type has been corrected
so the compiler can catch this class of mistake.

Closes #2615

## What this does
- `TaskParameter.value` is now `unknown` instead of `string`, which is what the decoded
  run arguments actually contain.
- `getParameterValueAsString()` returns an empty string for an unset value and coerces
  the value with `String()` before checking or truncating its length, so the 500
  character threshold is applied to characters and `substring()` is always valid.
- `setupRepeatTask()` narrows the value with `Array.isArray()` before iterating it,
  which is required by the corrected type and also handles a scalar value for a list
  argument.
- Task arguments are decoded with `??` instead of `||`, so arguments with the value `0`
  or `false` are no longer displayed as empty.

## Approach
`String()` was chosen over `JSON.stringify()` for non-`json` argument types so that long
and short lists render in the same notation: short lists are already stringified by
Angular's interpolation as `1,2,3`, and switching long ones to `[1,2,3]` would be
inconsistent. Correcting the model type was included deliberately — the wrong type is
why TypeScript accepted a string method on an array. There are only two consumers of the
field, both updated here; `CreateTask.arguments` is a separate `string` field, so task
creation is unaffected.

## Deviations from the plan
- The unit test for `getParameterValueAsString` described in the plan was written and
  then removed, so this change ships without test coverage.

## Testing
No automated tests were run. The UI test suite requires a Chrome binary via
`karma-chrome-launcher` and `node_modules` was not installed in the environment where
this was written; lint and typecheck were likewise not run. The affected consumers of
`TaskParameter.value` were traced by hand across `vantage6-ui/src/app`.
