### PR TITLE
Guard the node's socket event handlers and shut down properly on fatal errors

### DIFF
--- a/vantage6-node/tests_node/test_network_isolation.py
+++ b/vantage6-node/tests_node/test_network_isolation.py
@@ -1,3 +1,5 @@
+import os
+import signal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -84,13 +86,15 @@ class TestNodeProductionGating:
                 False,
                 "probe failed",
             )
-            with patch("vantage6.node.exit", side_effect=SystemExit(1)) as mock_exit:
+            # the node signals itself rather than calling sys.exit(), so that it also
+            # shuts down when a fatal error is detected outside of the main thread
+            with patch("vantage6.node.os.kill") as mock_kill:
                 with (
                     patch.object(Node, "_setup_node_client", return_value=MagicMock()),
                     pytest.raises(SystemExit),
                 ):
                     Node(ctx)
-                mock_exit.assert_called_once_with(1)
+                mock_kill.assert_called_once_with(os.getpid(), signal.SIGTERM)
 
     def test_production_false_warns_on_isolation_failure(self, caplog):
         ctx = MagicMock()

--- a/vantage6-node/tests_node/test_socket_handlers.py
+++ b/vantage6-node/tests_node/test_socket_handlers.py
@@ -1,0 +1,186 @@
+import os
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from keycloak import KeycloakAuthenticationError
+
+from vantage6.node import Node
+from vantage6.node.socket import NodeTaskNamespace
+
+
+def _namespace() -> NodeTaskNamespace:
+    """Create a namespace with its logger and node reference mocked out."""
+    namespace = NodeTaskNamespace("/tasks")
+    namespace.log = MagicMock()
+    namespace.node_worker_ref = MagicMock()
+    return namespace
+
+
+def _node() -> Node:
+    """Create a node without running its (heavy) initialization."""
+    node = Node.__new__(Node)
+    node.log = MagicMock()
+    node.client = MagicMock()
+    return node
+
+
+class TestTriggerEvent:
+    def test_handler_result_is_returned(self):
+        namespace = _namespace()
+        namespace.on_pong = lambda: "result"
+
+        assert namespace.trigger_event("pong") == "result"
+
+    def test_failing_handler_is_logged_and_does_not_raise(self):
+        namespace = _namespace()
+        namespace.on_boom = MagicMock(side_effect=RuntimeError("boom"))
+
+        assert namespace.trigger_event("boom") is None
+        namespace.log.exception.assert_called_once()
+
+    def test_unknown_event_is_ignored(self):
+        namespace = _namespace()
+
+        assert namespace.trigger_event("event_that_does_not_exist") is None
+        namespace.log.exception.assert_not_called()
+
+    def test_disconnect_handler_without_reason_is_still_called(self):
+        # python-socketio retries the disconnect event without its `reason` argument
+        # when the handler does not accept one. Guarding the dispatch should not
+        # interfere with that fallback.
+        namespace = _namespace()
+        calls = []
+        namespace.on_disconnect = lambda: calls.append("called")
+
+        namespace.trigger_event("disconnect", "ping timeout")
+
+        assert calls == ["called"]
+        namespace.log.exception.assert_not_called()
+
+
+class TestDeleteDataframe:
+    @patch("vantage6.node.socket.SessionFileManager")
+    def test_incomplete_instruction_is_ignored(self, mock_session_file_manager):
+        namespace = _namespace()
+        namespace.emit = MagicMock()
+
+        namespace.on_delete_dataframe({"session_id": 1})
+
+        mock_session_file_manager.assert_not_called()
+        namespace.emit.assert_not_called()
+        namespace.log.error.assert_called_once()
+
+    @patch("vantage6.node.socket.SessionFileManager")
+    def test_dataframe_is_deleted_and_acknowledged(self, mock_session_file_manager):
+        namespace = _namespace()
+        namespace.emit = MagicMock()
+
+        namespace.on_delete_dataframe({"session_id": 1, "df_name": "df"})
+
+        mock_session_file_manager.return_value.delete_dataframe_file.assert_called_once_with(
+            "df"
+        )
+        event, data = namespace.emit.call_args[0]
+        assert event == "dataframe_deleted"
+        assert data["df_name"] == "df"
+        assert data["session_id"] == 1
+
+
+class TestKillContainers:
+    def test_status_change_is_emitted_for_each_killed_run(self):
+        namespace = _namespace()
+        namespace.emit = MagicMock()
+        namespace.node_worker_ref.kill_containers.return_value = [
+            MagicMock(run_id=1, task_id=10, parent_id=None),
+            MagicMock(run_id=2, task_id=11, parent_id=10),
+        ]
+
+        namespace.on_kill_containers({"collaboration_id": 1})
+
+        assert namespace.emit.call_count == 2
+        assert [call[0][1]["run_id"] for call in namespace.emit.call_args_list] == [
+            1,
+            2,
+        ]
+
+    def test_failing_kill_is_reported_via_trigger_event(self):
+        namespace = _namespace()
+        namespace.node_worker_ref.kill_containers.side_effect = RuntimeError("boom")
+
+        namespace.trigger_event("kill_containers", {"collaboration_id": 1})
+
+        namespace.log.exception.assert_called_once()
+
+
+class TestFatal:
+    @patch("vantage6.node.os.kill")
+    def test_node_is_terminated(self, mock_kill):
+        # sys.exit() would only end the thread that hit the fatal error, so the node
+        # signals itself instead. It is Kubernetes that restarts the node afterwards.
+        node = _node()
+
+        with pytest.raises(SystemExit):
+            node._fatal("the sky is falling")
+
+        mock_kill.assert_called_once_with(os.getpid(), signal.SIGTERM)
+        node.log.critical.assert_called_once_with("the sky is falling")
+
+    @patch("vantage6.node.os.kill")
+    def test_message_placeholders_are_filled_in_by_the_logger(self, _mock_kill):
+        node = _node()
+
+        with pytest.raises(SystemExit):
+            node._fatal("cannot reach %s", "hq")
+
+        node.log.critical.assert_called_once_with("cannot reach %s", "hq")
+
+    def test_node_really_stops_when_the_signal_is_not_fatal(self):
+        # if a SIGTERM handler is ever installed, os.kill() no longer ends the process
+        # by itself. The node should still not continue past a fatal error.
+        node = _node()
+
+        with patch("vantage6.node.os.kill"), pytest.raises(SystemExit):
+            node._fatal("the sky is falling")
+
+
+class TestProxyServerWorker:
+    @patch("vantage6.node.os.kill")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_missing_proxy_host_shuts_the_node_down(self, _mock_kill):
+        # this runs in the node's proxy thread, where sys.exit() would only have ended
+        # that thread and left the node running without a proxy server
+        node = _node()
+
+        with pytest.raises(SystemExit):
+            node._Node__proxy_server_worker()
+
+        assert "V6_PROXY_HOST" in node.log.critical.call_args[0][0]
+
+
+class TestAuthenticate:
+    @patch("vantage6.node.os.kill")
+    @patch("vantage6.node.time.sleep")
+    def test_failure_shuts_the_node_down(self, _mock_sleep, _mock_kill):
+        node = _node()
+        node.client.authenticate.side_effect = KeycloakAuthenticationError(
+            "wrong API key"
+        )
+
+        with pytest.raises(SystemExit):
+            node.authenticate()
+
+        node.client.auto_renew_token.assert_not_called()
+
+
+class TestConnectToSocket:
+    @patch("vantage6.node.os.kill")
+    @patch("vantage6.node.time.sleep")
+    @patch("vantage6.node.SocketIO")
+    def test_timeout_shuts_the_node_down(self, mock_socketio, _mock_sleep, _mock_kill):
+        node = _node()
+        node.debug = {}
+        mock_socketio.return_value.connected = False
+
+        with pytest.raises(SystemExit):
+            node.connect_to_socket()

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -26,6 +26,7 @@ import importlib.metadata
 import logging
 import os
 import queue
+import signal
 import sys
 import threading
 import time
@@ -119,8 +120,7 @@ class Node:
         self.log.debug("Ensuring that the task namespace is properly configured")
         namespace_created = self.k8s_container_manager.ensure_task_namespace()
         if not namespace_created:
-            self.log.error("Could not create the task namespace. Exiting.")
-            sys.exit(1)
+            self._fatal("Could not create the task namespace. Exiting.")
 
         self.check_algorithm_isolation()
 
@@ -155,6 +155,29 @@ class Node:
 
         self.log.info("Init complete")
 
+    def _fatal(self, message: str, *args) -> None:
+        """
+        Log why the node cannot continue and shut it down.
+
+        Note that `sys.exit()` cannot be used for this, as fatal errors
+        are also detected in the node's other threads, where it would only end that
+        single thread and leave the node running without a proxy server or a connection
+        to HQ.
+
+        Parameters
+        ----------
+        message: str
+            Message that explains why the node is shutting down. May contain %s-style
+            placeholders.
+        *args
+            Values for the placeholders in the message.
+        """
+        self.log.critical(message, *args)
+        os.kill(os.getpid(), signal.SIGTERM)
+        # the signal already terminated the node; this makes the method verifiably
+        # terminal for its callers - and for the tests, which patch os.kill()
+        raise SystemExit(1)
+
     def check_algorithm_isolation(self) -> None:
         """
         Verify that algorithm containers cannot reach the public internet.
@@ -162,12 +185,13 @@ class Node:
         When ``production`` is true (default), the node exits if isolation is not
         enforced. Otherwise, a failed check is logged as a warning only.
         """
-        isolated, isolation_message = (
-            self.k8s_container_manager.validate_algorithm_isolation()
-        )
+        (
+            isolated,
+            isolation_message,
+        ) = self.k8s_container_manager.validate_algorithm_isolation()
         if not isolated:
             if self.config.get("production", True):
-                self.log.error(
+                self._fatal(
                     "Algorithm network isolation check failed: %s. Nodes with "
                     "production=true require a Kubernetes environment that enforces "
                     "NetworkPolicies. Common causes: Docker Desktop Kubernetes, missing "
@@ -175,7 +199,6 @@ class Node:
                     "central_compute egress whitelist (e.g. 0.0.0.0/0).",
                     isolation_message,
                 )
-                sys.exit(1)
             self.log.warning(
                 "Algorithm network isolation check failed: %s",
                 isolation_message,
@@ -303,12 +326,10 @@ class Node:
             proxy_host = os.environ.get("V6_PROXY_HOST")
             os.environ["V6_PROXY_HOST"] = proxy_host
         else:
-            self.log.error(
+            self._fatal(
                 "The environment variable V6_PROXY_HOST, required to start the Node's "
-                "proxy-server is not set"
+                "proxy-server is not set. Shutting down the node..."
             )
-            self.log.info("Shutting down the node...")
-            sys.exit(1)
 
         # 'app' is defined in vantage6.node.proxy_server
         debug_mode = self.debug.get("proxy_server", False)
@@ -354,8 +375,7 @@ class Node:
                 node_proxy_port,
             )
             self.log.info("%s: %s", type(e), e)
-            self.log.info("Shutting down the node...")
-            sys.exit(1)
+            self._fatal("Could not start the proxy server. Shutting down the node...")
 
     def sync_task_queue_with_HQ(self) -> None:
         """Get all unprocessed tasks from HQ for this node."""
@@ -593,7 +613,8 @@ class Node:
         """
         Authenticate with HQ using the API key from the configuration file. If HQ
         rejects the authentication for any reason -other than a wrong API key-
-        several attempts are taken to retry.
+        several attempts are taken to retry. If the node cannot be authenticated at
+        all, it is shut down.
         """
 
         success = False
@@ -628,8 +649,7 @@ class Node:
         if success:
             self.log.info("Node '%s' authenticated successfully", self.client.name)
         else:
-            self.log.critical("Unable to authenticate. Exiting")
-            sys.exit(1)
+            self._fatal("Unable to authenticate. Exiting")
 
         # start thread to keep the connection alive by refreshing the token
         self.client.auto_renew_token()
@@ -681,7 +701,8 @@ class Node:
     def connect_to_socket(self) -> None:
         """
         Create long-lasting websocket connection with HQ. The connection is used to
-        receive status updates, such as new tasks.
+        receive status updates, such as new tasks. If the connection cannot be
+        established, the node is shut down.
         """
         debug_mode = self.debug.get("socketio", False)
         if debug_mode:
@@ -703,11 +724,10 @@ class Node:
         i = 0
         while not self.socketIO.connected:
             if i > TIME_LIMIT_INITIAL_CONNECTION_WEBSOCKET:
-                self.log.critical(
+                self._fatal(
                     "Could not connect to the websocket channels, do you have a "
                     "slow connection?"
                 )
-                sys.exit(1)
             self.log.debug("Waiting for socket connection...")
             time.sleep(1)
             i += 1

--- a/vantage6-node/vantage6/node/socket.py
+++ b/vantage6-node/vantage6/node/socket.py
@@ -20,6 +20,32 @@ class NodeTaskNamespace(ClientNamespace):
         super().__init__(*args, **kwargs)
         self.log = logging.getLogger(logger_name(__name__))
 
+    def trigger_event(self, event, *args):
+        """
+        Dispatch an event to its handler, without letting the handler take down the
+        thread it runs in.
+
+        Each incoming event is handled in its own thread, and an exception that escapes
+        a handler would otherwise be reported outside of the node's logging setup and
+        leave the event half-handled.
+
+        Parameters
+        ----------
+        event: str
+            Name of the socket event to dispatch.
+        *args
+            Arguments that HQ sent along with the event.
+
+        Returns
+        -------
+        Any
+            Whatever the handler returned, or None if it raised an exception.
+        """
+        try:
+            return super().trigger_event(event, *args)
+        except Exception:
+            self.log.exception("Error while handling socket event '%s'", event)
+
     def on_message(self, msg):
         """
         Receive messages over socket connection
@@ -192,20 +218,28 @@ class NodeTaskNamespace(ClientNamespace):
         """
         Action to be taken when a dataframe is instructed to be deleted.
         """
-        self.log.info("Received instruction to delete dataframe: %s", data["df_name"])
+        session_id = data.get("session_id")
+        df_name = data.get("df_name")
+        if session_id is None or df_name is None:
+            self.log.error(
+                "Cannot delete dataframe: incomplete instruction received (%s)", data
+            )
+            return
+
+        self.log.info("Received instruction to delete dataframe: %s", df_name)
         session_file_manager = SessionFileManager(
-            data["session_id"],
+            session_id,
             task_dir_extension=self.node_worker_ref.ctx.config.get("dev", {}).get(
                 "task_dir_extension"
             ),
         )
-        session_file_manager.delete_dataframe_file(data["df_name"])
+        session_file_manager.delete_dataframe_file(df_name)
         # send back a socket event to HQ to indicate that the dataframe has been deleted
         self.emit(
             "dataframe_deleted",
             {
-                "df_name": data["df_name"],
-                "session_id": data["session_id"],
+                "df_name": df_name,
+                "session_id": session_id,
                 "node_id": self.node_worker_ref.client.whoami.id_,
             },
             namespace="/tasks",


### PR DESCRIPTION

If you call `sys.kill()` from a thread, it will kill the thread. If you call the `node_worker_ref.bla` function it runs in the thread. So calling `authenticate` from a thread that fails and in turn calls `kill`. This kill wont kill the node but the thread, leaving the node in a somewhat dead state. Full summary:

----

## Summary
Nodes could stay alive but do nothing. Two causes, both thread-related:

| Problem | Effect |
|---|---|
| Socket handlers ran unguarded | An exception killed only that event's thread — silently, outside the node's logging |
| `sys.exit(1)` called off the main thread | `SystemExit` swallowed by `threading`; node kept running with no HQ connection, or no proxy server |

The `emit()` calls named in #2648 are all guarded already — the failure had moved one frame up, into the handlers.

Closes #2648 — won't auto-close, this targets a feature branch rather than the default one.

## The audit #2648 asked for
Every `emit()` in the node package (`grep -rn "\.emit(" vantage6-node/vantage6/`), and what guards it. Line numbers are as of this branch.

| `emit()` site | Guarded by | Was it OK before? |
|---|---|---|
| `k8s/container_manager.py:716` `stream_logs()` | own `try/except` | ✅ |
| `__init__.py:240` `__metadata_worker()` | `try/except` in its loop | ✅ |
| `__init__.py:751` `__socket_ping_worker()` | `try/except` + `connected` check | ✅ |
| `__init__.py:550` `__emit_algorithm_status_change()`, via `__start_task():519` | caller's loop `__process_new_tasks_queue():759` | ✅ |
| `__init__.py:550` `__emit_algorithm_status_change()`, via `__report_finished_run():603` | caller's loop `__send_updates_finished_tasks():564` | ✅ |
| `__init__.py:890` `share_node_details()`, via `socket.py:74` `on_sync()` | **nothing** → now `trigger_event()` | ❌ |
| `socket.py:203` `on_kill_containers()` | **nothing** → now `trigger_event()` | ❌ |
| `socket.py:238` `on_delete_dataframe()` | **nothing** → now `trigger_event()` | ❌ |

So five of eight were already fixed, as #2648 suspected. The remaining three are exactly the ones reached from a socket event handler rather than from a worker-thread loop — the handlers were the one path that never got a guard.

## What this does
| File | Change |
|---|---|
| `node/socket.py` | `trigger_event()` guards every event dispatch, logging failures through the node's own logger |
| `node/socket.py` | `on_delete_dataframe()` validates its payload — a malformed one raised `KeyError` before the ack, leaving HQ waiting |
| `node/__init__.py` | New `Node._fatal()` — logs, then `SIGTERM`s the process so it stops from any thread |
| `node/__init__.py` | All 6 `sys.exit(1)` in `Node` now go through it, incl. 2 in `__proxy_server_worker` with the same defect |

## Approach
- **Guard the dispatch point, not each handler** — handlers added later are covered for free; delegating to `super()` keeps python-socketio's legacy `disconnect` fallback.
- **Terminate rather than retry in-process** — the node is a k8s Deployment, so the pod restarts with backoff. That was the original `sys.exit()` intent; it just didn't work off the main thread.
- **`_fatal()` raises after signalling** — unreachable in production, but tests patch `os.kill`, and without the raise `connect_to_socket()` loops forever instead of stopping.
- **Cross-platform** — `os.kill(getpid(), SIGTERM)` is a real signal on Linux/macOS and `TerminateProcess()` on Windows. (`signal.raise_signal()` would have been wrong: Windows ignores `SIGTERM`.)
- `cli/node.py`'s two `sys.exit(1)` are untouched — main thread, before a `Node` exists.

## Deviations from the plan
- **Dropped** a first attempt at `reconnect_to_hq()` with retry/backoff, a new exception and 2 globals — it reimplemented what k8s already does on restart. Token handlers are unchanged from base as a result.
- **Added** `__proxy_server_worker`: same defect, one line each once `_fatal()` existed.
- **Also converted** the 2 main-thread call sites, for a single shutdown path. Exit code goes 1 → 143 there — irrelevant under k8s, visible with `vnode-local start`.
- **Fixed** `test_network_isolation.py`, which patched `vantage6.node.exit` while the code called `sys.exit`. It asserted nothing and was already failing on the base branch.
- **Formatting**: the pre-commit `black` hook reformatted a pre-existing tuple unpack in `check_algorithm_isolation()` that I did not otherwise touch.

## Testing
- `uv run pytest vantage6-node/tests_node vantage6-common -q` → **53 passed**
- `uv run ruff check` / `ruff format --check` → clean
- 15 new tests: dispatch guard (result passthrough, exceptions, unknown events, legacy `disconnect`), payload validation, and the fatal paths for `authenticate()` / `connect_to_socket()` / proxy worker
