### PR TITLE
Restrict algorithm edits to the developer who submitted them

### DIFF
--- a/vantage6-algorithm-store/tests_store/resources/test_algorithm.py
+++ b/vantage6-algorithm-store/tests_store/resources/test_algorithm.py
@@ -544,6 +544,21 @@ class TestAlgorithmResources(TestResources):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(response.json["description"], "new_description")
 
+        # check that another developer cannot update this algorithm - they are
+        # not its owner
+        self.register_user(
+            username="other_developer",
+            user_rules=[Rule.get_by_("algorithm", Operation.EDIT)],
+            authenticate_mock=authenticate_mock,
+        )
+        response = self.app.patch(
+            f"/api/algorithm/{algorithm.id}", json={"description": "other_description"}
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+        # switch back to the algorithm's own developer for the remaining checks
+        self._mock_auth(user, authenticate_mock, True)
+
         # check that algorithm cannot be updated if it is approved
         algorithm.status = AlgorithmStatus.APPROVED.value
         algorithm.approved_at = datetime.datetime.now(datetime.UTC)

--- a/vantage6-algorithm-store/vantage6/algorithm/store/resource/algorithm.py
+++ b/vantage6-algorithm-store/vantage6/algorithm/store/resource/algorithm.py
@@ -863,6 +863,12 @@ class Algorithm(AlgorithmBaseResource):
         if not algorithm:
             return {"msg": "Algorithm not found"}, HTTPStatus.NOT_FOUND
 
+        # only the algorithm's own developer may edit it
+        if algorithm.developer_id != g.user.id:
+            return {
+                "msg": "You can only edit algorithms you submitted yourself."
+            }, HTTPStatus.FORBIDDEN
+
         data = request.get_json(silent=True)
 
         # validate the request body


### PR DESCRIPTION
## Summary
Any user with algorithm edit permission in the algorithm store could edit
another developer's pending algorithm submission — not just their own. This
adds an ownership check so only the developer who submitted an algorithm can
edit it while it's still pending review.

## What this does
`PATCH /api/algorithm/<id>` now rejects the request with 403 unless the
requesting user is the algorithm's original submitter (`developer_id`).
This applies uniformly — no role is exempt, including manager-tier roles.

## Approach
The algorithm store's permission model checks resource + operation only
(e.g. "can edit algorithms"), with no per-record ownership concept. The
`Algorithm` model already records who submitted it (`developer_id`), so the
fix adds a direct comparison against the authenticated user rather than
building out a broader scope system, keeping the change small and
self-contained to the one endpoint affected.

## Deviations from the plan
An earlier version of this change exempted roles that can also delete
algorithms (i.e. algorithm managers), on the theory that they already
manage all algorithms. That exemption was dropped based on review feedback:
ownership is now enforced unconditionally, with no bypass for any role.
Test coverage was updated to match.

## Testing
- Full algorithm store test suite: `python utest.py --algorithm-store` — 49/49 passed
- `ruff check` and `black --check` on the changed files — clean
