### PR TITLE
Prevent data leak from non-pandas errors

### DIFF
--- a/docs/algorithms/develop.rst
+++ b/docs/algorithms/develop.rst
@@ -257,24 +257,26 @@ vantage6 algorithm tools:
    for instance that a certain data value is not a valid date.
 
    To help you keep such sensitive information private, vantage6
-   provides a decorator that can be used to handle pandas errors. This decorator will
-   catch all pandas errors and return a generic error message. You can use this
-   decorator by adding it to your algorithm function:
+   provides a decorator that can be used to handle errors from data manipulation. This
+   decorator will catch such errors and return a generic error message. You can use
+   this decorator by adding it to your algorithm function:
 
    .. code:: python
 
-      from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+      from vantage6.algorithm.tools.error_handling import handle_data_errors
 
-      @handle_pandas_errors
+      @handle_data_errors
       def my_function(data: pd.DataFrame):
          return data
 
    All data extraction and preprocessing functions provided by the vantage6 algorithm
-   tools package are decorated with the ``handle_pandas_errors`` decorator, so that any
-   pandas-related error occurring during the execution of the function will be caught
-   and a generic error message will be returned instead of the traceback. Note that
-   this decorator does not catch all errors, so you should still be careful with the
-   data you handle in your algorithm functions.
+   tools package are decorated with the ``handle_data_errors`` decorator, so that any
+   error occurring during the execution of the function will be caught and a generic
+   error message will be returned instead of the traceback.
+
+   The errors defined in ``vantage6.algorithm.tools.exceptions`` are an exception to
+   this rule: they are not replaced, as their messages are written by you and are
+   meant to be shown to the user. Make sure not to include any sensitive data in them.
 
 .. _mock-test-algo-dev:
 

--- a/vantage6-algorithm-tools/tests/tools/test_error_handling.py
+++ b/vantage6-algorithm-tools/tests/tools/test_error_handling.py
@@ -1,0 +1,36 @@
+import traceback
+import unittest
+
+from vantage6.algorithm.tools.error_handling import handle_data_errors
+from vantage6.algorithm.tools.exceptions import AlgorithmRuntimeError, UserInputError
+
+
+class TestHandleDataErrors(unittest.TestCase):
+    def test_non_pandas_error_is_sanitized(self):
+        """Errors that are not raised by vantage6 should not leak any details."""
+
+        @handle_data_errors
+        def func():
+            raise ValueError("could not convert string to float: 'secret_42'")
+
+        with self.assertRaises(AlgorithmRuntimeError) as ctx:
+            func()
+
+        self.assertNotIn("secret_42", str(ctx.exception))
+        # the original error should not be printed when the traceback is logged
+        traceback_ = "".join(traceback.format_exception(ctx.exception))
+        self.assertNotIn("secret_42", traceback_)
+
+    def test_algorithm_errors_pass_through(self):
+        """Vantage6 errors are meant for the user and should not be replaced."""
+
+        @handle_data_errors
+        def func():
+            raise UserInputError("old_names and new_names must have the same length")
+
+        with self.assertRaises(UserInputError):
+            func()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vantage6-algorithm-tools/vantage6/algorithm/data_extraction/__init__.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/data_extraction/__init__.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine
 
 from vantage6.common import error, info
 
-from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+from vantage6.algorithm.tools.error_handling import handle_data_errors
 from vantage6.algorithm.tools.exceptions import DataReadError
 
 from vantage6.algorithm.decorator.action import data_extraction
@@ -15,7 +15,7 @@ from vantage6.algorithm.decorator.action import data_extraction
 _SPARQL_RETURN_FORMAT = CSV
 
 
-@handle_pandas_errors
+@handle_data_errors
 @data_extraction
 def read_csv(connection_details: dict) -> pd.DataFrame:
     """
@@ -55,7 +55,7 @@ def _read_csv(connection_details: dict) -> pd.DataFrame:
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @data_extraction
 def read_parquet(connection_details: dict) -> pd.DataFrame:
     """
@@ -94,7 +94,7 @@ def _read_parquet(connection_details: dict) -> pd.DataFrame:
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @data_extraction
 def read_excel(connection_details: dict, sheet_name: str | None = None) -> pd.DataFrame:
     """
@@ -144,7 +144,7 @@ def _read_excel(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @data_extraction
 def read_sparql_database(connection_details: dict, query: str) -> pd.DataFrame:
     """
@@ -230,7 +230,7 @@ def _sqldb_uri_preprocess(database_uri: str) -> str:
         return database_uri
 
 
-@handle_pandas_errors
+@handle_data_errors
 @data_extraction
 def read_sql_database(connection_details: dict, query: str) -> pd.DataFrame:
     """

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/aggregation.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/aggregation.py
@@ -7,13 +7,13 @@ DataFrame with statistical information based on a given grouping.
 
 import pandas as pd
 
-from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+from vantage6.algorithm.tools.error_handling import handle_data_errors
 from vantage6.algorithm.tools.exceptions import UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def collapse(
     df: pd.DataFrame,
@@ -160,7 +160,7 @@ def collapse(
     return agg_df.reset_index()
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def group_statistics(
     df: pd.DataFrame,

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/column.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/column.py
@@ -6,13 +6,13 @@ expressions.
 
 import pandas as pd
 
-from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+from vantage6.algorithm.tools.error_handling import handle_data_errors
 from vantage6.algorithm.tools.exceptions import UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def rename_columns(
     df: pd.DataFrame, old_names: list[str], new_names: list[str], strict: bool = False
@@ -55,7 +55,7 @@ def rename_columns(
     )
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def assign_column(df: pd.DataFrame, column_name: str, expression: str) -> pd.DataFrame:
     """
@@ -96,7 +96,7 @@ def assign_column(df: pd.DataFrame, column_name: str, expression: str) -> pd.Dat
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def redefine_column(
     df: pd.DataFrame, column_name: str, expression: str
@@ -140,7 +140,7 @@ def redefine_column(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def change_column_type(
     df: pd.DataFrame, columns: list[str], target_type: str

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/datetime.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/datetime.py
@@ -9,13 +9,13 @@ import datetime
 
 import pandas as pd
 
-from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+from vantage6.algorithm.tools.error_handling import handle_data_errors
 from vantage6.algorithm.tools.exceptions import DataError, UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def to_datetime(
     df: pd.DataFrame,
@@ -81,7 +81,7 @@ def to_datetime(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def to_timedelta(
     df: pd.DataFrame,
@@ -179,7 +179,7 @@ def to_timedelta(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def timedelta(
     df: pd.DataFrame,
@@ -268,7 +268,7 @@ def timedelta(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def calculate_age(
     df: pd.DataFrame,

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/encoding.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/encoding.py
@@ -9,13 +9,13 @@ standard deviations for scaling operations.
 
 import pandas as pd
 
-from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+from vantage6.algorithm.tools.error_handling import handle_data_errors
 from vantage6.algorithm.tools.exceptions import UserInputError
 
 from vantage6.algorithm.decorator.action import preprocessing
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def min_max_scale(
     df: pd.DataFrame,
@@ -89,7 +89,7 @@ def min_max_scale(
     return df_scaled
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def standard_scale(
     df: pd.DataFrame,
@@ -163,7 +163,7 @@ def standard_scale(
     return df_scaled
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def one_hot_encode(
     df: pd.DataFrame,
@@ -251,7 +251,7 @@ def one_hot_encode(
     return df_out
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def encode(
     df: pd.DataFrame,
@@ -335,7 +335,7 @@ def encode(
     return encoded_df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def discretize_column(
     df: pd.DataFrame,
@@ -401,7 +401,7 @@ def discretize_column(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def extract_from_string(
     df: pd.DataFrame,
@@ -457,7 +457,7 @@ def extract_from_string(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def impute(
     df: pd.DataFrame,

--- a/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/filtering.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/preprocessing/filtering.py
@@ -5,12 +5,12 @@ pandas DataFrames, such as selecting and filtering rows and columns.
 
 import pandas as pd
 
-from vantage6.algorithm.tools.error_handling import handle_pandas_errors
+from vantage6.algorithm.tools.error_handling import handle_data_errors
 
 from vantage6.algorithm.decorator.action import preprocessing
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def select_rows(df: pd.DataFrame, query: str) -> pd.DataFrame:
     """
@@ -78,7 +78,7 @@ def select_rows(df: pd.DataFrame, query: str) -> pd.DataFrame:
     return df.query(query)
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def filter_range(
     df: pd.DataFrame,
@@ -162,7 +162,7 @@ def filter_range(
     return df
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def select_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     """
@@ -218,7 +218,7 @@ def select_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     return df[columns]
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def drop_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     """
@@ -266,7 +266,7 @@ def drop_columns(df: pd.DataFrame, columns: list) -> pd.DataFrame:
     return df.drop(columns, axis=1)
 
 
-@handle_pandas_errors
+@handle_data_errors
 @preprocessing
 def filter_by_date(
     df: pd.DataFrame,

--- a/vantage6-algorithm-tools/vantage6/algorithm/tools/error_handling.py
+++ b/vantage6-algorithm-tools/vantage6/algorithm/tools/error_handling.py
@@ -2,58 +2,47 @@ import logging
 from collections.abc import Callable
 from functools import wraps
 
-import pandas as pd
-
 from vantage6.common import logger_name
 
-from vantage6.algorithm.tools.exceptions import AlgorithmRuntimeError
+from vantage6.algorithm.tools.exceptions import AlgorithmError, AlgorithmRuntimeError
 
 module_name = logger_name(__name__)
 log = logging.getLogger(module_name)
 
 
-def _collect_pandas_error_types() -> tuple[type, ...]:
+def handle_data_errors(func: Callable) -> Callable:
     """
-    Collect all exception classes exported from pandas.errors.
+    Decorator to catch errors from data manipulation in algorithm functions and
+    prevent leaking privacy-sensitive data via error messages or tracebacks.
 
-    Returns a tuple of exception types to be used in an except clause.
-    """
-    exception_types = []
-    errors_module = pd.errors
-    for attr_name in errors_module.__all__:
-        attr = getattr(errors_module, attr_name, None)
-        if isinstance(attr, type) and issubclass(attr, Exception):
-            exception_types.append(attr)
+    Any exception that is not a vantage6 ``AlgorithmError`` is replaced by a generic
+    ``AlgorithmRuntimeError``. This includes non-pandas exceptions such as
+    ``ValueError`` or ``KeyError``, which are commonly raised by pandas operations and
+    tend to contain data values in their message.
 
-    return tuple(exception_types)
-
-
-PANDAS_ERROR_TYPES = _collect_pandas_error_types()
-
-
-def handle_pandas_errors(func: Callable) -> Callable:
-    """
-    Decorator to catch pandas-related errors from algorithm functions and
-    prevent leaking privacy-sensitive data via tracebacks.
-
-    - Catches pandas-specific exceptions and common data-manipulation errors.
-    - Logs a minimal, non-identifying message (no traceback, no exception str).
-    - Returns a safe, generic error response with 400 Bad Request.
-    - Other unexpected exceptions continue to log with traceback for debugging.
+    The vantage6 ``AlgorithmError`` exceptions are re-raised unchanged: their messages
+    are written by algorithm developers and are meant to be shown to the user.
     """
 
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except PANDAS_ERROR_TYPES as e:
-            # Avoid logging tracebacks or exception messages that may contain data
+        except AlgorithmError:
+            raise
+        except Exception as e:  # noqa: BLE001
             msg = (
-                f"Pandas-related error of type {type(e).__name__} occurred in "
-                "algorithm function. Details have been omitted to protect privacy."
+                f"An error of type {type(e).__name__} occurred in "
+                f"'{func.__qualname__}'. Details have been omitted to protect privacy."
             )
             log.error(msg)
-            # pylint: disable=raise-missing-from
-            raise AlgorithmRuntimeError(msg)
+            # `from None` suppresses the exception context: without it, the original
+            # exception, including its message, is still printed when the traceback
+            # is logged
+            raise AlgorithmRuntimeError(msg) from None
 
     return wrapper
+
+
+# Backwards-compatible alias
+handle_pandas_errors = handle_data_errors


### PR DESCRIPTION
## Related issue

Fixes #2499

## Description

The `@handle_pandas_errors` decorator only caught exceptions from `pandas.errors` but pandas operations often raise plain Python errors that contain data values.

Those were passed on untouched and ended up in the algorithm logs, which are sent to HQ and can be read by the researcher.

## Changes

- The decorator now replaces every exception instead of only the pandas-specific ones.
- The vantage6 `AlgorithmError` exceptions are re-raised unchanged, so that algorithm developers can still report their own errors to the user.
- The generic message keeps the exception type and the function name, for example `An error of type ValueError occurred in 'select_rows'`.
- The new error is raised with `from None`. Without it, the original error is still printed as part of the traceback.
- Renamed the decorator to `handle_data_errors`, as it is no longer specific to pandas. `handle_pandas_errors` is kept as an alias, so existing algorithms keep working.
- Removed `PANDAS_ERROR_TYPES` and `_collect_pandas_error_types()`, which are no longer used.
- Updated the algorithm development documentation and added 2 unit tests.