### PR TITLE
Add 'pulling image' run status

### DIFF
--- a/vantage6-common/vantage6/common/enum.py
+++ b/vantage6-common/vantage6/common/enum.py
@@ -132,6 +132,8 @@ class RunStatus(StrEnumBase):
     PENDING = "pending"
     # Task is being started
     INITIALIZING = "initializing"
+    # The algorithm image is being pulled onto the node
+    PULLING_IMAGE = "pulling image"
     # Container started without exceptions
     ACTIVE = "active"
     # Container exited and had zero exit code
@@ -223,6 +225,7 @@ class RunStatus(StrEnumBase):
         return [
             cls.PENDING,
             cls.INITIALIZING,
+            cls.PULLING_IMAGE,
             cls.ACTIVE,
         ]
 

--- a/vantage6-node/tests_node/test_pod_status_mapping.py
+++ b/vantage6-node/tests_node/test_pod_status_mapping.py
@@ -96,6 +96,32 @@ class TestPodStatus(unittest.TestCase):
             RunStatus.NO_DOCKER_IMAGE,
         )
 
+    def test_image_being_pulled(self):
+        self.mock_pod.status.phase = "Pending"
+        self.mock_pod.status.container_statuses[0].state = self.waiting_container_state
+        self.mock_pod.status.container_statuses[
+            0
+        ].state.waiting.reason = "ContainerCreating"
+        self.assertEqual(
+            compute_run_pod_status(
+                log=self.silent_logger, task_namespace="", label="", pod=self.mock_pod
+            ),
+            RunStatus.PULLING_IMAGE,
+        )
+
+    def test_pod_still_initializing(self):
+        self.mock_pod.status.phase = "Pending"
+        self.mock_pod.status.container_statuses[0].state = self.waiting_container_state
+        self.mock_pod.status.container_statuses[
+            0
+        ].state.waiting.reason = "PodInitializing"
+        self.assertEqual(
+            compute_run_pod_status(
+                log=self.silent_logger, task_namespace="", label="", pod=self.mock_pod
+            ),
+            RunStatus.INITIALIZING,
+        )
+
     def test_waiting_reason_not_ready_err(self):
         self.mock_pod.status.phase = "Pending"
         self.mock_pod.status.container_statuses[0].state = self.waiting_container_state

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -471,8 +471,13 @@ class Node:
                     },
                 )
 
+        task_id = task["id"]
+        parent_id = get_parent_id(task)
+
         # Run the container. This adds the created container/task to the list
-        # __docker.active_tasks
+        # __docker.active_tasks. Starting may take a while - most notably when the
+        # algorithm image still has to be pulled - so the statuses the run goes through
+        # in the meantime are reported to HQ as they happen.
         run_status: RunStatus = self.k8s_container_manager.run(
             action=container_action,
             run_id=run_id,
@@ -482,11 +487,36 @@ class Node:
             session_id=task["session"]["id"],
             token=token,
             databases_to_use=task.get("databases", []),
+            on_status_change=lambda status: self.__report_run_status(
+                run_id, task_id, parent_id, status
+            ),
         )
 
+        self.__report_run_status(run_id, task_id, parent_id, run_status)
+
+    def __report_run_status(
+        self, run_id: int, task_id: int, parent_id: int | None, status: RunStatus
+    ) -> None:
+        """
+        Report a status of an algorithm run to HQ.
+
+        This is called both while the algorithm is still being started (e.g. while its
+        image is being pulled) and when the run has reached its final status.
+
+        Parameters
+        ----------
+        run_id : int
+            Run ID
+        task_id : int
+            Task ID
+        parent_id : int | None
+            ID of the parent task, if any
+        status : RunStatus
+            Status of the algorithm run
+        """
         # save task status to HQ
-        update = {"status": run_status.value}
-        if run_status == RunStatus.NOT_ALLOWED:
+        update = {"status": status.value}
+        if status == RunStatus.NOT_ALLOWED:
             # set finished_at to now, so that the task is not picked up again
             # (as the task is not started at all, unlike other crashes, it will
             # never finish and hence not be set to finished)
@@ -496,9 +526,7 @@ class Node:
         # send socket event to alert everyone of task status change. In case the
         # namespace is not connected, the socket notification will not be sent to other
         # nodes, but the task will still be processed
-        self.__emit_algorithm_status_change(
-            task["id"], run_id, get_parent_id(task), run_status
-        )
+        self.__emit_algorithm_status_change(task_id, run_id, parent_id, status)
 
     def __emit_algorithm_status_change(
         self, task_id: int, run_id: int, parent_id: int | None, status: RunStatus

--- a/vantage6-node/vantage6/node/__init__.py
+++ b/vantage6-node/vantage6/node/__init__.py
@@ -475,9 +475,7 @@ class Node:
         parent_id = get_parent_id(task)
 
         # Run the container. This adds the created container/task to the list
-        # __docker.active_tasks. Starting may take a while - most notably when the
-        # algorithm image still has to be pulled - so the statuses the run goes through
-        # in the meantime are reported to HQ as they happen.
+        # __docker.active_tasks
         run_status: RunStatus = self.k8s_container_manager.run(
             action=container_action,
             run_id=run_id,
@@ -500,8 +498,7 @@ class Node:
         """
         Report a status of an algorithm run to HQ.
 
-        This is called both while the algorithm is still being started (e.g. while its
-        image is being pulled) and when the run has reached its final status.
+        Used for both intermediate statuses and the final one.
 
         Parameters
         ----------

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -6,6 +6,7 @@ import re
 import threading
 import time
 import uuid
+from collections.abc import Callable
 from itertools import groupby
 from pathlib import Path
 
@@ -349,6 +350,7 @@ class ContainerManager:
         token: str,
         databases_to_use: list[dict],
         action: AlgorithmStepType,
+        on_status_change: Callable[[RunStatus], None] | None = None,
     ) -> RunStatus:
         """
         Run a vantage6 algorithm on the Kubernetes cluster.
@@ -371,6 +373,9 @@ class ContainerManager:
             Metadata of the databases to use.
         action: AlgorithmStepType
             The action to perform
+        on_status_change: Callable[[RunStatus], None] | None
+            Called whenever the run changes status while the algorithm is being
+            started. Not called with the final status that is returned here.
 
         Returns
         -------
@@ -622,6 +627,7 @@ class ContainerManager:
         status = self.__wait_until_pod_running(
             run_io=run_io,
             label=f"app={run_io.container_name}",
+            on_status_change=on_status_change,
         )
 
         # start streaming logs to HQ
@@ -728,7 +734,12 @@ class ContainerManager:
         finally:
             w.stop()
 
-    def __wait_until_pod_running(self, run_io: RunIO, label: str) -> RunStatus:
+    def __wait_until_pod_running(
+        self,
+        run_io: RunIO,
+        label: str,
+        on_status_change: Callable[[RunStatus], None] | None = None,
+    ) -> RunStatus:
         """"
         This method monitors the status of a Kubernetes POD created by a task job and
         waits until it transitions to a 'Running' state or another terminal state
@@ -749,6 +760,9 @@ class ContainerManager:
             RunIO object that contains information about the run
         label : str
             Label selector to identify the POD associated with the task job.
+        on_status_change: Callable[[RunStatus], None] | None
+            Called whenever the pod changes to a status that is not final yet, such as
+            RunStatus.PULLING_IMAGE.
 
         Returns
         -------
@@ -767,6 +781,20 @@ class ContainerManager:
 
         # Wait until the POD is created
         w = watch.Watch()
+
+        last_reported_status: RunStatus | None = None
+
+        def report_intermediate_status(status: RunStatus) -> None:
+            """Report a non-final status, but only when it differs from the last one.
+
+            The pod is watched through an event stream that fires on every pod update,
+            so without this check the same status would be reported over and over.
+            """
+            nonlocal last_reported_status
+            if on_status_change is None or status == last_reported_status:
+                return
+            last_reported_status = status
+            on_status_change(status)
 
         try:
             while True:
@@ -794,8 +822,15 @@ class ContainerManager:
                         task_namespace=self.task_namespace,
                     )
 
-                    if pod_phase != RunStatus.INITIALIZING:
+                    # The pod has either started or given up trying: this is the
+                    # status to report back. Anything else means the pod is still on
+                    # its way to being started, so keep waiting.
+                    if pod_phase == RunStatus.ACTIVE or RunStatus.has_finished(
+                        pod_phase
+                    ):
                         return pod_phase
+
+                    report_intermediate_status(pod_phase)
 
                 # POD event-watch TIMEOUT (timeout_seconds) was reached.
                 self.log.debug(
@@ -821,11 +856,12 @@ class ContainerManager:
                     task_namespace=self.task_namespace,
                 )
 
-                # Another iteration on the outer loop is performed if the pod is
-                # pending for reasons other than missing/invalid Docker image (which is
-                # reported as INITIALIZING).
-                if pod_phase != RunStatus.INITIALIZING:
+                # Another iteration on the outer loop is performed if the pod has
+                # not started yet (e.g. because a large image is still being pulled).
+                if pod_phase == RunStatus.ACTIVE or RunStatus.has_finished(pod_phase):
                     return pod_phase
+
+                report_intermediate_status(pod_phase)
 
                 self.log.debug(
                     "Task run (label %s, namespace %s) still pulling the algorithm "

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -350,7 +350,7 @@ class ContainerManager:
         token: str,
         databases_to_use: list[dict],
         action: AlgorithmStepType,
-        on_status_change: Callable[[RunStatus], None] | None = None,
+        on_status_change: Callable[[RunStatus], None],
     ) -> RunStatus:
         """
         Run a vantage6 algorithm on the Kubernetes cluster.
@@ -373,7 +373,7 @@ class ContainerManager:
             Metadata of the databases to use.
         action: AlgorithmStepType
             The action to perform
-        on_status_change: Callable[[RunStatus], None] | None
+        on_status_change: Callable[[RunStatus], None]
             Called whenever the run changes status while the algorithm is being
             started. Not called with the final status that is returned here.
 
@@ -738,7 +738,7 @@ class ContainerManager:
         self,
         run_io: RunIO,
         label: str,
-        on_status_change: Callable[[RunStatus], None] | None = None,
+        on_status_change: Callable[[RunStatus], None],
     ) -> RunStatus:
         """"
         This method monitors the status of a Kubernetes POD created by a task job and
@@ -760,7 +760,7 @@ class ContainerManager:
             RunIO object that contains information about the run
         label : str
             Label selector to identify the POD associated with the task job.
-        on_status_change: Callable[[RunStatus], None] | None
+        on_status_change: Callable[[RunStatus], None]
             Called whenever the pod changes to a status that is not final yet, such as
             RunStatus.PULLING_IMAGE.
 
@@ -791,7 +791,7 @@ class ContainerManager:
             so without this check the same status would be reported over and over.
             """
             nonlocal last_reported_status
-            if on_status_change is None or status == last_reported_status:
+            if status == last_reported_status:
                 return
             last_reported_status = status
             on_status_change(status)

--- a/vantage6-node/vantage6/node/k8s/container_manager.py
+++ b/vantage6-node/vantage6/node/k8s/container_manager.py
@@ -785,11 +785,8 @@ class ContainerManager:
         last_reported_status: RunStatus | None = None
 
         def report_intermediate_status(status: RunStatus) -> None:
-            """Report a non-final status, but only when it differs from the last one.
-
-            The pod is watched through an event stream that fires on every pod update,
-            so without this check the same status would be reported over and over.
-            """
+            """Report a non-final status, skipping repeats: the pod event stream
+            fires on every pod update, and each report is a request to HQ."""
             nonlocal last_reported_status
             if status == last_reported_status:
                 return
@@ -822,9 +819,6 @@ class ContainerManager:
                         task_namespace=self.task_namespace,
                     )
 
-                    # The pod has either started or given up trying: this is the
-                    # status to report back. Anything else means the pod is still on
-                    # its way to being started, so keep waiting.
                     if pod_phase == RunStatus.ACTIVE or RunStatus.has_finished(
                         pod_phase
                     ):
@@ -856,8 +850,8 @@ class ContainerManager:
                     task_namespace=self.task_namespace,
                 )
 
-                # Another iteration on the outer loop is performed if the pod has
-                # not started yet (e.g. because a large image is still being pulled).
+                # Keep watching if the pod has not started yet, e.g. because a
+                # large image is still being pulled.
                 if pod_phase == RunStatus.ACTIVE or RunStatus.has_finished(pod_phase):
                     return pod_phase
 

--- a/vantage6-node/vantage6/node/k8s/jobpod_state_to_run_status_mapper.py
+++ b/vantage6-node/vantage6/node/k8s/jobpod_state_to_run_status_mapper.py
@@ -46,12 +46,22 @@ RUNTIME_POD_RELATED_REASONS_FOR_STILL_PENDING = {
     "ContainerCannotRun": "The container failed to run.",
 }
 
-# The reasons reported for a 'waiting' state on a POD's container (when the POD is
-# Pending) that are related to an ongoing image pull or container initialization
-POD_INITIALIZATION_RELATED_REASONS_FOR_STILL_PENDING = {
+# The reason reported for a 'waiting' state on a POD's container (when the POD is
+# Pending) that indicates the algorithm image is still being fetched onto the node.
+#
+# Note: kubelet reports 'ContainerCreating' for both pulling the image and creating the
+# container. Creating takes well under a second, while pulling a large image dominates
+# the wait, so this is reported as PULLING_IMAGE. Separating the two would require
+# reading the pod's events.
+IMAGE_PULL_RELATED_REASONS_FOR_STILL_PENDING = {
     "ContainerCreating": (
         "Container image is being pulled and/or container is being created."
     ),
+}
+
+# The reasons reported for a 'waiting' state on a POD's container (when the POD is
+# Pending) that are related to an ongoing container initialization
+POD_INITIALIZATION_RELATED_REASONS_FOR_STILL_PENDING = {
     "PodInitializing": "Init containers are still running or haven't finished.",
 }
 
@@ -80,8 +90,9 @@ def compute_run_pod_status(
               problematic Docker image.
             - RunStatus.CRASHED: If the pod is still in pending status but has reported
               a runtime crash.
-            - RunStatus.INITIALIZING: If the pod is still initializing or waiting for
-              image pull.
+            - RunStatus.PULLING_IMAGE: If the pod is waiting for the algorithm image
+              to be pulled onto the node.
+            - RunStatus.INITIALIZING: If the pod is still initializing.
             - RunStatus.UNKNOWN_ERROR: If the pod is in an unexpected or unknown state.
             - RunStatus.COMPLETED: Not expected to happen but still possible: the task
               pod is reported as Succeded shortly after being created.
@@ -148,8 +159,24 @@ def compute_run_pod_status(
                         ],
                     )
                     return RunStatus.CRASHED
-                # The reason the POD status is "Pending" is an image still being pulled
-                # or intialized: INITIALIZING
+                # The reason the POD status is "Pending" is that the algorithm image
+                # is still being pulled onto the node: PULLING_IMAGE
+                elif (
+                    pending_status_reason
+                    in IMAGE_PULL_RELATED_REASONS_FOR_STILL_PENDING
+                ):
+                    log.debug(
+                        "Task run (label %s, namespace %s) - Reporting PULLING_IMAGE "
+                        "status: %s",
+                        label,
+                        task_namespace,
+                        IMAGE_PULL_RELATED_REASONS_FOR_STILL_PENDING[
+                            pending_status_reason
+                        ],
+                    )
+                    return RunStatus.PULLING_IMAGE
+                # The reason the POD status is "Pending" is a container still being
+                # initialized: INITIALIZING
                 elif (
                     pending_status_reason
                     in POD_INITIALIZATION_RELATED_REASONS_FOR_STILL_PENDING

--- a/vantage6-node/vantage6/node/k8s/jobpod_state_to_run_status_mapper.py
+++ b/vantage6-node/vantage6/node/k8s/jobpod_state_to_run_status_mapper.py
@@ -47,12 +47,8 @@ RUNTIME_POD_RELATED_REASONS_FOR_STILL_PENDING = {
 }
 
 # The reason reported for a 'waiting' state on a POD's container (when the POD is
-# Pending) that indicates the algorithm image is still being fetched onto the node.
-#
-# Note: kubelet reports 'ContainerCreating' for both pulling the image and creating the
-# container. Creating takes well under a second, while pulling a large image dominates
-# the wait, so this is reported as PULLING_IMAGE. Separating the two would require
-# reading the pod's events.
+# Pending) related to an ongoing image pull. 'ContainerCreating' also covers creating
+# the container, which is negligible next to pulling a large image.
 IMAGE_PULL_RELATED_REASONS_FOR_STILL_PENDING = {
     "ContainerCreating": (
         "Container image is being pulled and/or container is being created."

--- a/vantage6-ui/src/app/helpers/task.helper.ts
+++ b/vantage6-ui/src/app/helpers/task.helper.ts
@@ -4,6 +4,7 @@ import { Task, TaskStatus, TaskStatusGroup } from 'src/app/models/api/task.model
 export const getChipTypeForStatus = (status: TaskStatus): 'default' | 'active' | 'success' | 'error' => {
   switch (status) {
     case TaskStatus.Initializing:
+    case TaskStatus.PullingImage:
     case TaskStatus.Active:
       return 'active';
     case TaskStatus.Completed:
@@ -34,6 +35,7 @@ export const getTaskStatusTranslation = (translateService: TranslateService, sta
 export const getStatusType = (status: TaskStatus): TaskStatusGroup => {
   switch (status) {
     case TaskStatus.Initializing:
+    case TaskStatus.PullingImage:
     case TaskStatus.Active:
       return TaskStatusGroup.Active;
     case TaskStatus.Completed:
@@ -52,5 +54,5 @@ export const getStatusType = (status: TaskStatus): TaskStatusGroup => {
 };
 
 export const isTaskFinished = (task: Task): boolean => {
-  return ![TaskStatus.Pending, TaskStatus.Initializing, TaskStatus.Active].includes(task.status);
+  return ![TaskStatus.Pending, TaskStatus.Initializing, TaskStatus.PullingImage, TaskStatus.Active].includes(task.status);
 };

--- a/vantage6-ui/src/app/models/api/task.models.ts
+++ b/vantage6-ui/src/app/models/api/task.models.ts
@@ -24,6 +24,7 @@ export enum TaskDatabaseType {
 export enum TaskStatus {
   Pending = 'pending',
   Initializing = 'initializing',
+  PullingImage = 'pulling image',
   Active = 'active',
   Completed = 'completed',
   Failed = 'failed',

--- a/vantage6-ui/src/app/pipes/order-by-status.pipe.ts
+++ b/vantage6-ui/src/app/pipes/order-by-status.pipe.ts
@@ -9,6 +9,7 @@ export enum RunStatus {
   NoDockerImage = 'non-existing Docker image',
   Failed = 'failed',
   Active = 'active',
+  PullingImage = 'pulling image',
   Initializing = 'initializing',
   Pending = 'pending',
   Completed = 'completed',

--- a/vantage6-ui/src/assets/localizations/en.json
+++ b/vantage6-ui/src/assets/localizations/en.json
@@ -907,6 +907,7 @@
     "Killed": "Killed by user",
     "NoDockerImage": "Non-existing Docker image",
     "Pending": "Pending",
+    "PullingImage": "Pulling image",
     "StartFailed": "Start failed",
     "NotAllowed": "Algorithm not allowed by node"
   },

--- a/vantage6-ui/src/assets/localizations/en.json
+++ b/vantage6-ui/src/assets/localizations/en.json
@@ -907,7 +907,7 @@
     "Killed": "Killed by user",
     "NoDockerImage": "Non-existing Docker image",
     "Pending": "Pending",
-    "PullingImage": "Pulling image",
+    "PullingImage": "Downloading algorithm",
     "StartFailed": "Start failed",
     "NotAllowed": "Algorithm not allowed by node"
   },


### PR DESCRIPTION
## Related issue

Closes #2230

## Description

While a node pulls an algorithm image, the run stays at `pending`. That status means no node has started the run yet, usually because it is offline, so a user waiting in the UI cannot tell a slow download from a node that never picked the task up.

The node already knows what is happening. `compute_run_pod_status` maps kubelet's `ContainerCreating` reason during the pull, but `__wait_until_pod_running` used `INITIALIZING` as a sentinel meaning "keep waiting" and returned only once the pod reached a final state. Every status before that was discarded, so nothing was ever reported to HQ.

Simply returning a new status from the mapper would break the node. The wait loop treated anything other than `INITIALIZING` as final, so it would start the log stream against a container that has not been created yet. The loop condition had to change along with the new status.

## Before / after

Left is `release/5.0`, right is this branch. Same task, same image, same machine.

https://github.com/user-attachments/assets/e87d6ace-649e-4b10-af92-88b4ce66b733

The old build sits at `Pending` for the whole pull, which is indistinguishable from a node that never picked the task up. The new one shows `Pulling image` until the container starts.

## Changes

- Added `RunStatus.PULLING_IMAGE` ("pulling image") and included it in `alive_statuses()`, so the derived task status stays correct while a run is pulling.
- Split the pending-reason map so `ContainerCreating` maps to `PULLING_IMAGE`, while `PodInitializing` keeps `INITIALIZING`.
- Replaced the `!= INITIALIZING` sentinel in `__wait_until_pod_running` with a positive check for `ACTIVE` or a finished status, so any non-final status keeps the loop waiting instead of leaking out as a result.
- Added an `on_status_change` callback to `run()` and `__wait_until_pod_running`, called only when the status actually changes, so the run is not patched on every pod event.
- Extracted `Node.__report_run_status()` from the existing patch-and-emit pair, and used it for both the intermediate and the final reports.
- UI: added the status to `TaskStatus` and to the sort pipe, mapped it to the active chip type and status group, and added the "Pulling image" translation.
- Added 2 unit tests for the new mapping.

## Testing

Tested with DevSpace on a 529 MB algorithm image:

- Runs now report `pending` → `initializing` → `pulling image` → `active`, and spend 14 seconds showing "Pulling image" on a cold pull.
- kubelet measured the pull at 12.2s, against under a second to create and start the container, which is why `ContainerCreating` is reported as an image pull even though it also covers container creation.

Because DevSpace runs the node on the same machine, `pending` passes almost instantly and the run sits in `pulling image` for nearly the whole startup.
