### PR TITLE
Bugfix/prometheus in sandbox failing volume mount

### DIFF
--- a/charts/hq/values.yaml
+++ b/charts/hq/values.yaml
@@ -57,3 +57,4 @@ ui:
 
 prometheus:
   enabled: false
+  volumeHostPath: "/var/lib/prometheus"

--- a/charts/hub/Chart.lock
+++ b/charts/hub/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: common
   repository: file://../common
   version: 5.0.2
-digest: sha256:4987a37dbe1ece7b383750ebce255adb01d6a444d70f66feec4686faba90bf72
-generated: "2026-06-23T08:41:09.365128+00:00"
+digest: sha256:369185ffe14c9cc5e92f153e6977fd53ff05b4f2acd1e3748ac17ee72570105d
+generated: "2026-09-02T11:43:27.256099482+02:00"

--- a/vantage6/vantage6/cli/template/hq_config.j2
+++ b/vantage6/vantage6/cli/template/hq_config.j2
@@ -318,3 +318,9 @@ prometheus:
   {% else %}
   # storageClass: local-storage
   {% endif %}
+  # The host path for storing the Prometheus server data.
+  {% if prometheus.volumeHostPath is defined %}
+  volumeHostPath: {{ prometheus.volumeHostPath }}
+  {% else %}
+  # volumeHostPath: /var/lib/prometheus
+  {% endif %}


### PR DESCRIPTION
Prometheus failed to start in the Sandbox environment as the volume mount location was missing.